### PR TITLE
feat: add per-agent secret permissions

### DIFF
--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -67,10 +67,13 @@ impl PolicyEngine {
             .map_err(|e| ConnectError::Internal(format!("db error: {e}")))?
             .ok_or(ConnectError::InvalidToken)?;
 
-        // 2. Secret lookup
-        let secrets = db::find_secrets_by_user(&self.pool, &agent.user_id)
-            .await
-            .map_err(|e| ConnectError::Internal(format!("db error: {e}")))?;
+        // 2. Secret lookup — branch on agent's secret mode
+        let secrets = if agent.secret_mode == "selective" {
+            db::find_secrets_by_agent(&self.pool, &agent.id).await
+        } else {
+            db::find_secrets_by_user(&self.pool, &agent.user_id).await
+        }
+        .map_err(|e| ConnectError::Internal(format!("db error: {e}")))?;
 
         // 3. Filter by host pattern
         let matching: Vec<_> = secrets

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -22,10 +22,11 @@ pub(crate) async fn create_pool(database_url: &str) -> Result<PgPool> {
 /// An agent row from the `Agent` table.
 #[derive(Debug, FromRow)]
 pub(crate) struct AgentRow {
-    #[allow(dead_code)]
     pub id: String,
     #[sqlx(rename = "userId")]
     pub user_id: String,
+    #[sqlx(rename = "secretMode")]
+    pub secret_mode: String,
 }
 
 /// A secret row from the `Secret` table.
@@ -69,7 +70,7 @@ pub(crate) async fn find_agent_by_token(
     access_token: &str,
 ) -> Result<Option<AgentRow>> {
     sqlx::query_as::<_, AgentRow>(
-        r#"SELECT id, "userId" FROM "Agent" WHERE "accessToken" = $1 LIMIT 1"#,
+        r#"SELECT id, "userId", "secretMode" FROM "Agent" WHERE "accessToken" = $1 LIMIT 1"#,
     )
     .bind(access_token)
     .fetch_optional(pool)
@@ -86,4 +87,18 @@ pub(crate) async fn find_secrets_by_user(pool: &PgPool, user_id: &str) -> Result
     .fetch_all(pool)
     .await
     .context("querying Secrets by userId")
+}
+
+/// Find secrets assigned to a specific agent (selective mode).
+pub(crate) async fn find_secrets_by_agent(pool: &PgPool, agent_id: &str) -> Result<Vec<SecretRow>> {
+    sqlx::query_as::<_, SecretRow>(
+        r#"SELECT s."type", s."encryptedValue", s."hostPattern", s."pathPattern", s."injectionConfig"
+           FROM "Secret" s
+           INNER JOIN "AgentSecret" as_ ON s.id = as_."secretId"
+           WHERE as_."agentId" = $1"#,
+    )
+    .bind(agent_id)
+    .fetch_all(pool)
+    .await
+    .context("querying Secrets by agentId")
 }

--- a/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { MoreHorizontal, RotateCw, Trash2 } from "lucide-react";
+import { MoreHorizontal, RotateCw, Trash2, KeyRound } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@onecli/ui/components/card";
 import { Button } from "@onecli/ui/components/button";
@@ -23,6 +23,7 @@ import {
   AlertDialogTitle,
 } from "@onecli/ui/components/alert-dialog";
 import { deleteAgent, regenerateAgentToken } from "@/lib/actions/agents";
+import { ManageSecretsDialog } from "./manage-secrets-dialog";
 
 interface AgentCardProps {
   agent: {
@@ -30,7 +31,9 @@ interface AgentCardProps {
     name: string;
     accessToken: string;
     isDefault: boolean;
+    secretMode: string;
     createdAt: Date;
+    _count: { agentSecrets: number };
   };
   onUpdate: () => void;
 }
@@ -40,6 +43,7 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
   const [regenerating, setRegenerating] = useState(false);
   const [rotateDialogOpen, setRotateDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [secretsDialogOpen, setSecretsDialogOpen] = useState(false);
 
   const handleRegenerate = async () => {
     setRegenerating(true);
@@ -67,6 +71,11 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
     }
   };
 
+  const secretsLabel =
+    agent.secretMode === "selective"
+      ? `${agent._count.agentSecrets} ${agent._count.agentSecrets === 1 ? "secret" : "secrets"}`
+      : "All secrets";
+
   return (
     <Card className="p-5">
       <div className="flex items-start justify-between gap-4">
@@ -80,9 +89,19 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
             )}
           </div>
 
-          <p className="text-muted-foreground text-xs">
-            Created {new Date(agent.createdAt).toLocaleDateString()}
-          </p>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+            <span className="text-muted-foreground">
+              Created {new Date(agent.createdAt).toLocaleDateString()}
+            </span>
+            <button
+              type="button"
+              onClick={() => setSecretsDialogOpen(true)}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 transition-colors"
+            >
+              <KeyRound className="size-3" />
+              {secretsLabel}
+            </button>
+          </div>
         </div>
 
         <DropdownMenu>
@@ -92,6 +111,10 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => setSecretsDialogOpen(true)}>
+              <KeyRound className="size-4" />
+              Manage secrets
+            </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => setRotateDialogOpen(true)}>
               <RotateCw className="size-4" />
               Rotate token
