### PR TITLE
refactor: snake_case database naming

### DIFF
--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -19,60 +19,49 @@ pub(crate) async fn create_pool(database_url: &str) -> Result<PgPool> {
 
 // ── Row types ───────────────────────────────────────────────────────────
 
-/// An agent row from the `Agent` table.
+/// An agent row from the `agent` table.
 #[derive(Debug, FromRow)]
 pub(crate) struct AgentRow {
     pub id: String,
-    #[sqlx(rename = "userId")]
     pub user_id: String,
-    #[sqlx(rename = "secretMode")]
     pub secret_mode: String,
 }
 
-/// A secret row from the `Secret` table.
+/// A secret row from the `secret` table.
 #[derive(Debug, FromRow)]
 pub(crate) struct SecretRow {
     #[sqlx(rename = "type")]
     pub type_: String,
-    #[sqlx(rename = "encryptedValue")]
     pub encrypted_value: String,
-    #[sqlx(rename = "hostPattern")]
     pub host_pattern: String,
-    #[sqlx(rename = "pathPattern")]
     pub path_pattern: Option<String>,
-    #[sqlx(rename = "injectionConfig")]
     pub injection_config: Option<serde_json::Value>,
 }
 
-/// A policy rule row from the `PolicyRule` table.
+/// A policy rule row from the `policy_rule` table.
 #[derive(Debug, FromRow)]
 pub(crate) struct PolicyRuleRow {
-    #[sqlx(rename = "hostPattern")]
     pub host_pattern: String,
-    #[sqlx(rename = "pathPattern")]
     pub path_pattern: Option<String>,
     pub method: Option<String>,
-    #[sqlx(rename = "agentId")]
     pub agent_id: Option<String>,
 }
 
-/// A user row from the `User` table.
+/// A user row from the `user` table.
 #[derive(Debug, FromRow)]
 pub(crate) struct UserRow {
     pub id: String,
 }
 
-/// A vault connection row from the `VaultConnection` table.
+/// A vault connection row from the `vault_connection` table.
 #[derive(Debug, FromRow)]
 #[allow(dead_code)]
 pub(crate) struct VaultConnectionRow {
     pub id: String,
-    #[sqlx(rename = "userId")]
     pub user_id: String,
     pub provider: String,
     pub name: Option<String>,
     pub status: String,
-    #[sqlx(rename = "connectionData")]
     pub connection_data: Option<serde_json::Value>,
 }
 
@@ -83,11 +72,11 @@ pub(crate) async fn find_user_by_external_auth_id(
     pool: &PgPool,
     external_auth_id: &str,
 ) -> Result<Option<UserRow>> {
-    sqlx::query_as::<_, UserRow>(r#"SELECT id FROM "User" WHERE "externalAuthId" = $1 LIMIT 1"#)
+    sqlx::query_as::<_, UserRow>(r#"SELECT id FROM "user" WHERE external_auth_id = $1 LIMIT 1"#)
         .bind(external_auth_id)
         .fetch_optional(pool)
         .await
-        .context("querying User by externalAuthId")
+        .context("querying user by external_auth_id")
 }
 
 /// Look up an agent by its access token.
@@ -96,37 +85,37 @@ pub(crate) async fn find_agent_by_token(
     access_token: &str,
 ) -> Result<Option<AgentRow>> {
     sqlx::query_as::<_, AgentRow>(
-        r#"SELECT id, "userId", "secretMode" FROM "Agent" WHERE "accessToken" = $1 LIMIT 1"#,
+        r#"SELECT id, user_id, secret_mode FROM agent WHERE access_token = $1 LIMIT 1"#,
     )
     .bind(access_token)
     .fetch_optional(pool)
     .await
-    .context("querying Agent by accessToken")
+    .context("querying agent by access_token")
 }
 
 /// Find all secrets for a given user.
 pub(crate) async fn find_secrets_by_user(pool: &PgPool, user_id: &str) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT "type", "encryptedValue", "hostPattern", "pathPattern", "injectionConfig" FROM "Secret" WHERE "userId" = $1"#,
+        r#"SELECT type, encrypted_value, host_pattern, path_pattern, injection_config FROM secret WHERE user_id = $1"#,
     )
     .bind(user_id)
     .fetch_all(pool)
     .await
-    .context("querying Secrets by userId")
+    .context("querying secrets by user_id")
 }
 
 /// Find secrets assigned to a specific agent (selective mode).
 pub(crate) async fn find_secrets_by_agent(pool: &PgPool, agent_id: &str) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT s."type", s."encryptedValue", s."hostPattern", s."pathPattern", s."injectionConfig"
-           FROM "Secret" s
-           INNER JOIN "AgentSecret" as_ ON s.id = as_."secretId"
-           WHERE as_."agentId" = $1"#,
+        r#"SELECT s.type, s.encrypted_value, s.host_pattern, s.path_pattern, s.injection_config
+           FROM secret s
+           INNER JOIN agent_secret as_ ON s.id = as_.secret_id
+           WHERE as_.agent_id = $1"#,
     )
     .bind(agent_id)
     .fetch_all(pool)
     .await
