### PR TITLE
chore: dashboard UX improvements and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ docker/
 
 ### Prerequisites
 
-- **Node.js** >= 18
-- **pnpm** 9+
+- **[mise](https://mise.jdx.dev)** (installs Node.js, pnpm, and other tools)
 - **Rust** (for the gateway)
 
 ### Setup
 
 ```bash
+mise install
 pnpm install
 cp .env.example .env
 pnpm db:generate

--- a/apps/web/src/app/(dashboard)/_components/try-demo-button.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Terminal } from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
 import {
@@ -8,23 +8,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@onecli/ui/components/tooltip";
-import { useAuth } from "@/providers/auth-provider";
-import { getDemoInfo } from "@/lib/actions/secrets";
 import { TryDemoDialog } from "./try-demo-dialog";
 
 export const TryDemoButton = () => {
-  const { user: authUser } = useAuth();
-  const [demoInfo, setDemoInfo] = useState<{
-    agentToken: string | null;
-  } | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
-
-  useEffect(() => {
-    if (!authUser?.id) return;
-    getDemoInfo(authUser.id).then(setDemoInfo);
-  }, [authUser?.id]);
-
-  if (!demoInfo?.agentToken) return null;
 
   return (
     <>
@@ -37,11 +24,7 @@ export const TryDemoButton = () => {
         </TooltipTrigger>
         <TooltipContent>Run a quick test of secret injection</TooltipContent>
       </Tooltip>
-      <TryDemoDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        agentToken={demoInfo.agentToken}
-      />
+      <TryDemoDialog open={dialogOpen} onOpenChange={setDialogOpen} />
     </>
   );
 };

--- a/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -9,20 +11,31 @@ import {
   DialogTitle,
 } from "@onecli/ui/components/dialog";
 import { Button } from "@onecli/ui/components/button";
+import { useAuth } from "@/providers/auth-provider";
+import { getDemoInfo } from "@/lib/actions/secrets";
 import { TryDemoCommand } from "./try-demo-command";
 
 interface TryDemoDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  agentToken: string;
 }
 
-export const TryDemoDialog = ({
-  open,
-  onOpenChange,
-  agentToken,
-}: TryDemoDialogProps) => {
-  const command = `curl -k -x http://x:${agentToken}@localhost:10255 -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`;
+export const TryDemoDialog = ({ open, onOpenChange }: TryDemoDialogProps) => {
+  const { user: authUser } = useAuth();
+  const [agentToken, setAgentToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !authUser?.id) return;
+    setLoading(true);
+    getDemoInfo(authUser.id)
+      .then((info) => setAgentToken(info?.agentToken ?? null))
+      .finally(() => setLoading(false));
+  }, [open, authUser?.id]);
+
+  const command = agentToken
+    ? `curl -k -x http://x:${agentToken}@localhost:10255 -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`
+    : "";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -33,46 +46,52 @@ export const TryDemoDialog = ({
             Run a request and see secret injection in action.
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <p className="text-sm font-medium">
-              <span className="bg-foreground text-background mr-2 inline-flex size-5 items-center justify-center rounded-full text-xs font-semibold">
-                1
-              </span>
-              Copy and run this in your terminal
-            </p>
-            <TryDemoCommand command={command} highlight="FAKE_TOKEN" />
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="text-muted-foreground size-5 animate-spin" />
           </div>
-          <div className="space-y-2">
-            <p className="text-sm font-medium">
-              <span className="bg-foreground text-background mr-2 inline-flex size-5 items-center justify-center rounded-full text-xs font-semibold">
-                2
-              </span>
-              Check the response
-            </p>
-            <pre className="bg-muted rounded-md border p-3 font-mono text-xs whitespace-pre-wrap break-all">
-              <span className="text-muted-foreground">
-                {'{\n  ...\n  "headers": {\n    '}
-              </span>
-              <span className="text-muted-foreground line-through">
-                {'"Authorization": "Bearer FAKE_TOKEN"'}
-              </span>
-              {"\n    "}
-              <span className="text-green-600 dark:text-green-400 font-semibold">
-                {
-                  '"Authorization": "Bearer WELCOME-TO-ONECLI-SECRETS-ARE-WORKING"'
-                }
-              </span>
-              <span className="text-muted-foreground">
-                {"\n    ...\n  }\n}"}
-              </span>
-            </pre>
-            <p className="text-muted-foreground text-sm">
-              You sent <code className="text-xs">FAKE_TOKEN</code> - OneCLI
-              replaced it with the real secret.
-            </p>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm font-medium">
+                <span className="bg-foreground text-background mr-2 inline-flex size-5 items-center justify-center rounded-full text-xs font-semibold">
+                  1
+                </span>
+                Copy and run this in your terminal
+              </p>
+              <TryDemoCommand command={command} highlight="FAKE_TOKEN" />
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium">
+                <span className="bg-foreground text-background mr-2 inline-flex size-5 items-center justify-center rounded-full text-xs font-semibold">
+                  2
+                </span>
+                Check the response
+              </p>
+              <pre className="bg-muted rounded-md border p-3 font-mono text-xs whitespace-pre-wrap break-all">
+                <span className="text-muted-foreground">
+                  {'{\n  ...\n  "headers": {\n    '}
+                </span>
+                <span className="text-muted-foreground line-through">
+                  {'"Authorization": "Bearer FAKE_TOKEN"'}
+                </span>
+                {"\n    "}
+                <span className="text-green-600 dark:text-green-400 font-semibold">
+                  {
+                    '"Authorization": "Bearer WELCOME-TO-ONECLI-SECRETS-ARE-WORKING"'
+                  }
+                </span>
+                <span className="text-muted-foreground">
+                  {"\n    ...\n  }\n}"}
+                </span>
+              </pre>
+              <p className="text-muted-foreground text-sm">
+                You sent <code className="text-xs">FAKE_TOKEN</code> - OneCLI
+                replaced it with the real secret.
+              </p>
+            </div>
           </div>
-        </div>
+        )}
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Close