@@ -152,6 +175,13 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <ManageSecretsDialog
+        agent={agent}
+        open={secretsDialogOpen}
+        onOpenChange={setSecretsDialogOpen}
+        onUpdated={onUpdate}
+      />
     </Card>
   );
 };

--- a/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
@@ -14,7 +14,9 @@ interface Agent {
   name: string;
   accessToken: string;
   isDefault: boolean;
+  secretMode: string;
   createdAt: Date;
+  _count: { agentSecrets: number };
 }
 
 export const AgentsContent = () => {

--- a/apps/web/src/app/(dashboard)/agents/_components/manage-secrets-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/manage-secrets-dialog.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useEffect, useState, useCallback, useMemo } from "react";
+import {
+  KeyRound,
+  Loader2,
+  Search,
+  ShieldCheck,
+  Globe,
+  ListChecks,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@onecli/ui/components/dialog";
+import { Button } from "@onecli/ui/components/button";
+import { Input } from "@onecli/ui/components/input";
+import { Badge } from "@onecli/ui/components/badge";
+import { Checkbox } from "@onecli/ui/components/checkbox";
+import { ScrollArea } from "@onecli/ui/components/scroll-area";
+import { cn } from "@onecli/ui/lib/utils";
+import { getSecrets } from "@/lib/actions/secrets";
+import {
+  getAgentSecrets,
+  updateAgentSecretMode,
+  updateAgentSecrets,
+} from "@/lib/actions/agents";
+
+interface ManageSecretsDialogProps {
+  agent: {
+    id: string;
+    name: string;
+    secretMode: string;
+  };
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpdated: () => void;
+}
+
+type Secret = Awaited<ReturnType<typeof getSecrets>>[number];
+
+export const ManageSecretsDialog = ({
+  agent,
+  open,
+  onOpenChange,
+  onUpdated,
+}: ManageSecretsDialogProps) => {
+  const [mode, setMode] = useState<"all" | "selective">(
+    agent.secretMode === "selective" ? "selective" : "all",
+  );
+  const [secrets, setSecrets] = useState<Secret[]>([]);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [allSecrets, assignedIds] = await Promise.all([
+        getSecrets(),
+        getAgentSecrets(agent.id),
+      ]);
+      setSecrets(allSecrets);
+      setSelectedIds(new Set(assignedIds));
+    } catch {
+      toast.error("Failed to load secrets");
+    } finally {
+      setLoading(false);
+    }
+  }, [agent.id]);
+
+  useEffect(() => {
+    if (open) {
+      setMode(agent.secretMode === "selective" ? "selective" : "all");
+      setSearch("");
+      fetchData();
+    }
+  }, [open, agent.secretMode, fetchData]);
+
+  const filteredSecrets = useMemo(() => {
+    if (!search.trim()) return secrets;
+    const q = search.toLowerCase();
+    return secrets.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.hostPattern.toLowerCase().includes(q),
+    );
+  }, [secrets, search]);
+
+  const toggleSecret = (secretId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(secretId)) {
+        next.delete(secretId);
+      } else {
+        next.add(secretId);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await updateAgentSecretMode(agent.id, mode);
+      if (mode === "selective") {
+        await updateAgentSecrets(agent.id, Array.from(selectedIds));
+      }
+      onUpdated();
+      onOpenChange(false);
+      toast.success("Secret permissions updated");
+    } catch {
+      toast.error("Failed to update secret permissions");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isSelective = mode === "selective";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 p-0 sm:max-w-lg">
+        <DialogHeader className="p-6 pb-4">
+          <DialogTitle>Secret access for {agent.name}</DialogTitle>
+        </DialogHeader>
+
+        {/* Security callout — always visible */}
+        <div className="border-border/50 mx-6 flex items-start gap-2.5 rounded-md border px-3 py-2.5">
+          <ShieldCheck className="text-muted-foreground mt-px size-3.5 shrink-0" />
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            Secrets are injected by the OneCLI gateway at request time. The
+            agent never sees raw secret values.
+          </p>
+        </div>
+
+        {/* Mode selection — radio card pattern */}
+        <div className="space-y-2 px-6 pt-4 pb-2">
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+            Access mode
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => setMode("all")}
+              className={cn(
+                "flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors",
+                !isSelective
+                  ? "border-foreground/30 bg-muted/60"
+                  : "border-border hover:border-border hover:bg-muted/30",
+              )}
+            >
+              <Globe
+                className={cn(
+                  "size-4",
+                  !isSelective ? "text-foreground" : "text-muted-foreground/60",
+                )}
+              />
+              <div>
+                <p
+                  className={cn(
+                    "text-sm font-medium",
+                    isSelective && "text-muted-foreground",
+                  )}
+                >
+                  All secrets
+                </p>
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  Access every secret in your account
+                </p>
+              </div>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setMode("selective")}
+              className={cn(
+                "flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors",
+                isSelective
+                  ? "border-foreground/30 bg-muted/60"
+                  : "border-border hover:border-border hover:bg-muted/30",
+              )}
+            >
+              <ListChecks
+                className={cn(
+                  "size-4",
+                  isSelective ? "text-foreground" : "text-muted-foreground/60",
+                )}
+              />
+              <div>
+                <p
+                  className={cn(
+                    "text-sm font-medium",
+                    !isSelective && "text-muted-foreground",
+                  )}
+                >
+                  Specific secrets
+                </p>
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  Choose which secrets to allow
+                </p>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        {/* Secret list — revealed when selective */}
+        {isSelective && (
+          <div className="px-6 pt-2 pb-1">
+            {loading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="text-muted-foreground size-4 animate-spin" />
+              </div>
+            ) : secrets.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-8 text-center">
+                <div className="bg-muted mb-3 flex size-10 items-center justify-center rounded-full">
+                  <KeyRound className="text-muted-foreground size-4" />
+                </div>
+                <p className="text-sm font-medium">No secrets yet</p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Add secrets in the Secrets page first.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {/* Search */}
+                <div className="relative">
+                  <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+                  <Input
+                    placeholder="Filter secrets..."
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    className="h-8 pl-8 text-sm"
+                  />
+                </div>
+
+                {/* Toolbar: count + actions */}
+                <div className="flex items-center justify-between">
+                  <p className="text-muted-foreground text-xs">
+                    <span className="text-foreground font-medium">
+                      {selectedIds.size}
+                    </span>{" "}
+                    of {secrets.length} selected
+                  </p>
+                  <div className="flex gap-1">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setSelectedIds(new Set(secrets.map((s) => s.id)))
+                      }
+                      className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+                    >
+                      Select all
+                    </button>
+                    <span className="text-muted-foreground/40 text-xs">/</span>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedIds(new Set())}
+                      className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </div>
+
+                {/* List */}
+                <ScrollArea className="h-[200px] overflow-hidden rounded-md border">
+                  <div className="divide-border divide-y">
+                    {filteredSecrets.map((secret) => (
+                      <label
+                        key={secret.id}
+                        className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors"
+                      >
+                        <Checkbox
+                          checked={selectedIds.has(secret.id)}
+                          onCheckedChange={() => toggleSecret(secret.id)}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium">
+                            {secret.name}
+                          </p>
+                          <code className="text-muted-foreground text-xs">
+                            {secret.hostPattern}
+                          </code>
+                        </div>
+                        <Badge variant="secondary" className="shrink-0 text-xs">
+                          {secret.typeLabel}
+                        </Badge>
+                      </label>
+                    ))}
+                    {filteredSecrets.length === 0 && (
+                      <p className="text-muted-foreground py-6 text-center text-xs">
+                        No secrets match &ldquo;{search}&rdquo;
+                      </p>
+                    )}
+                  </div>
+                </ScrollArea>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Footer */}
+        <DialogFooter className="border-border/50 border-t px-6 py-4">
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} loading={saving} disabled={loading}>
+            {saving ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/src/lib/actions/agents.ts
+++ b/apps/web/src/lib/actions/agents.ts
@@ -16,7 +16,9 @@ export async function getAgents() {
       name: true,
       accessToken: true,
       isDefault: true,
+      secretMode: true,
       createdAt: true,
+      _count: { select: { agentSecrets: true } },
     },
     orderBy: [{ isDefault: "desc" }, { createdAt: "desc" }],
   });