-    .context("querying Secrets by agentId")
+    .context("querying secrets by agent_id")
 }
 
 /// Find all enabled policy rules for a given user.
@@ -135,14 +124,14 @@ pub(crate) async fn find_policy_rules_by_user(
     user_id: &str,
 ) -> Result<Vec<PolicyRuleRow>> {
     sqlx::query_as::<_, PolicyRuleRow>(
-        r#"SELECT "hostPattern", "pathPattern", method, "agentId"
-           FROM "PolicyRule"
-           WHERE "userId" = $1 AND enabled = true AND action = 'block'"#,
+        r#"SELECT host_pattern, path_pattern, method, agent_id
+           FROM policy_rule
+           WHERE user_id = $1 AND enabled = true AND action = 'block'"#,
     )
     .bind(user_id)
     .fetch_all(pool)
     .await
-    .context("querying PolicyRules by userId")
+    .context("querying policy_rules by user_id")
 }
 
 // ── Vault connection queries ────────────────────────────────────────────
@@ -154,16 +143,16 @@ pub(crate) async fn find_vault_connection(
     provider: &str,
 ) -> Result<Option<VaultConnectionRow>> {
     sqlx::query_as::<_, VaultConnectionRow>(
-        r#"SELECT id, "userId", provider, name, status, "connectionData" FROM "VaultConnection" WHERE "userId" = $1 AND provider = $2 LIMIT 1"#,
+        r#"SELECT id, user_id, provider, name, status, connection_data FROM vault_connection WHERE user_id = $1 AND provider = $2 LIMIT 1"#,
     )
     .bind(user_id)
     .bind(provider)
     .fetch_optional(pool)
     .await
-    .context("querying VaultConnection by userId + provider")
+    .context("querying vault_connection by user_id + provider")
 }
 
