### PR TITLE
fix: add explicit bridge network to Docker Compose for reliable DNS resolution

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    networks:
+      - onecli
 
   app:
     image: ghcr.io/onecli/onecli:latest
@@ -30,7 +32,13 @@ services:
     env_file:
       - path: ../.env
         required: false
+    networks:
+      - onecli
 
 volumes:
   pgdata:
   app-data:
+
+networks:
+  onecli:
+    driver: bridge


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On Docker Desktop with WSL2 backend, running `docker compose -f docker/docker-compose.yml up` causes the app container to fail with:

```
Error: P1001: Can't reach database server at `postgres:5432`
```

Docker's internal DNS resolver (`127.0.0.11`) returns NXDOMAIN when the app container tries to resolve the `postgres` hostname. This prevents Prisma from running database migrations at startup.

**Tested environment:**
- Docker Desktop with WSL2 backend
- Docker v29.2.1, Docker Compose v5.1.0
- Ubuntu 24.04.1 LTS (WSL2 kernel 5.15.153.1-microsoft-standard-WSL2)

## What is the new behavior?

Both services are placed on an explicit bridge network (`onecli`), ensuring reliable DNS resolution between containers. The app container can consistently resolve the `postgres` hostname and connect to the database.

## Additional context

The implicit default network created by Docker Compose does not always provide reliable DNS resolution on Docker Desktop with WSL2 backend. Adding an explicit bridge network with a dedicated DNS scope resolves this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)