### PR TITLE
fix: restructure settings with sub-navigation and reorder main nav

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -17,6 +17,7 @@ const nextConfig = {
           "@/lib/nav-items": "@/cloud/nav-items",
           "@/lib/crypto": "@/cloud/kms-crypto",
           "@/lib/gateway-auth": "@/cloud/gateway-auth",
+          "@/lib/settings-nav-items": "@/cloud/settings-nav-items",
         }
       : {},
   },

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useEffect, useState, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { ScrollArea } from "@onecli/ui/components/scroll-area";
 import { SidebarInset, SidebarProvider } from "@onecli/ui/components/sidebar";
 import { DashboardSidebar } from "@dashboard/dashboard-sidebar";
 import { DashboardHeader } from "@dashboard/dashboard-header";
+import { SettingsNav } from "@/app/(dashboard)/settings/_components/settings-nav";
 import { useAuth } from "@/providers/auth-provider";
 
 export default function DashboardLayout({
@@ -15,9 +16,12 @@ export default function DashboardLayout({
 }) {
   const { isAuthenticated, isLoading, signOut } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
   const [ready, setReady] = useState(false);
   const signOutRef = useRef(signOut);
   signOutRef.current = signOut;
+
+  const isSettings = pathname.startsWith("/settings");
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -66,9 +70,16 @@ export default function DashboardLayout({
         <header className="flex h-12 shrink-0 items-center border-b">
           <DashboardHeader />
         </header>
-        <ScrollArea className="h-full min-h-0 flex-1">
-          <main className="p-6">{children}</main>
-        </ScrollArea>
+        <div className="flex min-h-0 flex-1">
+          {isSettings && (
+            <aside className="hidden w-56 shrink-0 overflow-y-auto border-r px-6 pt-6 md:block">
+              <SettingsNav />
+            </aside>
+          )}
+          <ScrollArea className="h-full min-h-0 flex-1">
+            <main className="p-6">{children}</main>
+          </ScrollArea>
+        </div>
       </SidebarInset>
     </SidebarProvider>
   );

--- a/apps/web/src/app/(dashboard)/settings/_components/settings-nav.tsx
+++ b/apps/web/src/app/(dashboard)/settings/_components/settings-nav.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@onecli/ui/lib/utils";
+import { settingsSections } from "@/lib/settings-nav-items";
+
+export const SettingsNav = () => {
+  const pathname = usePathname();
+
+  return (
+    <nav className="space-y-5">
+      {settingsSections.map((section) => (
+        <div key={section.label} className="space-y-1">
+          <p className="text-muted-foreground px-2 pb-1 text-xs font-medium">
+            {section.label}
+          </p>
+          <ul className="space-y-0.5">
+            {section.items.map((item) => {
+              const isActive = pathname === item.url;
+              return (
+                <li key={item.url}>
+                  <Link
+                    href={item.url}
+                    className={cn(
+                      "flex h-8 items-center gap-2 rounded-md px-2 text-sm transition-colors",
+                      isActive
+                        ? "bg-brand/10 font-medium text-brand hover:bg-brand/15"
+                        : "text-foreground hover:bg-accent hover:text-accent-foreground",
+                    )}
+                  >
+                    <item.icon className="size-4 shrink-0" />
+                    <span className="truncate">{item.title}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+};

--- a/apps/web/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { PageHeader } from "@dashboard/page-header";
+import { ApiKeyCard } from "@/app/(dashboard)/overview/_components/api-key-card";
+
+export const metadata: Metadata = {
+  title: "API Keys",
+};
+
+export default function ApiKeysPage() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+      <PageHeader
+        title="API Keys"
+        description="Manage your API keys for OneCLI services."
+      />
+      <ApiKeyCard />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/settings/encryption/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/encryption/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { PageHeader } from "@dashboard/page-header";
+import { KeyManagementCard } from "@/app/(dashboard)/settings/profile/_components/key-management-card";
+
+export const metadata: Metadata = {
+  title: "Encryption",
+};
+
+export default function EncryptionPage() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+      <PageHeader
+        title="Encryption"
+        description="Configure how your secrets are encrypted."
+      />
+      <KeyManagementCard />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/settings/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/profile/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { PageHeader } from "@dashboard/page-header";
 import { ProfileForm } from "./_components/profile-form";
-import { KeyManagementCard } from "./_components/key-management-card";
 
 export const metadata: Metadata = {
   title: "Profile",
@@ -9,15 +8,12 @@ export const metadata: Metadata = {
 
 export default function ProfilePage() {
   return (
-    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
-      <div className="flex flex-col gap-4">
-        <PageHeader title="Profile" />
-        <ProfileForm />
-      </div>
-      <div className="flex flex-col gap-4">
-        <PageHeader title="Encryption" />
-        <KeyManagementCard />
-      </div>
+    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+      <PageHeader
+        title="Profile"
+        description="Manage your personal information."
+      />
+      <ProfileForm />
     </div>
   );
 }

--- a/apps/web/src/lib/nav-items.ts
+++ b/apps/web/src/lib/nav-items.ts
@@ -1,10 +1,10 @@
-import { LayoutDashboard, Bot, KeyRound, Shield, Settings } from "lucide-react";
+import { LayoutDashboard, Bot, Shield, KeyRound, Settings } from "lucide-react";
 import type { NavItem } from "@/app/(dashboard)/_components/nav-main";
 
 export const navItems: NavItem[] = [
   { title: "Overview", url: "/overview", icon: LayoutDashboard },
   { title: "Agents", url: "/agents", icon: Bot },
-  { title: "Secrets", url: "/secrets", icon: KeyRound },
   { title: "Rules", url: "/rules", icon: Shield },
+  { title: "Secrets", url: "/secrets", icon: KeyRound },
   { title: "Settings", url: "/settings", icon: Settings },
 ];

--- a/apps/web/src/lib/settings-nav-items.ts
+++ b/apps/web/src/lib/settings-nav-items.ts
@@ -1,0 +1,28 @@
+import { User, KeyRound, ShieldCheck } from "lucide-react";
+
+export interface SettingsNavItem {
+  title: string;
+  url: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+export interface SettingsNavSection {
+  label: string;
+  items: SettingsNavItem[];
+}
+
+export const settingsSections: SettingsNavSection[] = [
+  {
+    label: "Account",
+    items: [
+      { title: "Profile", url: "/settings/profile", icon: User },
+      { title: "API Keys", url: "/settings/api-keys", icon: KeyRound },
+    ],
+  },
+  {
+    label: "Security",
+    items: [
+      { title: "Encryption", url: "/settings/encryption", icon: ShieldCheck },
+    ],
+  },
+];

--- a/turbo.json
+++ b/turbo.json
@@ -51,7 +51,8 @@
         "REDIS_HOST",
         "REDIS_PORT",
         "REDIS_PASSWORD",
-        "REDIS_TLS"
+        "REDIS_TLS",
+        "COGNITO_USER_POOL_ID"
       ]
     },
     "@onecli/gateway#check": {


### PR DESCRIPTION
## Summary

- **Settings sub-navigation** — full-height aside panel with grouped nav items (Account: Profile, API Keys / Security: Encryption). Rendered outside ScrollArea for proper border alignment.
- **Settings pages restructured** — Encryption split into its own page, API Keys added as a dedicated settings page.
- **Main nav reordered** — Overview, Agents, Rules, Secrets, Settings
- **Config** — added gateway `COGNITO_USER_POOL_ID` to turbo passThroughEnv, prisma format check in CI, redis convenience scripts

## Test plan

- [ ] Navigate to Settings — verify sub-nav appears with full-height border
- [ ] Click each settings sub-page (Profile, API Keys, Encryption) — verify content loads
- [ ] Check main sidebar order matches: Overview, Agents, Rules, Secrets, Settings
- [ ] Verify non-settings pages (Agents, Rules, etc.) don't show the settings aside