### PR TITLE
feat: default new agents to selective mode with anthropic secret

### DIFF
--- a/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import { useState } from "react";
-import { MoreHorizontal, RotateCw, Trash2, KeyRound } from "lucide-react";
+import {
+  MoreHorizontal,
+  RotateCw,
+  Trash2,
+  KeyRound,
+  Pencil,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@onecli/ui/components/card";
 import { Button } from "@onecli/ui/components/button";
 import { Badge } from "@onecli/ui/components/badge";
+import { Input } from "@onecli/ui/components/input";
+import { Label } from "@onecli/ui/components/label";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -22,16 +30,29 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@onecli/ui/components/alert-dialog";
-import { deleteAgent, regenerateAgentToken } from "@/lib/actions/agents";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@onecli/ui/components/dialog";
+import {
+  deleteAgent,
+  regenerateAgentToken,
+  renameAgent,
+  type SecretMode,
+} from "@/lib/actions/agents";
 import { ManageSecretsDialog } from "./manage-secrets-dialog";
 
 interface AgentCardProps {
   agent: {
     id: string;
     name: string;
+    identifier: string | null;
     accessToken: string;
     isDefault: boolean;
-    secretMode: string;
+    secretMode: SecretMode;
     createdAt: Date;
     _count: { agentSecrets: number };
   };
@@ -41,8 +62,11 @@ interface AgentCardProps {
 export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
   const [deleting, setDeleting] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
+  const [renaming, setRenaming] = useState(false);
   const [rotateDialogOpen, setRotateDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [newName, setNewName] = useState("");
   const [secretsDialogOpen, setSecretsDialogOpen] = useState(false);
 
   const handleRegenerate = async () => {
@@ -71,6 +95,21 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
     }
   };
 
+  const handleRename = async () => {
+    if (!newName.trim()) return;
+    setRenaming(true);
+    try {
+      await renameAgent(agent.id, newName);
+      onUpdate();
+      setRenameDialogOpen(false);
+      toast.success("Agent renamed");
+    } catch {
+      toast.error("Failed to rename agent");
+    } finally {
+      setRenaming(false);
+    }
+  };
+
   const secretsLabel =
     agent.secretMode === "selective"
       ? `${agent._count.agentSecrets} ${agent._count.agentSecrets === 1 ? "secret" : "secrets"}`
@@ -90,6 +129,11 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
           </div>
 
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+            {agent.identifier && (
+              <code className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono">
+                {agent.identifier}
+              </code>
+            )}
             <span className="text-muted-foreground">
               Created {new Date(agent.createdAt).toLocaleDateString()}
             </span>
@@ -111,6 +155,15 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onSelect={() => {
+                setNewName(agent.name);
+                setRenameDialogOpen(true);
+              }}
+            >
+              <Pencil className="size-4" />
+              Rename
+            </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => setSecretsDialogOpen(true)}>
               <KeyRound className="size-4" />
               Manage secrets
@@ -175,6 +228,38 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename agent</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor={`rename-agent-${agent.id}`}>Name</Label>
+            <Input
+              id={`rename-agent-${agent.id}`}
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && newName.trim()) handleRename();
+              }}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRenameDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRename}
+              loading={renaming}
+              disabled={!newName.trim()}
+            >
+              {renaming ? "Renaming..." : "Rename"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <ManageSecretsDialog
         agent={agent}

--- a/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { Plus, Bot } from "lucide-react";
-import { getAgents } from "@/lib/actions/agents";
+import { getAgents, type SecretMode } from "@/lib/actions/agents";
 import { Button } from "@onecli/ui/components/button";
 import { Card } from "@onecli/ui/components/card";
 import { Skeleton } from "@onecli/ui/components/skeleton";
@@ -12,9 +12,10 @@ import { CreateAgentDialog } from "./create-agent-dialog";
 interface Agent {
   id: string;
   name: string;
+  identifier: string | null;
   accessToken: string;
   isDefault: boolean;
-  secretMode: string;
+  secretMode: SecretMode;
   createdAt: Date;
   _count: { agentSecrets: number };
 }
@@ -58,13 +59,10 @@ export const AgentsContent = () => {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-xs">Coming soon</span>
-          <Button size="sm" disabled>
-            <Plus className="size-3.5" />
-            Create Agent
-          </Button>
-        </div>
+        <Button size="sm" onClick={() => setCreateOpen(true)}>
+          <Plus className="size-3.5" />
+          Create Agent
+        </Button>
       </div>
 
       {agents.length === 0 ? (

--- a/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Check } from "lucide-react";
+import { Copy, Check, CircleCheck } from "lucide-react";
 import { toast } from "sonner";
 import {
   Dialog,
@@ -23,26 +23,54 @@ interface CreateAgentDialogProps {
   onCreated: () => void;
 }
 
+const nameToIdentifier = (name: string) =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+
 export const CreateAgentDialog = ({
   open,
   onOpenChange,
   onCreated,
 }: CreateAgentDialogProps) => {
   const [name, setName] = useState("");
+  const [identifier, setIdentifier] = useState("");
+  const [identifierTouched, setIdentifierTouched] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [newToken, setNewToken] = useState<string | null>(null);
+  const [createdIdentifier, setCreatedIdentifier] = useState<string | null>(
+    null,
+  );
   const { copied, copy } = useCopyToClipboard();
 
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (!identifierTouched) {
+      setIdentifier(nameToIdentifier(value));
+    }
+  };
+
+  const handleIdentifierChange = (value: string) => {
+    setIdentifierTouched(true);
+    setIdentifier(value.toLowerCase().replace(/[^a-z0-9-]/g, ""));
+  };
+
+  const isValidIdentifier = /^[a-z][a-z0-9-]{0,49}$/.test(identifier);
+
   const handleCreate = async () => {
-    if (!name.trim()) return;
+    if (!name.trim() || !isValidIdentifier) return;
     setCreating(true);
     try {
-      const agent = await createAgent(name);
-      setNewToken(agent.accessToken);
+      const agent = await createAgent(name, identifier);
+      setCreatedIdentifier(agent.identifier);
       onCreated();
       toast.success("Agent created");
-    } catch {
-      toast.error("Failed to create agent");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create agent",
+      );
     } finally {
       setCreating(false);
     }
@@ -51,7 +79,9 @@ export const CreateAgentDialog = ({
   const handleClose = (value: boolean) => {
     if (!value) {
       setName("");
-      setNewToken(null);
+      setIdentifier("");
+      setIdentifierTouched(false);
+      setCreatedIdentifier(null);
     }
     onOpenChange(value);
   };
@@ -59,39 +89,42 @@ export const CreateAgentDialog = ({
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent>
-        {newToken ? (
+        {createdIdentifier ? (
           <>
-            <DialogHeader>
-              <DialogTitle>Agent created</DialogTitle>
-              <DialogDescription>
-                Copy the access token now. You won&apos;t be able to see it
-                again.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-3 py-2">
-              <div className="flex items-center gap-2">
-                <code className="bg-muted flex-1 truncate rounded-md border px-3 py-2 font-mono text-sm break-all select-all">
-                  {newToken}
+            <div className="flex flex-col items-center pt-2 text-center">
+              <div className="bg-emerald-500/10 mb-3 flex size-10 items-center justify-center rounded-full">
+                <CircleCheck className="size-5 text-emerald-500" />
+              </div>
+              <DialogHeader className="items-center">
+                <DialogTitle>Agent created</DialogTitle>
+                <DialogDescription>
+                  Use this identifier to select the agent in the SDK.
+                </DialogDescription>
+              </DialogHeader>
+            </div>
+            <div className="py-2">
+              <div className="bg-muted flex items-center justify-between gap-3 rounded-lg border px-4 py-3">
+                <code className="min-w-0 truncate font-mono text-sm font-medium">
+                  {createdIdentifier}
                 </code>
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() => copy(newToken)}
+                  className="size-7 shrink-0"
+                  onClick={() => copy(createdIdentifier)}
                 >
                   {copied ? (
-                    <Check className="size-4 text-green-500" />
+                    <Check className="size-3.5 text-emerald-500" />
                   ) : (
-                    <Copy className="size-4" />
+                    <Copy className="size-3.5" />
                   )}
                 </Button>
               </div>
-              <p className="text-muted-foreground text-xs">
-                Use this token to configure your agent&apos;s connection to the
-                gateway.
-              </p>
             </div>
             <DialogFooter>
-              <Button onClick={() => handleClose(false)}>Done</Button>
+              <Button onClick={() => handleClose(false)} className="w-full">
+                Done
+              </Button>
             </DialogFooter>
           </>
         ) : (
@@ -109,12 +142,37 @@ export const CreateAgentDialog = ({
                   id="agent-name"
                   placeholder="e.g. Production Claude"
                   value={name}
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e) => handleNameChange(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter" && name.trim()) handleCreate();
+                    if (e.key === "Enter" && name.trim() && isValidIdentifier)
+                      handleCreate();
                   }}
                   autoFocus
                 />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="agent-identifier">Identifier</Label>
+                <Input
+                  id="agent-identifier"
+                  placeholder="e.g. production"
+                  value={identifier}
+                  onChange={(e) => handleIdentifierChange(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && name.trim() && isValidIdentifier)
+                      handleCreate();
+                  }}
+                />
+                <p
+                  className={`text-xs ${
+                    identifier && !isValidIdentifier
+                      ? "text-destructive"
+                      : "text-muted-foreground"
+                  }`}
+                >
+                  {identifier && !isValidIdentifier
+                    ? "Must start with a letter and contain only lowercase letters, numbers, and hyphens."
+                    : "Used to select this agent in the SDK. Lowercase letters, numbers, and hyphens."}
+                </p>
               </div>
             </div>
             <DialogFooter>
@@ -124,7 +182,7 @@ export const CreateAgentDialog = ({
               <Button
                 onClick={handleCreate}
                 loading={creating}
-                disabled={!name.trim()}
+                disabled={!name.trim() || !isValidIdentifier}
               >
                 {creating ? "Creating..." : "Create"}
               </Button>

--- a/apps/web/src/app/(dashboard)/agents/_components/manage-secrets-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/manage-secrets-dialog.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useMemo } from "react";
-import {
-  KeyRound,
-  Loader2,
-  Search,
-  ShieldCheck,
-  Globe,
-  ListChecks,
-} from "lucide-react";
+import { KeyRound, Loader2, Search, Globe, ListChecks } from "lucide-react";
 import { toast } from "sonner";
 import {
   Dialog,
@@ -28,13 +21,14 @@ import {
   getAgentSecrets,
   updateAgentSecretMode,
   updateAgentSecrets,
+  type SecretMode,
 } from "@/lib/actions/agents";
 
 interface ManageSecretsDialogProps {
   agent: {
     id: string;
     name: string;
-    secretMode: string;
+    secretMode: SecretMode;
   };
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -49,7 +43,7 @@ export const ManageSecretsDialog = ({
   onOpenChange,
   onUpdated,
 }: ManageSecretsDialogProps) => {
-  const [mode, setMode] = useState<"all" | "selective">(
+  const [mode, setMode] = useState<SecretMode>(
     agent.secretMode === "selective" ? "selective" : "all",
   );
   const [secrets, setSecrets] = useState<Secret[]>([]);
@@ -128,84 +122,66 @@ export const ManageSecretsDialog = ({
       <DialogContent className="gap-0 p-0 sm:max-w-lg">
         <DialogHeader className="p-6 pb-4">
           <DialogTitle>Secret access for {agent.name}</DialogTitle>
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            Secrets are injected by the gateway at request time. The agent never
+            sees raw values.
+          </p>
         </DialogHeader>
 
-        {/* Security callout — always visible */}
-        <div className="border-border/50 mx-6 flex items-start gap-2.5 rounded-md border px-3 py-2.5">
-          <ShieldCheck className="text-muted-foreground mt-px size-3.5 shrink-0" />
-          <p className="text-muted-foreground text-xs leading-relaxed">
-            Secrets are injected by the OneCLI gateway at request time. The
-            agent never sees raw secret values.
-          </p>
-        </div>
-
-        {/* Mode selection — radio card pattern */}
-        <div className="space-y-2 px-6 pt-4 pb-2">
+        {/* Mode selection */}
+        <div className="space-y-2 px-6 pb-2">
           <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
             Access mode
           </p>
           <div className="grid grid-cols-2 gap-2">
-            <button
-              type="button"
-              onClick={() => setMode("all")}
-              className={cn(
-                "flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors",
-                !isSelective
-                  ? "border-foreground/30 bg-muted/60"
-                  : "border-border hover:border-border hover:bg-muted/30",
-              )}
-            >
-              <Globe
+            {(
+              [
+                {
+                  value: "all",
+                  icon: Globe,
+                  label: "All secrets",
+                  desc: "Every secret in your account",
+                },
+                {
+                  value: "selective",
+                  icon: ListChecks,
+                  label: "Selective",
+                  desc: "Choose specific secrets",
+                },
+              ] as const
+            ).map(({ value, icon: Icon, label, desc }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setMode(value)}
                 className={cn(
-                  "size-4",
-                  !isSelective ? "text-foreground" : "text-muted-foreground/60",
+                  "flex flex-col gap-2 rounded-lg border p-3 text-left transition-colors",
+                  mode === value
+                    ? "border-foreground/30 bg-muted/60"
+                    : "border-border hover:bg-muted/30",
                 )}
-              />
-              <div>
-                <p
-                  className={cn(
-                    "text-sm font-medium",
-                    isSelective && "text-muted-foreground",
-                  )}
-                >
-                  All secrets
-                </p>
-                <p className="text-muted-foreground mt-0.5 text-xs">
-                  Access every secret in your account
-                </p>
-              </div>
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setMode("selective")}
-              className={cn(
-                "flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors",
-                isSelective
-                  ? "border-foreground/30 bg-muted/60"
-                  : "border-border hover:border-border hover:bg-muted/30",
-              )}
-            >
-              <ListChecks
-                className={cn(
-                  "size-4",
-                  isSelective ? "text-foreground" : "text-muted-foreground/60",
-                )}
-              />
-              <div>
-                <p
-                  className={cn(
-                    "text-sm font-medium",
-                    !isSelective && "text-muted-foreground",
-                  )}
-                >
-                  Specific secrets
-                </p>
-                <p className="text-muted-foreground mt-0.5 text-xs">
-                  Choose which secrets to allow
-                </p>
-              </div>
-            </button>
+              >
+                <div className="flex items-center gap-2">
+                  <Icon
+                    className={cn(
+                      "size-3.5",
+                      mode === value
+                        ? "text-foreground"
+                        : "text-muted-foreground/60",
+                    )}
+                  />
+                  <p
+                    className={cn(
+                      "text-sm font-medium",
+                      mode !== value && "text-muted-foreground",
+                    )}
+                  >
+                    {label}
+                  </p>
+                </div>
+                <p className="text-muted-foreground text-xs">{desc}</p>
+              </button>
+            ))}
           </div>
         </div>
 

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { db, Prisma } from "@onecli/db";
+import { validateApiKey } from "@/lib/validate-api-key";
+import { getServerSession } from "@/lib/auth/server";
+
+const IDENTIFIER_REGEX = /^[a-z][a-z0-9-]{0,49}$/;
+
+const generateAccessToken = () => `aoc_${randomBytes(32).toString("hex")}`;
+
+/**
+ * POST /api/agents
+ *
+ * Create a new agent programmatically.
+ * Auth: `Authorization: Bearer oc_...` (user API key) or JWT session.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const apiKeyUser = await validateApiKey(request);
+
+    let userId: string | null = null;
+
+    if (apiKeyUser) {
+      userId = apiKeyUser.id;
+    } else {
+      const session = await getServerSession();
+      if (session) {
+        const user = await db.user.findUnique({
+          where: { externalAuthId: session.id },
+          select: { id: true },
+        });
+        userId = user?.id ?? null;
+      }
+    }
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    if (
+      !body ||
+      typeof body.name !== "string" ||
+      typeof body.identifier !== "string"
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Request body must include 'name' (string) and 'identifier' (string)",
+        },
+        { status: 400 },
+      );
+    }
+
+    const name = body.name.trim();
+    if (!name || name.length > 255) {
+      return NextResponse.json(
+        { error: "Name must be between 1 and 255 characters" },
+        { status: 400 },
+      );
+    }
+
+    const identifier = body.identifier.trim();
+    if (!IDENTIFIER_REGEX.test(identifier)) {
+      return NextResponse.json(
+        {
+          error:
+            "Identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens",
+        },
+        { status: 400 },
+      );
+    }
+
+    const existing = await db.agent.findFirst({
+      where: { userId, identifier },
+      select: { id: true },
+    });
+    if (existing) {
+      return NextResponse.json(
+        { error: "An agent with this identifier already exists" },
+        { status: 400 },
+      );
+    }
+
+    const accessToken = generateAccessToken();
+
+    const agent = await db.agent.create({
+      data: {
+        name,
+        identifier,
+        accessToken,
+        secretMode: "selective",
+        userId,
+      },
+      select: {
+        id: true,
+        name: true,
+        identifier: true,
+        accessToken: true,
+      },
+    });
+
+    // Auto-assign the first anthropic secret if one exists
+    const anthropicSecret = await db.secret.findFirst({
+      where: { userId, type: "anthropic" },
+      select: { id: true },
+      orderBy: { createdAt: "asc" },
+    });
+
+    if (anthropicSecret) {
+      await db.agentSecret.create({
+        data: { agentId: agent.id, secretId: anthropicSecret.id },
+      });
+    }
+
+    return NextResponse.json(agent, { status: 201 });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "An agent with this identifier already exists" },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/container-config/route.ts
+++ b/apps/web/src/app/api/container-config/route.ts
@@ -50,21 +50,32 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Look up the user's default agent to embed its token in the gateway URL
-    const defaultAgent = await db.agent.findFirst({
-      where: { userId, isDefault: true },
-      select: { accessToken: true },
-    });
+    // Look up agent: by identifier if provided, otherwise default
+    const agentIdentifier = request.nextUrl.searchParams.get("agent");
 
-    if (!defaultAgent) {
+    const agent = agentIdentifier
+      ? await db.agent.findFirst({
+          where: { userId, identifier: agentIdentifier },
+          select: { accessToken: true },
+        })
+      : await db.agent.findFirst({
+          where: { userId, isDefault: true },
+          select: { accessToken: true },
+        });
+
+    if (!agent) {
       return NextResponse.json(
-        { error: "No default agent found. Please create one first." },
+        {
+          error: agentIdentifier
+            ? "Agent with the given identifier not found."
+            : "No default agent found. Please create one first.",
+        },
         { status: 404 },
       );
     }
 
     const gatewayHost = getGatewayHost();
-    const gatewayUrl = `http://x:${defaultAgent.accessToken}@${gatewayHost}:${GATEWAY_PORT}`;
+    const gatewayUrl = `http://x:${agent.accessToken}@${gatewayHost}:${GATEWAY_PORT}`;
 
     const caCertificate = loadCaCertificate();
     if (!caCertificate) {

--- a/apps/web/src/lib/actions/agents.ts
+++ b/apps/web/src/lib/actions/agents.ts
@@ -1,19 +1,32 @@
 "use server";
 
 import { randomBytes } from "crypto";
-import { db } from "@onecli/db";
+import { db, Prisma } from "@onecli/db";
 import { resolveUserId } from "@/lib/actions/resolve-user";
 
+export type SecretMode = "all" | "selective";
+
 const generateAccessToken = () => `aoc_${randomBytes(32).toString("hex")}`;
+
+const IDENTIFIER_REGEX = /^[a-z][a-z0-9-]{0,49}$/;
+
+const validateIdentifier = (identifier: string) => {
+  if (!IDENTIFIER_REGEX.test(identifier)) {
+    throw new Error(
+      "Identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens",
+    );
+  }
+};
 
 export async function getAgents() {
   const userId = await resolveUserId();
 
-  return db.agent.findMany({
+  const agents = await db.agent.findMany({
     where: { userId },
     select: {
       id: true,
       name: true,
+      identifier: true,
       accessToken: true,
       isDefault: true,
       secretMode: true,
@@ -22,6 +35,11 @@ export async function getAgents() {
     },
     orderBy: [{ isDefault: "desc" }, { createdAt: "desc" }],
   });
+
+  return agents.map((a) => ({
+    ...a,
+    secretMode: a.secretMode as SecretMode,
+  }));
 }
 
 export async function getDefaultAgent() {
@@ -39,30 +57,67 @@ export async function getDefaultAgent() {
   });
 }
 
-export async function createAgent(name: string) {
+export async function createAgent(name: string, identifier: string) {
   const trimmed = name.trim();
   if (!trimmed || trimmed.length > 255) {
     throw new Error("Name must be between 1 and 255 characters");
   }
 
+  const trimmedIdentifier = identifier.trim();
+  validateIdentifier(trimmedIdentifier);
+
   const userId = await resolveUserId();
+
+  const existing = await db.agent.findFirst({
+    where: { userId, identifier: trimmedIdentifier },
+    select: { id: true },
+  });
+  if (existing) {
+    throw new Error("An agent with this identifier already exists");
+  }
+
   const accessToken = generateAccessToken();
 
-  const agent = await db.agent.create({
-    data: {
-      name: trimmed,
-      accessToken,
-      userId,
-    },
-    select: {
-      id: true,
-      name: true,
-      accessToken: true,
-      createdAt: true,
-    },
-  });
+  try {
+    const agent = await db.agent.create({
+      data: {
+        name: trimmed,
+        identifier: trimmedIdentifier,
+        accessToken,
+        secretMode: "selective",
+        userId,
+      },
+      select: {
+        id: true,
+        name: true,
+        identifier: true,
+        createdAt: true,
+      },
+    });
 
-  return agent;
+    // Auto-assign the first anthropic secret if one exists
+    const anthropicSecret = await db.secret.findFirst({
+      where: { userId, type: "anthropic" },
+      select: { id: true },
+      orderBy: { createdAt: "asc" },
+    });
+
+    if (anthropicSecret) {
+      await db.agentSecret.create({
+        data: { agentId: agent.id, secretId: anthropicSecret.id },
+      });
+    }
+
+    return agent;
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      throw new Error("An agent with this identifier already exists");
+    }
+    throw err;
+  }
 }
 
 export async function deleteAgent(agentId: string) {
@@ -77,6 +132,27 @@ export async function deleteAgent(agentId: string) {
   if (agent.isDefault) throw new Error("Cannot delete the default agent");
 
   await db.agent.delete({ where: { id: agentId } });
+}
+
+export async function renameAgent(agentId: string, name: string) {
+  const trimmed = name.trim();
+  if (!trimmed || trimmed.length > 255) {
+    throw new Error("Name must be between 1 and 255 characters");
+  }
+
+  const userId = await resolveUserId();
+
+  const agent = await db.agent.findFirst({
+    where: { id: agentId, userId },
+    select: { id: true },
+  });
+
+  if (!agent) throw new Error("Agent not found");
+
+  await db.agent.update({
+    where: { id: agentId },
+    data: { name: trimmed },
+  });
 }
 
 export async function regenerateAgentToken(agentId: string) {
@@ -118,10 +194,7 @@ export async function getAgentSecrets(agentId: string) {
   return rows.map((r) => r.secretId);
 }
 
-export async function updateAgentSecretMode(
-  agentId: string,
-  mode: "all" | "selective",
-) {
+export async function updateAgentSecretMode(agentId: string, mode: SecretMode) {
   const userId = await resolveUserId();
 
   const agent = await db.agent.findFirst({

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "fix": "turbo run lint:fix && pnpm run format",
     "db:up": "docker compose -f docker/docker-compose.yml up postgres -d",
     "db:down": "docker compose -f docker/docker-compose.yml down postgres",
+    "db:nuke": "docker compose -f docker/docker-compose.yml down postgres -v",
     "db:generate": "pnpm --filter @onecli/db prisma generate",
     "db:push": "dotenv -e .env -- pnpm --filter @onecli/db prisma db push",
     "db:migrate": "dotenv -e .env -- pnpm --filter @onecli/db db:migrate",

--- a/packages/db/prisma/migrations/20260317111513_add_agent_identifier/migration.sql
+++ b/packages/db/prisma/migrations/20260317111513_add_agent_identifier/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId,identifier]` on the table `Agent` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Agent" ADD COLUMN     "identifier" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Agent_userId_identifier_key" ON "Agent"("userId", "identifier");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Agent {
   id          String   @id @default(cuid())
   userId      String
   name        String
+  identifier  String?  // user-provided machine-readable ID, unique per user
   accessToken String   @unique // "aoc_..." prefix, used for gateway auth
   isDefault   Boolean  @default(false)
   secretMode  String   @default("all") // "all" or "selective"
@@ -36,6 +37,7 @@ model Agent {
 
   agentSecrets AgentSecret[]
 
+  @@unique([userId, identifier])
   @@index([userId])
 }
 


### PR DESCRIPTION
## Summary

- New agents default to **selective** secret mode instead of "all"
- The first anthropic secret is automatically assigned to new agents, giving minimum access needed out of the box
- Adds agent **identifier** field — a unique per-user machine-readable ID for programmatic agent lookup
- Adds `POST /api/agents` endpoint for creating agents programmatically
- Adds `db:nuke` script for fresh database resets (removes container + volume)
- Refactors manage-secrets dialog to a cleaner data-driven layout with inline icon+label cards
- Exports `SecretMode` type from agents action for consistent typing across components