### PR TITLE
fix: improve Docker publish performance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,33 +10,96 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            suffix: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            suffix: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.suffix }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -44,12 +107,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push multi-arch Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create multi-arch manifest and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,26 @@
 # Build context: repo root (run with `docker build -f docker/Dockerfile .`)
 
 # ──────────────────────────────────────────────
-# Stage 1: Build Rust proxy
+# Stage 1a: Install cargo-chef
 # ──────────────────────────────────────────────
-FROM rust:1-alpine AS proxy-builder
-RUN apk add --no-cache musl-dev
+FROM rust:1-alpine AS chef
+RUN apk add --no-cache musl-dev && cargo install cargo-chef
 WORKDIR /build
-COPY apps/proxy/Cargo.toml apps/proxy/Cargo.lock ./
-COPY apps/proxy/src ./src
+
+# ──────────────────────────────────────────────
+# Stage 1b: Prepare dependency recipe
+# ──────────────────────────────────────────────
+FROM chef AS planner
+COPY apps/proxy/ .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ──────────────────────────────────────────────
+# Stage 1c: Build Rust proxy
+# ──────────────────────────────────────────────
+FROM chef AS proxy-builder
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY apps/proxy/ .
 RUN cargo build --release
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Native ARM builds**: Replace QEMU emulation with `ubuntu-24.04-arm` runner, eliminating the 5-20x slowdown for arm64 builds
- **Digest-based merge**: Each arch pushes by digest, then a merge job creates the multi-arch manifest — follows Docker's official recommended pattern
- **cargo-chef**: Replace dummy `main.rs` dependency caching with `cargo-chef` for more robust Rust dependency layer caching
- **GHA cache**: Per-architecture Docker layer cache with `type=gha,mode=max`

## Expected impact

The arm64 build was taking ~73 minutes due to QEMU emulation. With native ARM runners, both architectures should build in parallel in ~5-10 minutes.

## Test plan

- [ ] Tag a release and verify both amd64 and arm64 builds complete successfully
- [ ] Verify the multi-arch manifest is created with both architectures
- [ ] Pull and run the image on both amd64 and arm64 hosts