@@ -96,4 +98,71 @@ export async function regenerateAgentToken(agentId: string) {
   });
 
   return { accessToken: updated.accessToken };
+}
+
+export async function getAgentSecrets(agentId: string) {
+  const userId = await resolveUserId();
+
+  const agent = await db.agent.findFirst({
+    where: { id: agentId, userId },
+    select: { id: true },
+  });
+
+  if (!agent) throw new Error("Agent not found");
+
+  const rows = await db.agentSecret.findMany({
+    where: { agentId },
+    select: { secretId: true },
+  });
+
+  return rows.map((r) => r.secretId);
+}
+
+export async function updateAgentSecretMode(
+  agentId: string,
+  mode: "all" | "selective",
+) {
+  const userId = await resolveUserId();
+
+  const agent = await db.agent.findFirst({
+    where: { id: agentId, userId },
+    select: { id: true },
+  });
+
+  if (!agent) throw new Error("Agent not found");
+
+  await db.agent.update({
+    where: { id: agentId },
+    data: { secretMode: mode },
+  });
+}
+
+export async function updateAgentSecrets(agentId: string, secretIds: string[]) {
+  const userId = await resolveUserId();
+
+  const agent = await db.agent.findFirst({
+    where: { id: agentId, userId },
+    select: { id: true },
+  });
+
+  if (!agent) throw new Error("Agent not found");
+
+  // Validate all secrets belong to this user
+  const secrets = await db.secret.findMany({
+    where: { id: { in: secretIds }, userId },
+    select: { id: true },
+  });
+
+  const validIds = new Set(secrets.map((s) => s.id));
+  const invalid = secretIds.filter((id) => !validIds.has(id));
+  if (invalid.length > 0) {
+    throw new Error("One or more secrets not found");
+  }
+
+  await db.$transaction([
+    db.agentSecret.deleteMany({ where: { agentId } }),
+    ...secretIds.map((secretId) =>
+      db.agentSecret.create({ data: { agentId, secretId } }),
+    ),
+  ]);
 }

