### PR TITLE
chore: add error boundaries and favicon

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,6 +3,7 @@ const isCloud = process.env.NEXT_PUBLIC_EDITION === "cloud";
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  compress: !isCloud, // Cloud: CloudFront handles compression at the edge; OSS: Next.js compresses
   serverExternalPackages: ["@onecli/db"],
   env: {
     NEXT_PUBLIC_EDITION: process.env.NEXT_PUBLIC_EDITION || "oss",

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="48" height="52" viewBox="0 0 48 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- First chevron (rounded thick strokes) -->
+  <path d="M4 8L18 24L4 40" stroke="#19BA5D" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <!-- Second chevron -->
+  <path d="M20 8L34 24L20 40" stroke="#19BA5D" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <!-- Underline bar -->
+  <rect x="4" y="46" width="30" height="5" rx="2.5" fill="#19BA5D"/>
+</svg>

--- a/apps/web/src/app/(dashboard)/error.tsx
+++ b/apps/web/src/app/(dashboard)/error.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Dashboard error boundary — catches chunk load errors from lazy-loaded
+ * dashboard routes after deployments.
+ */
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (
+      error.name === "ChunkLoadError" ||
+      error.message?.includes("ChunkLoadError")
+    ) {
+      const key = "chunk-error-reloaded";
+      const alreadyReloaded = sessionStorage.getItem(key);
+
+      if (!alreadyReloaded) {
+        sessionStorage.setItem(key, "1");
+        window.location.reload();
+        return;
+      }
+
+      sessionStorage.removeItem(key);
+    }
+  }, [error]);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-6">
+      <p className="text-sm font-medium">Something went wrong</p>
+      <p className="text-muted-foreground max-w-sm text-center text-xs">
+        A new version may have been deployed. Try refreshing the page.
+      </p>
+      <button
+        onClick={() => {
+          sessionStorage.removeItem("chunk-error-reloaded");
+          reset();
+        }}
+        className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Global error boundary for the entire app.
+ *
+ * Handles ChunkLoadError gracefully — after a deployment, cached HTML may
+ * reference old JS chunks that no longer exist. A single reload fetches
+ * the new HTML with correct chunk references. Session storage prevents
+ * infinite reload loops.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (
+      error.name === "ChunkLoadError" ||
+      error.message?.includes("ChunkLoadError")
+    ) {
+      const key = "chunk-error-reloaded";
+      const alreadyReloaded = sessionStorage.getItem(key);
+
+      if (!alreadyReloaded) {
+        sessionStorage.setItem(key, "1");
+        window.location.reload();
+        return;
+      }
+
+      // Clear flag so future deploys can retry
+      sessionStorage.removeItem(key);
+    }
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            fontFamily: "system-ui, sans-serif",
+            gap: "16px",
+          }}
+        >
+          <h2 style={{ fontSize: "18px", fontWeight: 600 }}>
+            Something went wrong
+          </h2>
+          <p style={{ fontSize: "14px", color: "#666" }}>
+            A new version may have been deployed. Try refreshing the page.
+          </p>
+          <button
+            onClick={() => {
+              sessionStorage.removeItem("chunk-error-reloaded");
+              reset();
+            }}
+            style={{
+              padding: "8px 16px",
+              fontSize: "14px",
+              borderRadius: "6px",
+              border: "1px solid #ddd",
+              background: "#fff",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -32,6 +32,9 @@ export const metadata: Metadata = {
     template: "%s — OneCLI",
   },
   description: "Universal CLI gateway for AI agents.",
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

- **Error boundaries**: Add `global-error.tsx` (root) and `(dashboard)/error.tsx` to handle `ChunkLoadError` after deployments — auto-reloads once with `sessionStorage` loop prevention, then shows a friendly retry UI
- **Favicon**: Add SVG favicon with double-chevron brand mark
- **Compression config**: Conditionally disable Next.js built-in compression when running behind a CDN (`compress: !isCloud`) to avoid double-compression

## Test plan

- [ ] Deploy a new version and verify stale tabs auto-reload instead of showing a blank page
- [ ] Verify favicon appears in browser tab
- [ ] Verify `pnpm build` succeeds with updated next.config.js