### PR TITLE
feat: add 'Try it' demo button in dashboard header

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/dashboard-header.tsx
+++ b/apps/web/src/app/(dashboard)/_components/dashboard-header.tsx
@@ -21,6 +21,7 @@ import {
   BreadcrumbSeparator,
 } from "@onecli/ui/components/breadcrumb";
 import { navItems } from "@/lib/nav-items";
+import { TryDemoButton } from "./try-demo-button";
 
 export const DashboardHeader = () => {
   const pathname = usePathname();
@@ -65,6 +66,7 @@ export const DashboardHeader = () => {
         </BreadcrumbList>
       </Breadcrumb>
       <div className="ml-auto flex items-center gap-2">
+        <TryDemoButton />
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/apps/web/src/app/(dashboard)/_components/try-demo-button.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-button.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Terminal } from "lucide-react";
+import { Button } from "@onecli/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@onecli/ui/components/tooltip";
+import { useAuth } from "@/providers/auth-provider";
+import { getDemoInfo } from "@/lib/actions/secrets";
+import { TryDemoDialog } from "./try-demo-dialog";
+
+export const TryDemoButton = () => {
+  const { user: authUser } = useAuth();
+  const [demoInfo, setDemoInfo] = useState<{
+    agentToken: string | null;
+  } | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (!authUser?.id) return;
+    getDemoInfo(authUser.id).then(setDemoInfo);
+  }, [authUser?.id]);
+
+  if (!demoInfo?.agentToken) return null;
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="brand" size="sm" onClick={() => setDialogOpen(true)}>
+            <Terminal className="size-3.5" />
+            Try it
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Run a quick test of secret injection</TooltipContent>
+      </Tooltip>
+      <TryDemoDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        agentToken={demoInfo.agentToken}
+      />
+    </>
+  );
+};

--- a/apps/web/src/app/(dashboard)/_components/try-demo-command.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-command.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Copy, Check } from "lucide-react";
+import { Button } from "@onecli/ui/components/button";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+
+interface TryDemoCommandProps {
+  command: string;
+  highlight?: string;
+}
+
+export const TryDemoCommand = ({ command, highlight }: TryDemoCommandProps) => {
+  const { copied, copy } = useCopyToClipboard();
+
+  const renderCommand = () => {
+    if (!highlight) return command;
+    const idx = command.indexOf(highlight);
+    if (idx === -1) return command;
+    return (
+      <>
+        {command.slice(0, idx)}
+        <span className="text-green-600 font-semibold dark:text-green-400">
+          {highlight}
+        </span>
+        {command.slice(idx + highlight.length)}
+      </>
+    );
+  };
+
+  return (
+    <div className="relative">
+      <pre className="bg-muted rounded-md border p-3 pr-10 font-mono text-xs whitespace-pre-wrap break-all">
+        {renderCommand()}
+      </pre>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute top-1.5 right-1.5"
+        onClick={() => copy(command)}
+      >
+        {copied ? (
+          <Check className="size-4 text-green-500" />
+        ) : (
+          <Copy className="size-4" />
+        )}
+      </Button>
+    </div>
+  );
+};