-/// Upsert a vault connection (insert or update on userId + provider conflict).
+/// Upsert a vault connection (insert or update on user_id + provider conflict).
 pub(crate) async fn upsert_vault_connection(
     pool: &PgPool,
     user_id: &str,
@@ -172,10 +161,10 @@ pub(crate) async fn upsert_vault_connection(
     connection_data: Option<&serde_json::Value>,
 ) -> Result<()> {
     sqlx::query(
-        r#"INSERT INTO "VaultConnection" (id, "userId", provider, status, "connectionData", "createdAt", "updatedAt")
+        r#"INSERT INTO vault_connection (id, user_id, provider, status, connection_data, created_at, updated_at)
            VALUES (gen_random_uuid()::text, $1, $2, $3, $4, NOW(), NOW())
-           ON CONFLICT ("userId", provider)
-           DO UPDATE SET status = $3, "connectionData" = $4, "updatedAt" = NOW()"#,
+           ON CONFLICT (user_id, provider)
+           DO UPDATE SET status = $3, connection_data = $4, updated_at = NOW()"#,
     )
     .bind(user_id)
     .bind(provider)
@@ -183,11 +172,11 @@ pub(crate) async fn upsert_vault_connection(
     .bind(connection_data)
     .execute(pool)
     .await
-    .context("upserting VaultConnection")?;
+    .context("upserting vault_connection")?;
     Ok(())
 }
 
-/// Update only the connectionData JSON for an existing vault connection.
+/// Update only the connection_data JSON for an existing vault connection.
 pub(crate) async fn update_vault_connection_data(
     pool: &PgPool,
     user_id: &str,
@@ -195,14 +184,14 @@ pub(crate) async fn update_vault_connection_data(
     connection_data: &serde_json::Value,
 ) -> Result<()> {
     sqlx::query(
-        r#"UPDATE "VaultConnection" SET "connectionData" = $3, "updatedAt" = NOW() WHERE "userId" = $1 AND provider = $2"#,
+        r#"UPDATE vault_connection SET connection_data = $3, updated_at = NOW() WHERE user_id = $1 AND provider = $2"#,
     )
     .bind(user_id)
     .bind(provider)
     .bind(connection_data)
     .execute(pool)
     .await
-    .context("updating VaultConnection connectionData")?;
+    .context("updating vault_connection connection_data")?;
     Ok(())
 }
 
@@ -212,11 +201,11 @@ pub(crate) async fn delete_vault_connection(
     user_id: &str,
     provider: &str,
 ) -> Result<()> {
-    sqlx::query(r#"DELETE FROM "VaultConnection" WHERE "userId" = $1 AND provider = $2"#)
+    sqlx::query(r#"DELETE FROM vault_connection WHERE user_id = $1 AND provider = $2"#)
         .bind(user_id)
         .bind(provider)
         .execute(pool)
         .await
-        .context("deleting VaultConnection")?;
+        .context("deleting vault_connection")?;
     Ok(())
 }

--- a/packages/db/prisma/migrations/20260321120000_snake_case_columns/migration.sql
+++ b/packages/db/prisma/migrations/20260321120000_snake_case_columns/migration.sql
@@ -1,0 +1,66 @@
+-- Rename tables
+ALTER TABLE "User" RENAME TO "user";
+ALTER TABLE "Agent" RENAME TO "agent";
+ALTER TABLE "Secret" RENAME TO "secret";
+ALTER TABLE "PolicyRule" RENAME TO "policy_rule";
+ALTER TABLE "AgentSecret" RENAME TO "agent_secret";
+ALTER TABLE "ConnectedService" RENAME TO "connected_service";
+ALTER TABLE "AuditLog" RENAME TO "audit_log";
+ALTER TABLE "VaultConnection" RENAME TO "vault_connection";
+
+-- Rename columns: user
+ALTER TABLE "user" RENAME COLUMN "externalAuthId" TO "external_auth_id";
+ALTER TABLE "user" RENAME COLUMN "apiKey" TO "api_key";
+ALTER TABLE "user" RENAME COLUMN "stripeCustomerId" TO "stripe_customer_id";
+ALTER TABLE "user" RENAME COLUMN "subscriptionStatus" TO "subscription_status";
+ALTER TABLE "user" RENAME COLUMN "demoSeeded" TO "demo_seeded";
+ALTER TABLE "user" RENAME COLUMN "createdAt" TO "created_at";
+ALTER TABLE "user" RENAME COLUMN "updatedAt" TO "updated_at";
+
+-- Rename columns: agent
+ALTER TABLE "agent" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "agent" RENAME COLUMN "accessToken" TO "access_token";
+ALTER TABLE "agent" RENAME COLUMN "isDefault" TO "is_default";
+ALTER TABLE "agent" RENAME COLUMN "secretMode" TO "secret_mode";
+ALTER TABLE "agent" RENAME COLUMN "createdAt" TO "created_at";
+ALTER TABLE "agent" RENAME COLUMN "updatedAt" TO "updated_at";
+
+-- Rename columns: secret
+ALTER TABLE "secret" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "secret" RENAME COLUMN "encryptedValue" TO "encrypted_value";
+ALTER TABLE "secret" RENAME COLUMN "hostPattern" TO "host_pattern";
+ALTER TABLE "secret" RENAME COLUMN "pathPattern" TO "path_pattern";
+ALTER TABLE "secret" RENAME COLUMN "injectionConfig" TO "injection_config";
+ALTER TABLE "secret" RENAME COLUMN "createdAt" TO "created_at";
+ALTER TABLE "secret" RENAME COLUMN "updatedAt" TO "updated_at";
+
+-- Rename columns: policy_rule
+ALTER TABLE "policy_rule" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "policy_rule" RENAME COLUMN "hostPattern" TO "host_pattern";
+ALTER TABLE "policy_rule" RENAME COLUMN "pathPattern" TO "path_pattern";
+ALTER TABLE "policy_rule" RENAME COLUMN "agentId" TO "agent_id";
+ALTER TABLE "policy_rule" RENAME COLUMN "createdAt" TO "created_at";
+ALTER TABLE "policy_rule" RENAME COLUMN "updatedAt" TO "updated_at";
+
+-- Rename columns: agent_secret
+ALTER TABLE "agent_secret" RENAME COLUMN "agentId" TO "agent_id";
+ALTER TABLE "agent_secret" RENAME COLUMN "secretId" TO "secret_id";
+
+-- Rename columns: connected_service
+ALTER TABLE "connected_service" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "connected_service" RENAME COLUMN "accessToken" TO "access_token";
+ALTER TABLE "connected_service" RENAME COLUMN "refreshToken" TO "refresh_token";
+ALTER TABLE "connected_service" RENAME COLUMN "tokenExpiry" TO "token_expiry";
+ALTER TABLE "connected_service" RENAME COLUMN "connectedAt" TO "connected_at";
+ALTER TABLE "connected_service" RENAME COLUMN "updatedAt" TO "updated_at";
+
+-- Rename columns: audit_log
+ALTER TABLE "audit_log" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "audit_log" RENAME COLUMN "createdAt" TO "created_at";
+
+-- Rename columns: vault_connection
+ALTER TABLE "vault_connection" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "vault_connection" RENAME COLUMN "connectionData" TO "connection_data";
+ALTER TABLE "vault_connection" RENAME COLUMN "lastConnectedAt" TO "last_connected_at";
+ALTER TABLE "vault_connection" RENAME COLUMN "createdAt" TO "created_at";
+ALTER TABLE "vault_connection" RENAME COLUMN "updatedAt" TO "updated_at";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -8,16 +8,16 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  name      String?
-  externalAuthId String   @unique
-  apiKey             String?  @unique // "oc_..." prefix, used for API auth
-  stripeCustomerId   String?  @unique
-  subscriptionStatus String   @default("free")
-  demoSeeded         Boolean  @default(false)
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  id                 String   @id @default(cuid())
+  email              String   @unique
+  name               String?
+  externalAuthId     String   @unique @map("external_auth_id")
+  apiKey             String?  @unique @map("api_key") // "oc_..." prefix, used for API auth
+  stripeCustomerId   String?  @unique @map("stripe_customer_id")
+  subscriptionStatus String   @default("free") @map("subscription_status")
+  demoSeeded         Boolean  @default(false) @map("demo_seeded")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
 
   agents            Agent[]
   secrets           Secret[]
@@ -25,18 +25,20 @@ model User {
   connectedServices ConnectedService[]
   auditLogs         AuditLog[]
   vaultConnections  VaultConnection[]
+
+  @@map("user")
 }
 
 model Agent {
   id          String   @id @default(cuid())
-  userId      String
+  userId      String   @map("user_id")
   name        String
-  identifier  String?  // user-provided machine-readable ID, unique per user
-  accessToken String   @unique // "aoc_..." prefix, used for gateway auth
-  isDefault   Boolean  @default(false)
-  secretMode  String   @default("all") // "all" or "selective"
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  identifier  String? // user-provided machine-readable ID, unique per user
+  accessToken String   @unique @map("access_token") // "aoc_..." prefix, used for gateway auth
+  isDefault   Boolean  @default(false) @map("is_default")
+  secretMode  String   @default("all") @map("secret_mode") // "all" or "selective"
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
   user        User     @relation(fields: [userId], references: [id])
 
   agentSecrets AgentSecret[]
@@ -44,96 +46,103 @@ model Agent {
 
   @@unique([userId, identifier])
   @@index([userId])
+  @@map("agent")
 }
 
 model Secret {
   id              String   @id @default(cuid())
-  userId          String
+  userId          String   @map("user_id")
   name            String
   type            String // "anthropic", "generic"
-  encryptedValue  String // AES-256-GCM encrypted via CryptoService
-  hostPattern     String // "api.anthropic.com" or "*.example.com"
-  pathPattern     String? // "/v1/*", null = all paths
-  injectionConfig Json? // type-specific config (generic: { headerName, valueFormat })
+  encryptedValue  String   @map("encrypted_value") // AES-256-GCM encrypted via CryptoService
+  hostPattern     String   @map("host_pattern") // "api.anthropic.com" or "*.example.com"
+  pathPattern     String?  @map("path_pattern") // "/v1/*", null = all paths
+  injectionConfig Json?    @map("injection_config") // type-specific config (generic: { headerName, valueFormat })
   metadata        Json? // type-specific metadata (anthropic: { authMode: "api-key" | "oauth" })
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
   user            User     @relation(fields: [userId], references: [id])
 
   agentSecrets AgentSecret[]
 
   @@index([userId])
+  @@map("secret")
 }
 
 model PolicyRule {
   id          String   @id @default(cuid())
-  userId      String
+  userId      String   @map("user_id")
   name        String
-  hostPattern String   // "gmail.googleapis.com" or "*.googleapis.com"
-  pathPattern String?  // "/gmail/v1/users/me/messages/send" or "/gmail/*"
-  method      String?  // "POST", null = all methods
-  action      String   // "block"
+  hostPattern String   @map("host_pattern") // "gmail.googleapis.com" or "*.googleapis.com"
+  pathPattern String?  @map("path_pattern") // "/gmail/v1/users/me/messages/send" or "/gmail/*"
+  method      String? // "POST", null = all methods
+  action      String // "block"
   enabled     Boolean
-  agentId     String?  // null = all agents, set = one agent only
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  agentId     String?  @map("agent_id") // null = all agents, set = one agent only
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
   user        User     @relation(fields: [userId], references: [id])
   agent       Agent?   @relation(fields: [agentId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+  @@map("policy_rule")
 }
 
 model AgentSecret {
-  agentId  String
-  secretId String
+  agentId  String @map("agent_id")
+  secretId String @map("secret_id")
   agent    Agent  @relation(fields: [agentId], references: [id], onDelete: Cascade)
   secret   Secret @relation(fields: [secretId], references: [id], onDelete: Cascade)
 
   @@id([agentId, secretId])
+  @@map("agent_secret")
 }
 
 model ConnectedService {
   id           String    @id @default(cuid())
-  userId       String
+  userId       String    @map("user_id")
   provider     String
   status       String    @default("connected")
-  accessToken  String?
-  refreshToken String?
-  tokenExpiry  DateTime?
+  accessToken  String?   @map("access_token")
+  refreshToken String?   @map("refresh_token")
+  tokenExpiry  DateTime? @map("token_expiry")
   scopes       String[]  @default([])
   metadata     Json?
-  connectedAt  DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  connectedAt  DateTime  @default(now()) @map("connected_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
   user         User      @relation(fields: [userId], references: [id])
 
   @@unique([userId, provider])
+  @@map("connected_service")
 }
 
 model AuditLog {
   id        String   @id @default(cuid())
-  userId    String
+  userId    String   @map("user_id")
   action    String
   service   String
   status    String
   source    String   @default("app")
   metadata  Json?
-  createdAt DateTime @default(now())
+  createdAt DateTime @default(now()) @map("created_at")
   user      User     @relation(fields: [userId], references: [id])
 
   @@index([userId, createdAt])
+  @@map("audit_log")
 }
 
 model VaultConnection {
   id              String    @id @default(cuid())
-  userId          String
+  userId          String    @map("user_id")
   provider        String
   name            String?
   status          String
-  connectionData  Json?
-  lastConnectedAt DateTime?
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
+  connectionData  Json?     @map("connection_data")
+  lastConnectedAt DateTime? @map("last_connected_at")
+  createdAt       DateTime  @default(now()) @map("created_at")
+  updatedAt       DateTime  @updatedAt @map("updated_at")
   user            User      @relation(fields: [userId], references: [id])
 
   @@unique([userId, provider])
+  @@map("vault_connection")
 }


### PR DESCRIPTION
## Summary

Rename all PostgreSQL tables and columns from camelCase to snake_case, following PostgreSQL naming conventions.

### Schema
- Added `@map("snake_case")` to all camelCase fields
- Added `@@map("snake_table")` to all models
- Prisma client code continues using camelCase in TypeScript — the mapping is transparent

### Migration
- `ALTER TABLE RENAME` for all 8 tables
- `ALTER TABLE RENAME COLUMN` for all camelCase columns
- Non-destructive, data-preserving renames

### Gateway
- Updated all raw SQL queries in `db.rs` to use new snake_case names
- Removed `#[sqlx(rename = "...")]` annotations where Rust field names now match DB columns
- Kept `#[sqlx(rename = "type")]` for the `type_` field (Rust keyword)

### Tables renamed
`User` → `user`, `Agent` → `agent`, `Secret` → `secret`, `PolicyRule` → `policy_rule`, `AgentSecret` → `agent_secret`, `ConnectedService` → `connected_service`, `AuditLog` → `audit_log`, `VaultConnection` → `vault_connection`