### PR TITLE
fix: redesign rule dialog with two-step flow and brand colors

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/try-demo-command.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-command.tsx
@@ -19,9 +19,7 @@ export const TryDemoCommand = ({ command, highlight }: TryDemoCommandProps) => {
     return (
       <>
         {command.slice(0, idx)}
-        <span className="text-green-600 font-semibold dark:text-green-400">
-          {highlight}
-        </span>
+        <span className="text-brand font-semibold">{highlight}</span>
         {command.slice(idx + highlight.length)}
       </>
     );
@@ -39,7 +37,7 @@ export const TryDemoCommand = ({ command, highlight }: TryDemoCommandProps) => {
         onClick={() => copy(command)}
       >
         {copied ? (
-          <Check className="size-4 text-green-500" />
+          <Check className="size-4 text-brand" />
         ) : (
           <Copy className="size-4" />
         )}

--- a/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/try-demo-dialog.tsx
@@ -77,7 +77,7 @@ export const TryDemoDialog = ({ open, onOpenChange }: TryDemoDialogProps) => {
                   {'"Authorization": "Bearer FAKE_TOKEN"'}
                 </span>
                 {"\n    "}
-                <span className="text-green-600 dark:text-green-400 font-semibold">
+                <span className="text-brand font-semibold">
                   {
                     '"Authorization": "Bearer WELCOME-TO-ONECLI-SECRETS-ARE-WORKING"'
                   }

--- a/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
@@ -92,8 +92,8 @@ export const CreateAgentDialog = ({
         {createdIdentifier ? (
           <>
             <div className="flex flex-col items-center pt-2 text-center">
-              <div className="bg-emerald-500/10 mb-3 flex size-10 items-center justify-center rounded-full">
-                <CircleCheck className="size-5 text-emerald-500" />
+              <div className="bg-brand/10 mb-3 flex size-10 items-center justify-center rounded-full">
+                <CircleCheck className="size-5 text-brand" />
               </div>
               <DialogHeader className="items-center">
                 <DialogTitle>Agent created</DialogTitle>
@@ -114,7 +114,7 @@ export const CreateAgentDialog = ({
                   onClick={() => copy(createdIdentifier)}
                 >
                   {copied ? (
-                    <Check className="size-3.5 text-emerald-500" />
+                    <Check className="size-3.5 text-brand" />
                   ) : (
                     <Copy className="size-3.5" />
                   )}

--- a/apps/web/src/app/(dashboard)/overview/_components/api-key-card.tsx
+++ b/apps/web/src/app/(dashboard)/overview/_components/api-key-card.tsx
@@ -100,7 +100,7 @@ export const ApiKeyCard = () => {
             disabled={loading || !apiKey}
           >
             {copied ? (
-              <Check className="size-4 text-green-500" />
+              <Check className="size-4 text-brand" />
             ) : (
               <Copy className="size-4" />
             )}

--- a/apps/web/src/app/(dashboard)/rules/_components/rule-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/rule-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
-import { ShieldBan, Settings2, Gauge } from "lucide-react";
+import { ShieldBan, Gauge, Check, Settings2 } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -40,6 +40,21 @@ const METHOD_OPTIONS = [
   { value: "DELETE", label: "DELETE" },
 ] as const;
 
+const STEPS = [
+  {
+    id: "endpoint",
+    label: "Endpoint",
+    description: "Choose which requests this rule applies to.",
+  },
+  {
+    id: "action",
+    label: "Action",
+    description: "Decide what happens when a request matches.",
+  },
+] as const;
+
+type Step = (typeof STEPS)[number]["id"];
+
 interface RuleDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -58,6 +73,7 @@ export const RuleDialog = ({
 }: RuleDialogProps) => {
   const isEdit = !!rule;
   const [saving, setSaving] = useState(false);
+  const [step, setStep] = useState<Step>("endpoint");
   const [name, setName] = useState("");
   const [hostPattern, setHostPattern] = useState("");
   const [pathPattern, setPathPattern] = useState("");
@@ -73,6 +89,7 @@ export const RuleDialog = ({
   // Reset form when dialog opens or rule changes
   useEffect(() => {
     if (open) {
+      setStep("endpoint");
       setName(rule?.name ?? "");
       setHostPattern(rule?.hostPattern ?? "");
       setPathPattern(rule?.pathPattern ?? "");
@@ -87,10 +104,10 @@ export const RuleDialog = ({
     }
   }, [open, rule]);
 
-  const isValid =
-    name.trim() &&
-    hostPattern.trim() &&
-    (action !== "rate_limit" || (rateLimit > 0 && rateLimitWindow));
+  const isEndpointValid = !!(name.trim() && hostPattern.trim());
+  const isActionValid =
+    action !== "rate_limit" || (rateLimit > 0 && rateLimitWindow);
+  const isValid = isEndpointValid && isActionValid;
 
   const hasChanges = isEdit
     ? name.trim() !== rule.name ||
@@ -151,148 +168,201 @@ export const RuleDialog = ({
     onOpenChange(value);
   };
 
+  const currentStep = STEPS.find((s) => s.id === step)!;
+
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit rule" : "New rule"}</DialogTitle>
-          <DialogDescription>
-            {isEdit
-              ? "Update the conditions for this policy rule."
-              : "Control what your agents can do with specific endpoints."}
-          </DialogDescription>
+          <DialogDescription>{currentStep.description}</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
-          <div className="space-y-2">
-            <Label htmlFor="rule-name">Name</Label>
-            <Input
-              id="rule-name"
-              placeholder="e.g. Limit Anthropic calls"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              autoFocus
-            />
-          </div>
+        {/* ── Stepper ──────────────────────────────────────────── */}
+        <div className="flex items-center">
+          {STEPS.map((s, i) => {
+            const isCurrent = step === s.id;
+            const isCompleted =
+              s.id === "endpoint" && step === "action" && isEndpointValid;
+            const isClickable =
+              s.id === "endpoint" || (s.id === "action" && isEndpointValid);
 
-          <div className="grid grid-cols-2 gap-4">
+            return (
+              <div key={s.id} className="flex items-center">
+                {i > 0 && (
+                  <div
+                    className={`mx-3 h-px w-10 ${isCompleted || isCurrent ? "bg-brand/30" : "bg-border"}`}
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={() => isClickable && setStep(s.id)}
+                  disabled={!isClickable}
+                  className="flex items-center gap-2.5 disabled:cursor-default"
+                >
+                  <span
+                    className={`flex size-7 items-center justify-center rounded-full text-xs font-medium transition-colors ${
+                      isCurrent
+                        ? "bg-brand text-brand-foreground"
+                        : isCompleted
+                          ? "bg-brand/15 text-brand"
+                          : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {isCompleted ? <Check className="size-3.5" /> : i + 1}
+                  </span>
+                  <span
+                    className={`text-sm ${
+                      isCurrent
+                        ? "text-foreground font-medium"
+                        : isCompleted
+                          ? "text-foreground"
+                          : "text-muted-foreground"
+                    }`}
+                  >
+                    {s.label}
+                  </span>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* ── Step 1: Endpoint ─────────────────────────────────── */}
+        {step === "endpoint" && (
+          <div className="space-y-4 pt-1">
             <div className="space-y-2">
-              <Label htmlFor="rule-host">Host pattern</Label>
+              <Label htmlFor="rule-name">Name</Label>
               <Input
-                id="rule-host"
-                placeholder="e.g. api.anthropic.com"
-                value={hostPattern}
-                onChange={(e) => setHostPattern(e.target.value)}
+                id="rule-name"
+                placeholder="e.g. Limit Anthropic calls"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoFocus
               />
-              <p className="text-muted-foreground text-xs">
-                Use <code className="text-xs">*.example.com</code> for wildcard
-                subdomains.
-              </p>
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="rule-path">
-                Path pattern{" "}
-                <span className="text-muted-foreground font-normal">
-                  (optional)
-                </span>
-              </Label>
-              <Input
-                id="rule-path"
-                placeholder="e.g. /v1/messages"
-                value={pathPattern}
-                onChange={(e) => setPathPattern(e.target.value)}
-              />
-              <p className="text-muted-foreground text-xs">
-                Use <code className="text-xs">/path/*</code> for prefix
-                matching.
-              </p>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="rule-host">Host pattern</Label>
+                <Input
+                  id="rule-host"
+                  placeholder="e.g. api.anthropic.com"
+                  value={hostPattern}
+                  onChange={(e) => setHostPattern(e.target.value)}
+                />
+                <p className="text-muted-foreground text-xs">
+                  Use <code className="text-xs">*.example.com</code> for
+                  wildcard subdomains.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="rule-path">
+                  Path pattern{" "}
+                  <span className="text-muted-foreground font-normal">
+                    (optional)
+                  </span>
+                </Label>
+                <Input
+                  id="rule-path"
+                  placeholder="e.g. /v1/messages"
+                  value={pathPattern}
+                  onChange={(e) => setPathPattern(e.target.value)}
+                />
+                <p className="text-muted-foreground text-xs">
+                  Use <code className="text-xs">/path/*</code> for prefix
+                  matching.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Method</Label>
+                <Select
+                  value={method || "_all"}
+                  onValueChange={(v) => setMethod(v === "_all" ? "" : v)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {METHOD_OPTIONS.map((opt) => (
+                      <SelectItem
+                        key={opt.value || "_all"}
+                        value={opt.value || "_all"}
+                      >
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Scope</Label>
+                <Select
+                  value={agentId || "_all"}
+                  onValueChange={(v) => setAgentId(v === "_all" ? "" : v)}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_all">All agents</SelectItem>
+                    {agents.map((agent) => (
+                      <SelectItem key={agent.id} value={agent.id}>
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
           </div>
+        )}
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>Method</Label>
-              <Select
-                value={method || "_all"}
-                onValueChange={(v) => setMethod(v === "_all" ? "" : v)}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {METHOD_OPTIONS.map((opt) => (
-                    <SelectItem
-                      key={opt.value || "_all"}
-                      value={opt.value || "_all"}
-                    >
-                      {opt.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label>Scope</Label>
-              <Select
-                value={agentId || "_all"}
-                onValueChange={(v) => setAgentId(v === "_all" ? "" : v)}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_all">All agents</SelectItem>
-                  {agents.map((agent) => (
-                    <SelectItem key={agent.id} value={agent.id}>
-                      {agent.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Action</Label>
+        {/* ── Step 2: Action ───────────────────────────────────── */}
+        {step === "action" && (
+          <div className="space-y-4 pt-1">
             <div className="grid grid-cols-2 gap-2">
               <button
                 type="button"
                 onClick={() => setAction("block")}
-                className={`flex flex-col gap-1 rounded-md border p-2.5 text-left transition-colors ${
+                className={`flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors ${
                   action === "block"
-                    ? "border-primary bg-primary/5"
+                    ? "border-brand bg-brand/5"
                     : "hover:bg-muted/50"
                 }`}
               >
-                <span className="flex items-center gap-2 text-xs font-medium">
+                <span className="flex items-center gap-2 text-sm font-medium">
                   <ShieldBan
-                    className={`size-3.5 ${action === "block" ? "text-primary" : ""}`}
+                    className={`size-4 ${action === "block" ? "text-brand" : ""}`}
                   />
                   Block
                 </span>
-                <span className="text-muted-foreground text-[10px] leading-tight">
-                  Deny the request
+                <span className="text-muted-foreground text-xs">
+                  Deny the request entirely
                 </span>
               </button>
               <button
                 type="button"
                 onClick={() => setAction("rate_limit")}
-                className={`flex flex-col gap-1 rounded-md border p-2.5 text-left transition-colors ${
+                className={`flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors ${
                   action === "rate_limit"
-                    ? "border-primary bg-primary/5"
+                    ? "border-brand bg-brand/5"
                     : "hover:bg-muted/50"
                 }`}
               >
-                <span className="flex items-center gap-2 text-xs font-medium">
+                <span className="flex items-center gap-2 text-sm font-medium">
                   <Gauge
-                    className={`size-3.5 ${action === "rate_limit" ? "text-primary" : ""}`}
+                    className={`size-4 ${action === "rate_limit" ? "text-brand" : ""}`}
                   />
                   Rate Limit
                 </span>
-                <span className="text-muted-foreground text-[10px] leading-tight">
-                  Allow up to N, then block
+                <span className="text-muted-foreground text-xs">
+                  Allow up to N requests, then block
                 </span>
               </button>
             </div>
@@ -338,56 +408,73 @@ export const RuleDialog = ({
                 </p>
               </div>
             )}
+
+            <Accordion type="single" collapsible className="border-none">
+              <AccordionItem value="advanced" className="border-t border-b-0">
+                <AccordionTrigger className="py-3 hover:no-underline">
+                  <span className="text-muted-foreground flex items-center gap-2 text-xs font-normal">
+                    <Settings2 className="size-3.5" />
+                    Advanced settings
+                  </span>
+                </AccordionTrigger>
+                <AccordionContent className="pb-0">
+                  {!isEdit && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="rule-enabled"
+                        checked={enabled}
+                        onCheckedChange={(checked) =>
+                          setEnabled(checked === true)
+                        }
+                      />
+                      <Label
+                        htmlFor="rule-enabled"
+                        className="text-sm font-normal"
+                      >
+                        Enable rule immediately
+                      </Label>
+                    </div>
+                  )}
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           </div>
+        )}
 
-          <Accordion type="single" collapsible className="border-none">
-            <AccordionItem value="advanced" className="border-t border-b-0">
-              <AccordionTrigger className="py-3 hover:no-underline">
-                <span className="text-muted-foreground flex items-center gap-2 text-xs font-normal">
-                  <Settings2 className="size-3.5" />
-                  Advanced settings
-                </span>
-              </AccordionTrigger>
-              <AccordionContent className="pb-0">
-                {!isEdit && (
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="rule-enabled"
-                      checked={enabled}
-                      onCheckedChange={(checked) =>
-                        setEnabled(checked === true)
-                      }
-                    />
-                    <Label
-                      htmlFor="rule-enabled"
-                      className="text-sm font-normal"
-                    >
-                      Enable rule immediately
-                    </Label>
-                  </div>
-                )}
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-
+        {/* ── Footer ───────────────────────────────────────────── */}
         <DialogFooter>
-          <Button variant="ghost" onClick={() => handleClose(false)}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSave}
-            loading={saving}
-            disabled={!isValid || (isEdit && !hasChanges)}
-          >
-            {saving
-              ? isEdit
-                ? "Saving..."
-                : "Creating..."
-              : isEdit
-                ? "Save Changes"
-                : "Create Rule"}
-          </Button>
+          {step === "endpoint" ? (
+            <>
+              <Button variant="ghost" onClick={() => handleClose(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() => setStep("action")}
+                disabled={!isEndpointValid}
+              >
+                Continue
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="ghost" onClick={() => setStep("endpoint")}>
+                Back
+              </Button>
+              <Button
+                onClick={handleSave}
+                loading={saving}
+                disabled={!isValid || (isEdit && !hasChanges)}
+              >
+                {saving
+                  ? isEdit
+                    ? "Saving..."
+                    : "Creating..."
+                  : isEdit
+                    ? "Save Changes"
+                    : "Create Rule"}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/app/(dashboard)/secrets/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/secret-dialog.tsx
@@ -443,7 +443,7 @@ const AnthropicKeyBadge = ({ value }: { value: string }) => {
       <span
         className={
           detected === "api_key"
-            ? "bg-emerald-500 size-1.5 rounded-full"
+            ? "bg-brand size-1.5 rounded-full"
             : "bg-blue-500 size-1.5 rounded-full"
         }
       />

--- a/apps/web/src/app/(dashboard)/secrets/_components/vault-access-card.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/vault-access-card.tsx
@@ -55,8 +55,8 @@ const statusBadge = (
   }
   return {
     className:
-      "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
-    dotClassName: "bg-green-500",
+      "border-brand/20 bg-brand/5 text-brand dark:border-brand/30 dark:bg-brand/10 dark:text-brand",
+    dotClassName: "bg-brand",
     label: isReady ? "Connected" : "Paired",
   };
 };


### PR DESCRIPTION
## Summary

- **Rule dialog two-step flow** — split into "Endpoint" (name, host, path, method, scope) and "Action" (block/rate limit config). Stepper with numbered circles, completion checkmarks, and clickable navigation between steps.
- **Brand color unification** — replaced all `green-500`, `emerald-500`, `green-600/400` variants with the OneCLI brand color (`--brand: #19BA5D`) across the dashboard:
  - Copy-to-clipboard checkmarks (api-key-card, try-demo-command)
  - Success badges (create-agent-dialog)
  - Code syntax highlights (try-demo-command, try-demo-dialog)
  - Vault connection status (vault-access-card)
  - API key type detection dot (secret-dialog)
  - Rule dialog stepper and action selection
- **CI** — added `prisma format --check` to `format:check` script

## Test plan

- [ ] Open rule dialog — verify two-step flow with stepper
- [ ] Click between steps — verify navigation works
- [ ] Edit existing rule — verify all fields pre-filled, steps clickable
- [ ] Check brand green appears consistently across dashboard pages