--- a/packages/db/prisma/migrations/20260316175458_agent_secret_permissions/migration.sql
+++ b/packages/db/prisma/migrations/20260316175458_agent_secret_permissions/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable
+ALTER TABLE "Agent" ADD COLUMN     "secretMode" TEXT NOT NULL DEFAULT 'all';
+
+-- CreateTable
+CREATE TABLE "AgentSecret" (
+    "agentId" TEXT NOT NULL,
+    "secretId" TEXT NOT NULL,
+
+    CONSTRAINT "AgentSecret_pkey" PRIMARY KEY ("agentId","secretId")
+);
+
+-- AddForeignKey
+ALTER TABLE "AgentSecret" ADD CONSTRAINT "AgentSecret_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentSecret" ADD CONSTRAINT "AgentSecret_secretId_fkey" FOREIGN KEY ("secretId") REFERENCES "Secret"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -29,9 +29,12 @@ model Agent {
   name        String
   accessToken String   @unique // "aoc_..." prefix, used for gateway auth
   isDefault   Boolean  @default(false)
+  secretMode  String   @default("all") // "all" or "selective"
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   user        User     @relation(fields: [userId], references: [id])
+
+  agentSecrets AgentSecret[]
 
   @@index([userId])
 }
@@ -49,5 +52,16 @@ model Secret {
   updatedAt       DateTime @updatedAt
   user            User     @relation(fields: [userId], references: [id])
 
+  agentSecrets AgentSecret[]
+
   @@index([userId])
+}
+
+model AgentSecret {
+  agentId  String
+  secretId String
+  agent    Agent  @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  secret   Secret @relation(fields: [secretId], references: [id], onDelete: Cascade)
+
+  @@id([agentId, secretId])
 }


### PR DESCRIPTION
## Summary

Add per-agent secret permissions so users can control which secrets each agent accesses through the OneCLI gateway.

- **Schema**: Add `secretMode` field to `Agent` (`"all"` or `"selective"`) and `AgentSecret` join table with cascade deletes on both sides
- **Migration**: `20260316175458_agent_secret_permissions`
- **Server actions**: `getAgentSecrets`, `updateAgentSecretMode`, `updateAgentSecrets` with ownership validation
- **UI**: Manage secrets dialog with radio card mode picker, search/filter, select all/clear, scroll area
- **Gateway**: Branch on `secret_mode` in `resolve_uncached`, new `find_secrets_by_agent` query via join table

### How it works

- **All secrets (default)**: Agent has access to all user secrets (current behavior, unchanged)
- **Selective mode**: Only explicitly assigned secrets are available to the agent
- Switching from selective → all preserves assignments (dormant), so switching back restores the previous selection
- Gateway caches per (agent_token, host) with 60s TTL — no cache changes needed

## Test plan

- [ ] `pnpm db:migrate` — migration applies cleanly
- [ ] `pnpm check` — lint + types pass
- [ ] `cargo test` — gateway tests pass (60 unit + 5 integration)
- [ ] Create agent → defaults to "All secrets" → badge shows "All secrets"
- [ ] Open manage-secrets dialog → switch to selective → select secrets → save
- [ ] Delete a secret that was assigned → agent count decreases, no errors
- [ ] Switch back to "all" → all secrets available, previous selection preserved