--- a/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { Eye, EyeOff, Copy, Check, RefreshCw, Trash2 } from "lucide-react";
+import { MoreHorizontal, RotateCw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@onecli/ui/components/card";
 import { Button } from "@onecli/ui/components/button";
 import { Badge } from "@onecli/ui/components/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@onecli/ui/components/dropdown-menu";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,9 +21,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@onecli/ui/components/alert-dialog";
-import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useAuth } from "@/providers/auth-provider";
 import { deleteAgent, regenerateAgentToken } from "@/lib/actions/agents";
 
@@ -34,19 +38,16 @@ interface AgentCardProps {
 
 export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
   const { user } = useAuth();
-  const [revealed, setRevealed] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
-  const { copied, copy } = useCopyToClipboard();
-
-  const truncatedToken = `${agent.accessToken.slice(0, 8)}${"•".repeat(12)}${agent.accessToken.slice(-4)}`;
+  const [rotateDialogOpen, setRotateDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const handleRegenerate = async () => {
     if (!user?.id) return;
     setRegenerating(true);
     try {
       await regenerateAgentToken(agent.id, user.id);
-      setRevealed(false);
       onUpdate();
       toast.success("Token regenerated");
     } catch {
@@ -83,101 +84,78 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
             )}
           </div>
 
-          <div className="flex items-center gap-2">
-            <code className="bg-muted flex-1 truncate rounded-md border px-3 py-1.5 font-mono text-xs select-none">
-              {revealed ? agent.accessToken : truncatedToken}
-            </code>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7"
-              onClick={() => setRevealed(!revealed)}
-            >
-              {revealed ? (
-                <EyeOff className="size-3.5" />
-              ) : (
-                <Eye className="size-3.5" />
-              )}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7"
-              onClick={() => copy(agent.accessToken)}
-            >
-              {copied ? (
-                <Check className="size-3.5 text-green-500" />
-              ) : (
-                <Copy className="size-3.5" />
-              )}
-            </Button>
-          </div>
-
           <p className="text-muted-foreground text-xs">
             Created {new Date(agent.createdAt).toLocaleDateString()}
           </p>
         </div>
 
-        <div className="flex items-center gap-1">
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="ghost" size="icon" className="size-7">
-                <RefreshCw
-                  className={`size-3.5 ${regenerating ? "animate-spin" : ""}`}
-                />
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Regenerate token?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  The current token for <strong>{agent.name}</strong> will be
-                  invalidated immediately. Any agents using the old token will
-                  lose access.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleRegenerate}
-                  disabled={regenerating}
-                >
-                  {regenerating ? "Regenerating..." : "Regenerate"}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-
-          {!agent.isDefault && (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="ghost" size="icon" className="size-7">
-                  <Trash2 className="size-3.5" />
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete agent?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will permanently delete <strong>{agent.name}</strong>{" "}
-                    and its access token. This action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    variant="destructive"
-                    onClick={handleDelete}
-                    disabled={deleting}
-                  >
-                    {deleting ? "Deleting..." : "Delete"}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          )}
-        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="size-7">
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => setRotateDialogOpen(true)}>
+              <RotateCw className="size-4" />
+              Rotate token
+            </DropdownMenuItem>
+            {!agent.isDefault && (
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => setDeleteDialogOpen(true)}
+              >
+                <Trash2 className="size-4" />
+                Delete agent
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
+
+      <AlertDialog open={rotateDialogOpen} onOpenChange={setRotateDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rotate token?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The current token for <strong>{agent.name}</strong> will be
+              invalidated immediately. Any agents using the old token will lose
+              access.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRegenerate}
+              disabled={regenerating}
+            >
+              {regenerating ? "Rotating..." : "Rotate"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete agent?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete <strong>{agent.name}</strong> and its
+              access token. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
+              {deleting ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 };

--- a/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
@@ -59,10 +59,13 @@ export const AgentsContent = () => {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <Button size="sm" onClick={() => setCreateOpen(true)}>
-          <Plus className="size-3.5" />
-          Create Agent
-        </Button>
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-xs">Coming soon</span>
+          <Button size="sm" disabled>
+            <Plus className="size-3.5" />
+            Create Agent
+          </Button>
+        </div>
       </div>
 
       {agents.length === 0 ? (

--- a/apps/web/src/app/(dashboard)/secrets/_components/create-secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/create-secret-dialog.tsx
@@ -305,20 +305,22 @@ const FormStep = ({
           </div>
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="secret-host">Host pattern</Label>
-          <Input
-            id="secret-host"
-            placeholder="e.g. api.example.com or *.example.com"
-            value={hostPattern}
-            onChange={(e) => onHostPatternChange(e.target.value)}
-          />
-          <p className="text-muted-foreground text-xs">
-            The host this secret applies to. Use{" "}
-            <code className="text-xs">*.example.com</code> for wildcard
-            subdomains.
-          </p>
-        </div>
+        {type === "generic" && (
+          <div className="space-y-2">
+            <Label htmlFor="secret-host">Host pattern</Label>
+            <Input
+              id="secret-host"
+              placeholder="e.g. api.example.com or *.example.com"
+              value={hostPattern}
+              onChange={(e) => onHostPatternChange(e.target.value)}
+            />
+            <p className="text-muted-foreground text-xs">
+              The host this secret applies to. Use{" "}
+              <code className="text-xs">*.example.com</code> for wildcard
+              subdomains.
+            </p>
+          </div>
+        )}
 
         <Accordion type="single" collapsible className="border-none">
           <AccordionItem value="advanced" className="border-t border-b-0">
@@ -330,6 +332,23 @@ const FormStep = ({
             </AccordionTrigger>
             <AccordionContent className="pb-0">
               <div className="space-y-4">
+                {type === "anthropic" && (
+                  <div className="space-y-2">
+                    <Label htmlFor="secret-host">Host pattern</Label>
+                    <Input
+                      id="secret-host"
+                      placeholder="e.g. api.example.com or *.example.com"
+                      value={hostPattern}
+                      onChange={(e) => onHostPatternChange(e.target.value)}
+                    />
+                    <p className="text-muted-foreground text-xs">
+                      The host this secret applies to. Use{" "}
+                      <code className="text-xs">*.example.com</code> for
+                      wildcard subdomains.
+                    </p>
+                  </div>
+                )}
+
                 <div className="space-y-2">
                   <Label htmlFor="secret-path">
                     Path pattern{" "}

--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -180,6 +180,7 @@ interface UpdateSecretInput {
 
 export async function getDemoInfo(authId?: string) {
   const userId = await resolveUserId(authId);
+  await ensureDemoSecret(userId);
 
   const demoSecret = await db.secret.findFirst({
     where: { userId, name: DEMO_SECRET_NAME },


### PR DESCRIPTION
## Summary
- Always show "Try it" button in header; lazy-load demo secret when dialog opens
- Move host pattern field under "Injection settings" accordion for Anthropic secrets
- Agent card: replace token display with three-dot dropdown menu (rotate token / delete agent)
- Disable "Create Agent" button with inline "Coming soon" label
- Add `mise install` to README local development setup
- Ensure demo secret is seeded in `getDemoInfo` server action

## Test plan
- [ ] Verify "Try it" button appears immediately on fresh install
- [ ] Open Try It dialog and confirm curl command loads
- [ ] Create Anthropic secret — host pattern should be under accordion
- [ ] Create Generic secret — host pattern should be visible in main form
- [ ] Agent card dropdown menu works (rotate token, delete agent)
- [ ] Create Agent button is disabled with "Coming soon" text