--- a/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@onecli/ui/components/dialog";
+import { Button } from "@onecli/ui/components/button";
+import { TryDemoCommand } from "./try-demo-command";
+
+interface TryDemoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agentToken: string;
+}
+
+export const TryDemoDialog = ({
+  open,
+  onOpenChange,
+  agentToken,
+}: TryDemoDialogProps) => {
+  const command = `curl -k -x http://x:${agentToken}@localhost:18080 -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Try OneCLI in 30 Seconds</DialogTitle>
+          <DialogDescription>
+            Run a request and see secret injection in action.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">
+              <span className="bg-foreground text-background mr-2 inline-flex size-5 items-center justify-center rounded-full text-xs font-semibold">
+                1
+              </span>
+              Copy and run this in your terminal
+            </p>
+            <TryDemoCommand command={command} highlight="FAKE_TOKEN" />
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm font-medium">
+              <span className="bg-foreground text-background mr-2 inline-flex size-5 items-center justify-center rounded-full text-xs font-semibold">
+                2
+              </span>
+              Check the response
+            </p>
+            <pre className="bg-muted rounded-md border p-3 font-mono text-xs whitespace-pre-wrap break-all">
+              <span className="text-muted-foreground">
+                {'{\n  ...\n  "headers": {\n    '}
+              </span>
+              <span className="text-muted-foreground line-through">
+                {'"Authorization": "Bearer FAKE_TOKEN"'}
+              </span>
+              {"\n    "}
+              <span className="text-green-600 dark:text-green-400 font-semibold">
+                {
+                  '"Authorization": "Bearer WELCOME-TO-ONECLI-SECRETS-ARE-WORKING"'
+                }
+              </span>
+              <span className="text-muted-foreground">
+                {"\n    ...\n  }\n}"}
+              </span>
+            </pre>
+            <p className="text-muted-foreground text-sm">
+              You sent <code className="text-xs">FAKE_TOKEN</code> - OneCLI
+              replaced it with the real secret.
+            </p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -18,6 +18,42 @@ const buildPreview = (plaintext: string): string => {
   return `${plaintext.slice(0, 4)}${"•".repeat(8)}${plaintext.slice(-4)}`;
 };
 
+const DEMO_SECRET_NAME = "Demo Secret (httpbin)";
+
+const ensureDemoSecret = async (userId: string) => {
+  const user = await db.user.findUniqueOrThrow({
+    where: { id: userId },
+    select: { demoSeeded: true },
+  });
+
+  if (user.demoSeeded) return;
+
+  const encryptedValue = cryptoService.encrypt(
+    "WELCOME-TO-ONECLI-SECRETS-ARE-WORKING",
+  );
+
+  await db.$transaction([
+    db.secret.create({
+      data: {
+        name: DEMO_SECRET_NAME,
+        type: "generic",
+        encryptedValue,
+        hostPattern: "httpbin.org",
+        pathPattern: "/anything/*",
+        injectionConfig: {
+          headerName: "Authorization",
+          valueFormat: "Bearer {value}",
+        },
+        userId,
+      },
+    }),
+    db.user.update({
+      where: { id: userId },
+      data: { demoSeeded: true },
+    }),
+  ]);
+};
+
 const resolveUserId = async (authId?: string) => {
   let id = authId;
   if (!id) {
@@ -37,6 +73,7 @@ const resolveUserId = async (authId?: string) => {
 
 export async function getSecrets(authId?: string) {
   const userId = await resolveUserId(authId);
+  await ensureDemoSecret(userId);
 
   const secrets = await db.secret.findMany({
     where: { userId },
@@ -139,6 +176,23 @@ interface UpdateSecretInput {
   hostPattern?: string;
   pathPattern?: string | null;
   injectionConfig?: { headerName: string; valueFormat: string } | null;
+}
+
+export async function getDemoInfo(authId?: string) {
+  const userId = await resolveUserId(authId);
+
+  const demoSecret = await db.secret.findFirst({
+    where: { userId, name: DEMO_SECRET_NAME },
+    select: { id: true },
+  });
+  if (!demoSecret) return null;
+
+  const agent = await db.agent.findFirst({
+    where: { userId, isDefault: true },
+    select: { accessToken: true },
+  });
+
+  return { agentToken: agent?.accessToken ?? null };
 }
 
 export async function updateSecret(

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "engines": {
     "node": ">=18"
   },
-  "version": "1.0.3",
+  "version": "1.0.2",
   "lint-staged": {
     "*.{ts,tsx,js,jsx,md,css,json}": [
       "prettier --write"

--- a/packages/db/prisma/migrations/20260312080531_add_demo_seeded_to_user/migration.sql
+++ b/packages/db/prisma/migrations/20260312080531_add_demo_seeded_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "demoSeeded" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   apiKey             String?  @unique // "oc_..." prefix, used for API auth
   stripeCustomerId   String?  @unique
   subscriptionStatus String   @default("free")
+  demoSeeded         Boolean  @default(false)
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 


### PR DESCRIPTION
## Summary

- Add a green "Try it" CTA button in the dashboard header that opens a dialog with a pre-filled curl command to test secret injection against httpbin.org
- Add `getDemoInfo()` server action to check if the demo secret exists and return the agent token
- Add `demoSeeded` flag to User model to track demo secret provisioning
- Fix demo secret path pattern (`/anything/*` instead of `/anything*`) for correct proxy matching

## New files

- `try-demo-button.tsx` — Self-contained button (fetches demo info, hides if no demo secret)
- `try-demo-command.tsx` — Code block with copy button and optional keyword highlighting
- `try-demo-dialog.tsx` — Step-by-step dialog showing the curl command and expected output

## Modified files

- `dashboard-header.tsx` — Added TryDemoButton before theme toggle
- `secrets.ts` — Added `getDemoInfo()` action, fixed path pattern
- `schema.prisma` — Added `demoSeeded` Boolean field to User
- `package.json` — Version bump