### PR TITLE
fix: add setup error page with config validation

### DIFF
--- a/apps/web/src/app/auth/login/_components/login-content.tsx
+++ b/apps/web/src/app/auth/login/_components/login-content.tsx
@@ -7,11 +7,7 @@ import { Button } from "@onecli/ui/components/button";
 import { useAuth } from "@/providers/auth-provider";
 import { ensureUser } from "@/lib/actions/auth";
 
-export const LoginContent = ({
-  oauthConfigured,
-}: {
-  oauthConfigured: boolean;
-}) => {
+export const LoginContent = () => {
   const router = useRouter();
   const { isAuthenticated, isLoading, user, signIn } = useAuth();
 
@@ -60,28 +56,6 @@ export const LoginContent = ({
           <div className="text-brand h-8 w-8 animate-spin rounded-full border-2 border-current border-t-transparent" />
           <p className="text-muted-foreground text-sm">
             {isAuthenticated ? "Signing you in..." : "Loading..."}
-          </p>
-        </div>
-      ) : !oauthConfigured ? (
-        <div className="w-full max-w-sm rounded-2xl border border-destructive/50 bg-card p-8 text-center">
-          <p className="text-sm font-medium">OAuth not configured</p>
-          <p className="text-muted-foreground mt-2 text-xs leading-relaxed">
-            <code className="bg-muted rounded px-1 py-0.5">
-              NEXTAUTH_SECRET
-            </code>{" "}
-            is set but{" "}
-            <code className="bg-muted rounded px-1 py-0.5">
-              GOOGLE_CLIENT_ID
-            </code>{" "}
-            and{" "}
-            <code className="bg-muted rounded px-1 py-0.5">
-              GOOGLE_CLIENT_SECRET
-            </code>{" "}
-            are missing. Either provide all three or remove{" "}
-            <code className="bg-muted rounded px-1 py-0.5">
-              NEXTAUTH_SECRET
-            </code>{" "}
-            to use local mode.
           </p>
         </div>
       ) : (

--- a/apps/web/src/app/auth/login/page.tsx
+++ b/apps/web/src/app/auth/login/page.tsx
@@ -1,6 +1,5 @@
-import { isOAuthConfigured } from "@/lib/auth/auth-mode";
 import { LoginContent } from "./_components/login-content";
 
 export default function LoginPage() {
-  return <LoginContent oauthConfigured={isOAuthConfigured()} />;
+  return <LoginContent />;
 }

--- a/apps/web/src/app/setup-error/page.tsx
+++ b/apps/web/src/app/setup-error/page.tsx
@@ -1,0 +1,96 @@
+import { redirect } from "next/navigation";
+import Image from "next/image";
+import { AlertTriangle } from "lucide-react";
+
+const isDev = process.env.NODE_ENV === "development";
+
+const errors: Record<string, { title: string; description: React.ReactNode }> =
+  {
+    "oauth-misconfigured": {
+      title: "OAuth not configured",
+      description: (
+        <p>
+          <Code>NEXTAUTH_SECRET</Code> is set but <Code>GOOGLE_CLIENT_ID</Code>{" "}
+          and <Code>GOOGLE_CLIENT_SECRET</Code> are missing. Either provide all
+          three or remove <Code>NEXTAUTH_SECRET</Code> to use local mode.
+        </p>
+      ),
+    },
+    "missing-encryption-key": {
+      title: "Encryption key not configured",
+      description: isDev ? (
+        <div className="space-y-3">
+          <p>
+            <Code>SECRET_ENCRYPTION_KEY</Code> is required to encrypt stored
+            secrets. Run this to generate one and add it to your{" "}
+            <Code>.env</Code>:
+          </p>
+          <pre className="bg-muted overflow-x-auto rounded-lg px-3 py-2 text-xs">
+            {`echo "SECRET_ENCRYPTION_KEY=$(node -e \\"console.log(require('crypto').randomBytes(32).toString('base64'))\\")" >> .env`}
+          </pre>
+          <p className="text-xs">Then restart the dev server.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p>
+            <Code>SECRET_ENCRYPTION_KEY</Code> is required to encrypt stored
+            secrets. Generate one and add it to your environment:
+          </p>
+          <pre className="bg-muted overflow-x-auto rounded-lg px-3 py-2 text-xs">
+            {`node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`}
+          </pre>
+        </div>
+      ),
+    },
+  };
+
+export default async function SetupErrorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ code?: string }>;
+}) {
+  const { code } = await searchParams;
+  const error = code ? errors[code] : undefined;
+  if (!error) redirect("/auth/login");
+
+  return (
+    <div className="bg-background flex min-h-svh flex-col items-center justify-center px-6 pb-24">
+      <div className="mb-8">
+        <Image
+          src="/onecli-full-logo.png"
+          alt="onecli"
+          width={140}
+          height={40}
+          priority
+          className="dark:hidden"
+        />
+        <Image
+          src="/onecli-full-logo-dark.png"
+          alt="onecli"
+          width={140}
+          height={40}
+          priority
+          className="hidden dark:block"
+        />
+      </div>
+
+      <div className="w-full max-w-md rounded-2xl border border-destructive/50 bg-card p-8">
+        <div className="flex items-center gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle className="size-4 text-destructive" />
+          </div>
+          <h1 className="text-base font-medium">{error.title}</h1>
+        </div>
+        <div className="text-muted-foreground mt-4 text-sm leading-relaxed">
+          {error.description}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="bg-muted rounded px-1.5 py-0.5 text-xs">{children}</code>
+  );
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+type SetupErrorCode = "oauth-misconfigured" | "missing-encryption-key";
+
+/**
+ * Returns the first configuration error found, or null if setup is valid.
+ */
+const getSetupError = (): SetupErrorCode | null => {
+  if (process.env.NEXT_PUBLIC_EDITION === "cloud") return null;
+
+  // NEXTAUTH_SECRET is set but Google OAuth creds are missing
+  if (process.env.NEXTAUTH_SECRET && !process.env.GOOGLE_CLIENT_ID) {
+    return "oauth-misconfigured";
+  }
+
+  // SECRET_ENCRYPTION_KEY is required for encrypting secrets
+  if (!process.env.SECRET_ENCRYPTION_KEY) {
+    return "missing-encryption-key";
+  }
+
+  return null;
+};
+
+export const proxy = (request: NextRequest) => {
+  const { pathname } = request.nextUrl;
+  const error = getSetupError();
+
+  if (pathname.startsWith("/setup-error")) {
+    if (!error) {
+      return NextResponse.redirect(new URL("/auth/login", request.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (error) {
+    return NextResponse.redirect(
+      new URL(`/setup-error?code=${error}`, request.url),
+    );
+  }
+
+  return NextResponse.next();
+};
+
+export const config = {
+  matcher: [
+    // Match all routes except static files, _next, and api routes
+    "/((?!_next/static|_next/image|favicon.ico|api|.*\\.).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

- Add dedicated `/setup-error` page that displays configuration errors with actionable fix instructions
- Add Next.js 16 proxy (`proxy.ts`) that intercepts all routes and redirects to `/setup-error` when config is incomplete
- Currently checks: missing `SECRET_ENCRYPTION_KEY`, OAuth misconfiguration (NEXTAUTH_SECRET set without Google creds)
- Dev mode shows a copy-paste `echo` command to update `.env` directly
- Clean up login page — remove inline error handling (now handled by proxy)

## Test plan

- [ ] Start dev without `SECRET_ENCRYPTION_KEY` in `.env` — should redirect to setup error page with dev-friendly command
- [ ] Add the key and restart — should load normally
- [ ] Set `NEXTAUTH_SECRET` without `GOOGLE_CLIENT_ID` — should show OAuth error
- [ ] Navigate directly to `/setup-error` when config is valid — should redirect to login