### PR TITLE
chore: improve dashboard UI consistency and polish

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/dashboard-header.tsx
+++ b/apps/web/src/app/(dashboard)/_components/dashboard-header.tsx
@@ -6,6 +6,11 @@ import { Moon, Sun } from "lucide-react";
 import { SidebarTrigger } from "@onecli/ui/components/sidebar";
 import { Separator } from "@onecli/ui/components/separator";
 import { Button } from "@onecli/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@onecli/ui/components/tooltip";
 import Link from "next/link";
 import {
   Breadcrumb,
@@ -24,13 +29,11 @@ export const DashboardHeader = () => {
   const navItem = navItems.find((item) => pathname.startsWith(item.url));
   const title = navItem?.title ?? "Dashboard";
 
-  // Detect sub-pages (e.g. /settings/profile → ["profile"])
   const subPath = navItem
     ? pathname.slice(navItem.url.length).replace(/^\//, "")
     : "";
   const subSegments = subPath ? subPath.split("/") : [];
 
-  // Build a readable sub-page label from the last segment
   const lastSegment = subSegments[subSegments.length - 1];
   const subPageLabel = lastSegment
     ? lastSegment.charAt(0).toUpperCase() + lastSegment.slice(1)
@@ -62,15 +65,22 @@ export const DashboardHeader = () => {
         </BreadcrumbList>
       </Breadcrumb>
       <div className="ml-auto flex items-center gap-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-        >
-          <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() =>
+                setTheme(resolvedTheme === "dark" ? "light" : "dark")
+              }
+            >
+              <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+              <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+              <span className="sr-only">Toggle theme</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Toggle theme</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/_components/page-header.tsx
+++ b/apps/web/src/app/(dashboard)/_components/page-header.tsx
@@ -1,0 +1,11 @@
+interface PageHeaderProps {
+  title: string;
+  description: string;
+}
+
+export const PageHeader = ({ title, description }: PageHeaderProps) => (
+  <div>
+    <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+    <p className="text-muted-foreground text-sm">{description}</p>
+  </div>
+);

--- a/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Plus } from "lucide-react";
+import { Plus, Bot } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import { getAgents } from "@/lib/actions/agents";
 import { Button } from "@onecli/ui/components/button";
@@ -66,9 +66,14 @@ export const AgentsContent = () => {
       </div>
 
       {agents.length === 0 ? (
-        <Card className="flex flex-col items-center justify-center py-12 text-center">
-          <p className="text-muted-foreground text-sm">
-            No agents yet. Create one to get started.
+        <Card className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="bg-muted mb-4 flex size-12 items-center justify-center rounded-full">
+            <Bot className="text-muted-foreground size-6" />
+          </div>
+          <p className="text-sm font-medium">No agents yet</p>
+          <p className="text-muted-foreground mt-1 max-w-xs text-xs">
+            Create an agent to generate an access token for connecting to the
+            proxy.
           </p>
         </Card>
       ) : (

--- a/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
@@ -125,7 +125,8 @@ export const CreateAgentDialog = ({
               </Button>
               <Button
                 onClick={handleCreate}
-                disabled={!name.trim() || creating}
+                loading={creating}
+                disabled={!name.trim()}
               >
                 {creating ? "Creating..." : "Create"}
               </Button>

--- a/apps/web/src/app/(dashboard)/agents/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { PageHeader } from "@dashboard/page-header";
 import { AgentsContent } from "./_components/agents-content";
 
 export const metadata: Metadata = {
@@ -8,15 +9,11 @@ export const metadata: Metadata = {
 
 export default function AgentsPage() {
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 max-w-5xl">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
-        <p className="text-muted-foreground text-sm">
-          Manage agents that connect to the proxy and receive injected
-          credentials.
-        </p>
-      </div>
-
+    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+      <PageHeader
+        title="Agents"
+        description="Manage agents that connect to the proxy and receive injected credentials."
+      />
       <Suspense>
         <AgentsContent />
       </Suspense>

--- a/apps/web/src/app/(dashboard)/overview/_components/api-key-card.tsx
+++ b/apps/web/src/app/(dashboard)/overview/_components/api-key-card.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@onecli/ui/components/card";
 import { Button } from "@onecli/ui/components/button";
+import { Skeleton } from "@onecli/ui/components/skeleton";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -71,22 +72,24 @@ export const ApiKeyCard = () => {
       </CardHeader>
       <CardContent>
         <div className="flex items-center gap-2">
-          <code className="bg-muted flex-1 rounded-md border px-3 py-2 font-mono text-sm select-none">
-            {loading ? (
-              <span className="text-muted-foreground">Loading...</span>
-            ) : !apiKey ? (
-              <span className="text-muted-foreground">No API key yet</span>
-            ) : revealed ? (
-              apiKey
-            ) : (
-              truncatedKey
-            )}
-          </code>
+          {loading ? (
+            <Skeleton className="h-9 flex-1 rounded-md" />
+          ) : (
+            <code className="bg-muted flex-1 rounded-md border px-3 py-2 font-mono text-sm select-none">
+              {!apiKey ? (
+                <span className="text-muted-foreground">No API key yet</span>
+              ) : revealed ? (
+                apiKey
+              ) : (
+                truncatedKey
+              )}
+            </code>
+          )}
           <Button
             variant="ghost"
             size="icon"
             onClick={() => setRevealed(!revealed)}
-            disabled={!apiKey}
+            disabled={loading || !apiKey}
           >
             {revealed ? (
               <EyeOff className="size-4" />
@@ -98,7 +101,7 @@ export const ApiKeyCard = () => {
             variant="ghost"
             size="icon"
             onClick={() => copy(apiKey)}
-            disabled={!apiKey}
+            disabled={loading || !apiKey}
           >
             {copied ? (
               <Check className="size-4 text-green-500" />
@@ -111,7 +114,7 @@ export const ApiKeyCard = () => {
               <Button
                 variant="ghost"
                 size="icon"
-                disabled={regenerating || !apiKey}
+                disabled={loading || regenerating || !apiKey}
               >
                 <RefreshCw
                   className={`size-4 ${regenerating ? "animate-spin" : ""}`}

--- a/apps/web/src/app/(dashboard)/overview/_components/overview-content.tsx
+++ b/apps/web/src/app/(dashboard)/overview/_components/overview-content.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@/providers/auth-provider";
 import { getProxyCounts } from "@/lib/actions/counts";
+import { PageHeader } from "@dashboard/page-header";
 import { ApiKeyCard } from "./api-key-card";
 import { StatsCards } from "./stats-cards";
 
-export function OverviewContent() {
+export const OverviewContent = () => {
   const { user } = useAuth();
   const [proxyCounts, setProxyCounts] = useState({
     agents: 0,
@@ -25,16 +26,12 @@ export function OverviewContent() {
   }, [user?.id]);
 
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 max-w-5xl">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Overview</h1>
-        <p className="text-muted-foreground text-sm">
-          Your OneCLI dashboard at a glance.
-        </p>
-      </div>
-
+    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+      <PageHeader
+        title="Overview"
+        description="Your OneCLI dashboard at a glance."
+      />
       <ApiKeyCard />
-
       <StatsCards
         agentCount={proxyCounts.agents}
         secretCount={proxyCounts.secrets}
@@ -42,4 +39,4 @@ export function OverviewContent() {
       />
     </div>
   );
-}
+};

--- a/apps/web/src/app/(dashboard)/overview/_components/stats-cards.tsx
+++ b/apps/web/src/app/(dashboard)/overview/_components/stats-cards.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Bot, KeyRound } from "lucide-react";
+import { Bot, KeyRound, ArrowRight } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -14,48 +14,52 @@ interface StatsCardsProps {
   loading?: boolean;
 }
 
-export function StatsCards({
+export const StatsCards = ({
   agentCount,
   secretCount,
   loading = false,
-}: StatsCardsProps) {
-  return (
-    <div className="grid gap-4 sm:grid-cols-2">
-      <Link href="/agents" className="group">
-        <Card className="py-4 gap-3 transition-colors hover:border-foreground/20 cursor-pointer">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">Agents</CardTitle>
-            <Bot className="text-muted-foreground size-4 transition-colors group-hover:text-blue-500" />
-          </CardHeader>
-          <CardContent>
-            {loading ? (
-              <Skeleton className="h-7 w-8 mb-1" />
-            ) : (
-              <div className="text-2xl font-bold">{agentCount}</div>
-            )}
+}: StatsCardsProps) => (
+  <div className="grid gap-4 sm:grid-cols-2">
+    <Link href="/agents" className="group">
+      <Card className="py-4 gap-3 transition-colors hover:border-foreground/20 cursor-pointer">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Agents</CardTitle>
+          <Bot className="text-muted-foreground size-4 transition-colors group-hover:text-blue-500" />
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <Skeleton className="h-7 w-8 mb-1" />
+          ) : (
+            <div className="text-2xl font-bold">{agentCount}</div>
+          )}
+          <div className="flex items-center justify-between">
             <p className="text-muted-foreground text-xs">Configured agents</p>
-          </CardContent>
-        </Card>
-      </Link>
+            <ArrowRight className="size-3.5 text-muted-foreground/0 transition-all group-hover:text-muted-foreground group-hover:translate-x-0.5" />
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
 
-      <Link href="/secrets" className="group">
-        <Card className="py-4 gap-3 transition-colors hover:border-foreground/20 cursor-pointer">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">Secrets</CardTitle>
-            <KeyRound className="text-muted-foreground size-4 transition-colors group-hover:text-amber-500" />
-          </CardHeader>
-          <CardContent>
-            {loading ? (
-              <Skeleton className="h-7 w-8 mb-1" />
-            ) : (
-              <div className="text-2xl font-bold">{secretCount}</div>
-            )}
+    <Link href="/secrets" className="group">
+      <Card className="py-4 gap-3 transition-colors hover:border-foreground/20 cursor-pointer">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Secrets</CardTitle>
+          <KeyRound className="text-muted-foreground size-4 transition-colors group-hover:text-amber-500" />
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <Skeleton className="h-7 w-8 mb-1" />
+          ) : (
+            <div className="text-2xl font-bold">{secretCount}</div>
+          )}
+          <div className="flex items-center justify-between">
             <p className="text-muted-foreground text-xs">
               Encrypted credentials
             </p>
-          </CardContent>
-        </Card>
-      </Link>
-    </div>
-  );
-}
+            <ArrowRight className="size-3.5 text-muted-foreground/0 transition-all group-hover:text-muted-foreground group-hover:translate-x-0.5" />
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  </div>
+);

--- a/apps/web/src/app/(dashboard)/secrets/_components/create-secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/create-secret-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
+import { ArrowLeft, Bot, Key, Settings2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -13,18 +14,47 @@ import {
 import { Button } from "@onecli/ui/components/button";
 import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@onecli/ui/components/accordion";
+import { Badge } from "@onecli/ui/components/badge";
 import { useAuth } from "@/providers/auth-provider";
 import { createSecret } from "@/lib/actions/secrets";
 
-const SECRET_TYPES = [
+const detectAnthropicKeyType = (
+  val: string,
+): "api_key" | "oauth_token" | null => {
+  if (val.startsWith("sk-ant-api")) return "api_key";
+  if (val.startsWith("sk-ant-oat")) return "oauth_token";
+  return null;
+};
+
+type SecretType = "anthropic" | "generic";
+
+interface SecretTypeOption {
+  value: SecretType;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  hostDefault: string;
+}
+
+const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
   {
-    value: "anthropic" as const,
+    value: "anthropic",
     label: "Anthropic API Key",
+    description: "Inject your Anthropic key into requests to api.anthropic.com",
+    icon: <Bot className="size-5" />,
     hostDefault: "api.anthropic.com",
   },
   {
-    value: "generic" as const,
+    value: "generic",
     label: "Generic Secret",
+    description: "Inject a custom header into requests matching any host",
+    icon: <Key className="size-5" />,
     hostDefault: "",
   },
 ];
@@ -41,10 +71,11 @@ export const CreateSecretDialog = ({
   onCreated,
 }: CreateSecretDialogProps) => {
   const { user } = useAuth();
+  const [step, setStep] = useState<"type" | "form">("type");
   const [creating, setCreating] = useState(false);
 
+  const [type, setType] = useState<SecretType>("anthropic");
   const [name, setName] = useState("");
-  const [type, setType] = useState<"anthropic" | "generic">("anthropic");
   const [value, setValue] = useState("");
   const [hostPattern, setHostPattern] = useState("api.anthropic.com");
   const [pathPattern, setPathPattern] = useState("");
@@ -52,8 +83,9 @@ export const CreateSecretDialog = ({
   const [valueFormat, setValueFormat] = useState("Bearer {value}");
 
   const resetForm = () => {
-    setName("");
+    setStep("type");
     setType("anthropic");
+    setName("");
     setValue("");
     setHostPattern("api.anthropic.com");
     setPathPattern("");
@@ -61,14 +93,15 @@ export const CreateSecretDialog = ({
     setValueFormat("Bearer {value}");
   };
 
-  const handleTypeChange = (newType: "anthropic" | "generic") => {
-    setType(newType);
-    const config = SECRET_TYPES.find((t) => t.value === newType);
-    if (config?.hostDefault) {
-      setHostPattern(config.hostDefault);
-    } else {
-      setHostPattern("");
-    }
+  const handleSelectType = (selected: SecretType) => {
+    setType(selected);
+    const option = SECRET_TYPE_OPTIONS.find((o) => o.value === selected);
+    setHostPattern(option?.hostDefault ?? "");
+    setStep("form");
+  };
+
+  const handleBack = () => {
+    setStep("type");
   };
 
   const isValid =
@@ -105,140 +138,280 @@ export const CreateSecretDialog = ({
     }
   };
 
-  const handleClose = (value: boolean) => {
-    if (!value) resetForm();
-    onOpenChange(value);
+  const handleClose = (open: boolean) => {
+    if (!open) resetForm();
+    onOpenChange(open);
   };
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Add secret</DialogTitle>
-          <DialogDescription>
-            Store an encrypted credential for the proxy to inject into requests.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4 py-2">
-          <div className="space-y-2">
-            <Label htmlFor="secret-name">Name</Label>
-            <Input
-              id="secret-name"
-              placeholder="e.g. Anthropic Production Key"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              autoFocus
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label>Type</Label>
-            <div className="flex gap-2">
-              {SECRET_TYPES.map((t) => (
-                <Button
-                  key={t.value}
-                  type="button"
-                  variant={type === t.value ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => handleTypeChange(t.value)}
-                >
-                  {t.label}
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="secret-value">Secret value</Label>
-            <Input
-              id="secret-value"
-              type="password"
-              placeholder={
-                type === "anthropic" ? "sk-ant-api03-..." : "Enter secret value"
-              }
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-            />
-            <p className="text-muted-foreground text-xs">
-              Encrypted at rest. You won&apos;t be able to view this value
-              again.
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="secret-host">Host pattern</Label>
-            <Input
-              id="secret-host"
-              placeholder="e.g. api.anthropic.com or *.example.com"
-              value={hostPattern}
-              onChange={(e) => setHostPattern(e.target.value)}
-            />
-            <p className="text-muted-foreground text-xs">
-              The host this secret applies to. Use{" "}
-              <code className="text-xs">*.example.com</code> for wildcard
-              subdomains.
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="secret-path">
-              Path pattern{" "}
-              <span className="text-muted-foreground font-normal">
-                (optional)
-              </span>
-            </Label>
-            <Input
-              id="secret-path"
-              placeholder="e.g. /v1/*"
-              value={pathPattern}
-              onChange={(e) => setPathPattern(e.target.value)}
-            />
-          </div>
-
-          {type === "generic" && (
-            <>
-              <div className="space-y-2">
-                <Label htmlFor="secret-header">Header name</Label>
-                <Input
-                  id="secret-header"
-                  placeholder="e.g. Authorization"
-                  value={headerName}
-                  onChange={(e) => setHeaderName(e.target.value)}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="secret-format">
-                  Value format{" "}
-                  <span className="text-muted-foreground font-normal">
-                    (optional)
-                  </span>
-                </Label>
-                <Input
-                  id="secret-format"
-                  placeholder="e.g. Bearer {value}"
-                  value={valueFormat}
-                  onChange={(e) => setValueFormat(e.target.value)}
-                />
-                <p className="text-muted-foreground text-xs">
-                  Use <code className="text-xs">{"{value}"}</code> as a
-                  placeholder for the secret. Defaults to the raw value.
-                </p>
-              </div>
-            </>
-          )}
-        </div>
-
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => handleClose(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleCreate} disabled={!isValid || creating}>
-            {creating ? "Creating..." : "Add Secret"}
-          </Button>
-        </DialogFooter>
+        {step === "type" ? (
+          <TypeStep onSelect={handleSelectType} />
+        ) : (
+          <FormStep
+            type={type}
+            name={name}
+            value={value}
+            hostPattern={hostPattern}
+            pathPattern={pathPattern}
+            headerName={headerName}
+            valueFormat={valueFormat}
+            isValid={!!isValid}
+            creating={creating}
+            onNameChange={setName}
+            onValueChange={setValue}
+            onHostPatternChange={setHostPattern}
+            onPathPatternChange={setPathPattern}
+            onHeaderNameChange={setHeaderName}
+            onValueFormatChange={setValueFormat}
+            onBack={handleBack}
+            onCancel={() => handleClose(false)}
+            onCreate={handleCreate}
+          />
+        )}
       </DialogContent>
     </Dialog>
+  );
+};
+
+const TypeStep = ({ onSelect }: { onSelect: (type: SecretType) => void }) => (
+  <>
+    <DialogHeader>
+      <DialogTitle>Add secret</DialogTitle>
+      <DialogDescription>
+        Choose the type of credential to store.
+      </DialogDescription>
+    </DialogHeader>
+
+    <div className="grid gap-3 py-2">
+      {SECRET_TYPE_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          onClick={() => onSelect(option.value)}
+          className="border-border hover:border-foreground/20 hover:bg-muted/50 flex items-start gap-4 rounded-lg border p-4 text-left transition-colors"
+        >
+          <div className="bg-muted text-muted-foreground mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-md">
+            {option.icon}
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm font-medium">{option.label}</div>
+            <div className="text-muted-foreground text-xs">
+              {option.description}
+            </div>
+          </div>
+        </button>
+      ))}
+    </div>
+  </>
+);
+
+interface FormStepProps {
+  type: SecretType;
+  name: string;
+  value: string;
+  hostPattern: string;
+  pathPattern: string;
+  headerName: string;
+  valueFormat: string;
+  isValid: boolean;
+  creating: boolean;
+  onNameChange: (v: string) => void;
+  onValueChange: (v: string) => void;
+  onHostPatternChange: (v: string) => void;
+  onPathPatternChange: (v: string) => void;
+  onHeaderNameChange: (v: string) => void;
+  onValueFormatChange: (v: string) => void;
+  onBack: () => void;
+  onCancel: () => void;
+  onCreate: () => void;
+}
+
+const FormStep = ({
+  type,
+  name,
+  value,
+  hostPattern,
+  pathPattern,
+  headerName,
+  valueFormat,
+  isValid,
+  creating,
+  onNameChange,
+  onValueChange,
+  onHostPatternChange,
+  onPathPatternChange,
+  onHeaderNameChange,
+  onValueFormatChange,
+  onBack,
+  onCancel,
+  onCreate,
+}: FormStepProps) => {
+  const typeOption = SECRET_TYPE_OPTIONS.find((o) => o.value === type)!;
+
+  return (
+    <>
+      <DialogHeader>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onBack}
+            className="text-muted-foreground hover:text-foreground -ml-1 rounded-md p-1 transition-colors"
+          >
+            <ArrowLeft className="size-4" />
+          </button>
+          <DialogTitle>{typeOption.label}</DialogTitle>
+        </div>
+        <DialogDescription>
+          {type === "anthropic"
+            ? "Your key will be encrypted and injected into requests to api.anthropic.com."
+            : "Configure a custom secret to inject as a header into matching requests."}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 py-2">
+        <div className="space-y-2">
+          <Label htmlFor="secret-name">Name</Label>
+          <Input
+            id="secret-name"
+            placeholder={
+              type === "anthropic"
+                ? "e.g. Anthropic Production Key"
+                : "e.g. GitHub Token"
+            }
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            autoFocus
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="secret-value">Secret value</Label>
+          <Input
+            id="secret-value"
+            type="password"
+            placeholder={
+              type === "anthropic" ? "sk-ant-api03-..." : "Enter secret value"
+            }
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+          />
+          <div className="flex items-center gap-2">
+            <p className="text-muted-foreground text-xs">
+              {type === "anthropic"
+                ? "Paste your API key or OAuth token from the Anthropic Console."
+                : "Encrypted at rest. You won\u2019t be able to view this value again."}
+            </p>
+            {type === "anthropic" && <AnthropicKeyBadge value={value} />}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="secret-host">Host pattern</Label>
+          <Input
+            id="secret-host"
+            placeholder="e.g. api.example.com or *.example.com"
+            value={hostPattern}
+            onChange={(e) => onHostPatternChange(e.target.value)}
+          />
+          <p className="text-muted-foreground text-xs">
+            The host this secret applies to. Use{" "}
+            <code className="text-xs">*.example.com</code> for wildcard
+            subdomains.
+          </p>
+        </div>
+
+        <Accordion type="single" collapsible className="border-none">
+          <AccordionItem value="advanced" className="border-t border-b-0">
+            <AccordionTrigger className="py-3 hover:no-underline">
+              <span className="text-muted-foreground flex items-center gap-2 text-xs font-normal">
+                <Settings2 className="size-3.5" />
+                Injection settings
+              </span>
+            </AccordionTrigger>
+            <AccordionContent className="pb-0">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="secret-path">
+                    Path pattern{" "}
+                    <span className="text-muted-foreground font-normal">
+                      (optional)
+                    </span>
+                  </Label>
+                  <Input
+                    id="secret-path"
+                    placeholder="e.g. /v1/*"
+                    value={pathPattern}
+                    onChange={(e) => onPathPatternChange(e.target.value)}
+                  />
+                </div>
+
+                {type === "generic" && (
+                  <>
+                    <div className="space-y-2">
+                      <Label htmlFor="secret-header">Header name</Label>
+                      <Input
+                        id="secret-header"
+                        placeholder="e.g. Authorization"
+                        value={headerName}
+                        onChange={(e) => onHeaderNameChange(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="secret-format">
+                        Value format{" "}
+                        <span className="text-muted-foreground font-normal">
+                          (optional)
+                        </span>
+                      </Label>
+                      <Input
+                        id="secret-format"
+                        placeholder="e.g. Bearer {value}"
+                        value={valueFormat}
+                        onChange={(e) => onValueFormatChange(e.target.value)}
+                      />
+                      <p className="text-muted-foreground text-xs">
+                        Use <code className="text-xs">{"{value}"}</code> as a
+                        placeholder for the secret. Defaults to the raw value.
+                      </p>
+                    </div>
+                  </>
+                )}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+
+      <DialogFooter>
+        <Button variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button onClick={onCreate} loading={creating} disabled={!isValid}>
+          {creating ? "Creating..." : "Add Secret"}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+const AnthropicKeyBadge = ({ value }: { value: string }) => {
+  const detected = detectAnthropicKeyType(value);
+  if (!detected) return null;
+
+  return (
+    <Badge
+      variant="outline"
+      className="text-muted-foreground animate-in fade-in shrink-0 gap-1.5 text-[10px] font-normal"
+    >
+      <span
+        className={
+          detected === "api_key"
+            ? "bg-emerald-500 size-1.5 rounded-full"
+            : "bg-blue-500 size-1.5 rounded-full"
+        }
+      />
+      {detected === "api_key" ? "API Key" : "OAuth Token"}
+    </Badge>
   );
 };

--- a/apps/web/src/app/(dashboard)/secrets/_components/edit-secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/edit-secret-dialog.tsx
@@ -195,7 +195,8 @@ export const EditSecretDialog = ({
           </Button>
           <Button
             onClick={handleSave}
-            disabled={!hasChanges || !isValid || saving}
+            loading={saving}
+            disabled={!hasChanges || !isValid}
           >
             {saving ? "Saving..." : "Save Changes"}
           </Button>

--- a/apps/web/src/app/(dashboard)/secrets/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/secrets-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Plus } from "lucide-react";
+import { Plus, KeyRound } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import { getSecrets } from "@/lib/actions/secrets";
 import { Button } from "@onecli/ui/components/button";
@@ -70,9 +70,13 @@ export const SecretsContent = () => {
       </div>
 
       {secrets.length === 0 ? (
-        <Card className="flex flex-col items-center justify-center py-12 text-center">
-          <p className="text-muted-foreground text-sm">
-            No secrets yet. Add one to get started.
+        <Card className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="bg-muted mb-4 flex size-12 items-center justify-center rounded-full">
+            <KeyRound className="text-muted-foreground size-6" />
+          </div>
+          <p className="text-sm font-medium">No secrets yet</p>
+          <p className="text-muted-foreground mt-1 max-w-xs text-xs">
+            Add a secret to inject encrypted credentials into proxy requests.
           </p>
         </Card>
       ) : (

--- a/apps/web/src/app/(dashboard)/secrets/page.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { PageHeader } from "@dashboard/page-header";
 import { SecretsContent } from "./_components/secrets-content";
 
 export const metadata: Metadata = {
@@ -8,14 +9,11 @@ export const metadata: Metadata = {
 
 export default function SecretsPage() {
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 max-w-5xl">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Secrets</h1>
-        <p className="text-muted-foreground text-sm">
-          Manage encrypted credentials that the proxy injects into requests.
-        </p>
-      </div>
-
+    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+      <PageHeader
+        title="Secrets"
+        description="Manage encrypted credentials that the proxy injects into requests."
+      />
       <Suspense>
         <SecretsContent />
       </Suspense>

--- a/apps/web/src/app/(dashboard)/settings/profile/_components/profile-form.tsx
+++ b/apps/web/src/app/(dashboard)/settings/profile/_components/profile-form.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
 import {
   Card,
   CardContent,
@@ -13,10 +11,12 @@ import {
 import { Button } from "@onecli/ui/components/button";
 import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
+import { Skeleton } from "@onecli/ui/components/skeleton";
+import { toast } from "sonner";
 import { useAuth } from "@/providers/auth-provider";
 import { getUserByAuthId, updateProfile } from "@/lib/actions/user";
 
-export function ProfileForm() {
+export const ProfileForm = () => {
   const { user: authUser } = useAuth();
   const [name, setName] = useState("");
   const [initialName, setInitialName] = useState("");
@@ -52,10 +52,23 @@ export function ProfileForm() {
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
-        <Loader2 className="size-4 animate-spin" />
-        Loading profile...
-      </div>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-28" />
+          <Skeleton className="h-4 w-40" />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid gap-2">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+          <div className="grid gap-2">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+          <Skeleton className="h-9 w-24" />
+        </CardContent>
+      </Card>
     );
   }
 
@@ -84,7 +97,8 @@ export function ProfileForm() {
         </div>
         <Button
           onClick={handleSave}
-          disabled={saving || name === initialName}
+          loading={saving}
+          disabled={name === initialName}
           className="w-fit"
         >
           {saving ? "Saving..." : "Save changes"}
@@ -92,4 +106,4 @@ export function ProfileForm() {
       </CardContent>
     </Card>
   );
-}
+};

--- a/apps/web/src/app/(dashboard)/settings/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/profile/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { PageHeader } from "@dashboard/page-header";
 import { ProfileForm } from "./_components/profile-form";
 
 export const metadata: Metadata = {
@@ -7,14 +8,8 @@ export const metadata: Metadata = {
 
 export default function ProfilePage() {
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 max-w-5xl">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
-        <p className="text-muted-foreground text-sm">
-          Manage your account settings.
-        </p>
-      </div>
-
+    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+      <PageHeader title="Profile" description="Manage your account settings." />
       <ProfileForm />
     </div>
   );

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDownIcon } from "lucide-react";
+import { Accordion as AccordionPrimitive } from "radix-ui";
+
+import { cn } from "@onecli/ui/lib/utils";
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
+import { LoaderCircle } from "lucide-react";
 
 import { cn } from "@onecli/ui/lib/utils";
 
@@ -45,12 +46,17 @@ function Button({
   variant = "default",
   size = "default",
   asChild = false,
+  loading = false,
+  disabled,
+  children,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
+    loading?: boolean;
   }) {
   const Comp = asChild ? Slot.Root : "button";
+  const showSpinner = loading && !asChild;
 
   return (
     <Comp
@@ -58,8 +64,18 @@ function Button({
       data-variant={variant}
       data-size={size}
       className={cn(buttonVariants({ variant, size, className }))}
+      disabled={loading || disabled}
       {...props}
-    />
+    >
+      {showSpinner ? (
+        <>
+          <LoaderCircle className="animate-spin" />
+          {children}
+        </>
+      ) : (
+        children
+      )}
+    </Comp>
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,8 @@ importers:
         specifier: 5.9.2
         version: 5.9.2
 
+  apps/proxy: {}
+
   apps/web:
     dependencies:
       '@aws-amplify/adapter-nextjs':


### PR DESCRIPTION
## Summary

- **Button loading state** — new `loading` prop on Button that shows a spinner and auto-disables
- **PageHeader component** — shared component for consistent page title + description pattern
- **Fix double padding** — removed duplicate `p-6` from page wrappers (layout already provides it)
- **Skeleton loading states** — API key card and profile form now use skeletons instead of text spinners
- **Empty state improvements** — agents and secrets empty states have icons, titles, and descriptions
- **Stats card hover affordance** — arrow indicator on hover for clickable stat cards
- **Theme toggle tooltip** — added tooltip to the light/dark mode toggle button
- **Code style** — converted function declarations to const arrow functions
- **Secrets dialog** — two-step creation flow, collapsible injection settings, Anthropic key type detection badge