### PR TITLE
fix: button loading states and dynamic gateway URL

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/nav-user.tsx
+++ b/apps/web/src/app/(dashboard)/_components/nav-user.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ChevronsUpDown, LogOut } from "lucide-react";
+import { useState } from "react";
+import { ChevronsUpDown, Loader2, LogOut } from "lucide-react";
 
 import { useAuth } from "@/providers/auth-provider";
 import { Avatar, AvatarFallback } from "@onecli/ui/components/avatar";
@@ -22,6 +23,7 @@ import {
 export const NavUser = () => {
   const { isMobile } = useSidebar();
   const { user, signOut } = useAuth();
+  const [signingOut, setSigningOut] = useState(false);
 
   const displayName = user?.name ?? user?.email ?? "User";
   const initials = displayName
@@ -67,9 +69,15 @@ export const NavUser = () => {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => signOut()}>
-              <LogOut />
-              Sign out
+            <DropdownMenuItem
+              disabled={signingOut}
+              onClick={async () => {
+                setSigningOut(true);
+                await signOut();
+              }}
+            >
+              {signingOut ? <Loader2 className="animate-spin" /> : <LogOut />}
+              {signingOut ? "Signing out..." : "Sign out"}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
@@ -20,19 +20,22 @@ interface TryDemoDialogProps {
 }
 
 export const TryDemoDialog = ({ open, onOpenChange }: TryDemoDialogProps) => {
-  const [agentToken, setAgentToken] = useState<string | null>(null);
+  const [demoInfo, setDemoInfo] = useState<{
+    agentToken: string;
+    gatewayUrl: string;
+  } | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!open) return;
     setLoading(true);
     getDemoInfo()
-      .then((info) => setAgentToken(info?.agentToken ?? null))
+      .then((info) => setDemoInfo(info))
       .finally(() => setLoading(false));
   }, [open]);
 
-  const command = agentToken
-    ? `curl -k -x http://x:${agentToken}@localhost:10255 -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`
+  const command = demoInfo
+    ? `curl -k -x http://x:${demoInfo.agentToken}@${demoInfo.gatewayUrl} -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`
     : "";
 
   return (

--- a/apps/web/src/app/auth/login/_components/login-content.tsx
+++ b/apps/web/src/app/auth/login/_components/login-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Button } from "@onecli/ui/components/button";
@@ -9,6 +9,7 @@ import { useAuth } from "@/providers/auth-provider";
 export const LoginContent = () => {
   const router = useRouter();
   const { isAuthenticated, isLoading, user, signIn, signOut } = useAuth();
+  const [signingIn, setSigningIn] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated || !user) return;
@@ -77,10 +78,14 @@ export const LoginContent = () => {
               size="lg"
               variant="outline"
               className="w-full gap-2 text-base bg-white text-black hover:bg-gray-100 dark:bg-white dark:text-black dark:hover:bg-gray-100"
-              onClick={() => signIn()}
+              loading={signingIn}
+              onClick={() => {
+                setSigningIn(true);
+                signIn();
+              }}
             >
               <GoogleIcon />
-              Continue with Google
+              {signingIn ? "Redirecting..." : "Continue with Google"}
             </Button>
             <p className="text-muted-foreground mt-4 text-center text-xs whitespace-nowrap">
               By continuing, you acknowledge OneCLI&apos;s{" "}

--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -43,7 +43,13 @@ export const getDemoInfo = async () => {
 
   if (!demoSecret || !agent) return null;
 
-  return { agentToken: agent.accessToken };
+  const gatewayHost = process.env.GATEWAY_HOST ?? "localhost";
+  const gatewayPort = process.env.GATEWAY_PORT ?? "10255";
+
+  return {
+    agentToken: agent.accessToken,
+    gatewayUrl: `${gatewayHost}:${gatewayPort}`,
+  };
 };
 
 export const updateSecret = async (


### PR DESCRIPTION
## Summary

### Loading states
- **Login page**: "Continue with Google" button shows spinner + "Redirecting..." while OAuth redirect is pending, disabled to prevent double-clicks
- **Sign out**: Shows spinner + "Signing out..." in the dropdown menu during sign-out

### Dynamic gateway URL
- `getDemoInfo()` now returns `gatewayUrl` built from `GATEWAY_HOST` and `GATEWAY_PORT` env vars
- Try Demo dialog uses the dynamic URL instead of hardcoded `localhost:10255`