### PR TITLE
chore: change default ports to 10254 (web) and 10255 (proxy)

### DIFF
--- a/apps/proxy/src/main.rs
+++ b/apps/proxy/src/main.rs
@@ -20,7 +20,7 @@ use crate::proxy::ProxyServer;
 )]
 struct Cli {
     /// Port to listen on.
-    #[arg(long, default_value = "18080")]
+    #[arg(long, default_value = "10255")]
     port: u16,
 
     /// Data directory for CA certificates and persistent state.
@@ -28,7 +28,7 @@ struct Cli {
     data_dir: PathBuf,
 
     /// OneCLI web API base URL (for credential fetching).
-    #[arg(long, default_value = "http://localhost:3000")]
+    #[arg(long, default_value = "http://localhost:10254")]
     api_url: String,
 
     /// Path to the proxy–API shared secret file.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "dev": "next dev --port 3000",
+    "dev": "next dev --port 10254",
     "build": "next build",
     "start": "next start",
     "lint": "eslint --max-warnings 0",

--- a/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
@@ -22,7 +22,7 @@ export const TryDemoDialog = ({
   onOpenChange,
   agentToken,
 }: TryDemoDialogProps) => {
-  const command = `curl -k -x http://x:${agentToken}@localhost:18080 -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`;
+  const command = `curl -k -x http://x:${agentToken}@localhost:10255 -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/app/api/container-config/route.ts
+++ b/apps/web/src/app/api/container-config/route.ts
@@ -4,7 +4,7 @@ import { validateApiKey } from "@/lib/validate-api-key";
 import { getServerSession } from "@/lib/auth/server";
 import { loadCaCertificate } from "@/lib/proxy-ca";
 
-const PROXY_PORT = process.env.PROXY_PORT ?? "18080";
+const PROXY_PORT = process.env.PROXY_PORT ?? "10255";
 const CA_CONTAINER_PATH = "/tmp/onecli-proxy-ca.pem";
 
 const isCloud = process.env.NEXT_PUBLIC_EDITION === "cloud";

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,10 +69,10 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NO_COLOR=1
 ENV FORCE_COLOR=0
-ENV PORT=3000
+ENV PORT=10254
 ENV HOSTNAME="0.0.0.0"
 ENV AUTH_TRUST_HOST=true
-ENV NEXTAUTH_URL=http://localhost:3000
+ENV NEXTAUTH_URL=http://localhost:10254
 
 # Proxy binary from Rust build
 COPY --from=proxy-builder /build/target/release/onecli-proxy /usr/local/bin/onecli-proxy
@@ -103,9 +103,9 @@ VOLUME ["/app/data"]
 
 USER node
 
-EXPOSE 3000 18080
+EXPOSE 10254 10255
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost:3000/api/health && wget -qO- http://localhost:18080/healthz || exit 1
+  CMD wget -qO- http://localhost:10254/api/health && wget -qO- http://localhost:10255/healthz || exit 1
 
 CMD ["./entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,8 +4,8 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     ports:
-      - "3000:3000"
-      - "18080:18080"
+      - "10254:10254"
+      - "10255:10255"
     volumes:
       - onecli-data:/app/data
     env_file: ../.env

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -59,8 +59,8 @@ fi
 printf '{"authMode":"%s","oauthConfigured":%s}\n' "$AUTH_MODE" "$OAUTH_CONFIGURED" > /app/data/runtime-config.json
 
 # Start proxy in background
-echo "Starting proxy on port ${PROXY_PORT:-18080}..."
-onecli-proxy --port "${PROXY_PORT:-18080}" --data-dir /app/data &
+echo "Starting proxy on port ${PROXY_PORT:-10255}..."
+onecli-proxy --port "${PROXY_PORT:-10255}" --data-dir /app/data &
 PROXY_PID=$!
 
 # Graceful shutdown: stop both processes on SIGTERM

--- a/docs/nanoclaw-integration.md
+++ b/docs/nanoclaw-integration.md
@@ -22,7 +22,7 @@ The orchestrator needs two env vars:
 | `ONECLI_API_KEY` | Yes      | User API key from OneCLI dashboard (`oc_...`)            |
 | `ONECLI_URL`     | No       | OneCLI instance URL. Defaults to `https://app.onecli.sh` |
 
-For self-hosted: `ONECLI_URL=http://localhost:3000`
+For self-hosted: `ONECLI_URL=http://localhost:10254`
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Change web server default port from 3000 to 10254
- Change proxy default port from 18080 to 10255

## Files changed

- `apps/proxy/src/main.rs` — Rust CLI default `--port` and `--api-url`
- `apps/web/package.json` — `next dev --port`
- `docker/Dockerfile` — ENV PORT, NEXTAUTH_URL, EXPOSE, healthcheck
- `docker/docker-compose.yml` — port mappings
- `docker/entrypoint.sh` — PROXY_PORT fallback
- `apps/web/src/app/api/container-config/route.ts` — PROXY_PORT fallback
- `apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx` — demo curl command
- `docs/nanoclaw-integration.md` — self-hosted URL example