### PR TITLE
fix: auto-create default agent on first container-config call

### DIFF
--- a/apps/web/src/app/api/container-config/route.ts
+++ b/apps/web/src/app/api/container-config/route.ts
@@ -4,6 +4,8 @@ import { resolveApiAuth } from "@/lib/api-auth";
 import { unauthorized } from "@/lib/api-utils";
 import { loadCaCertificate } from "@/lib/gateway-ca";
 import { parseAnthropicMetadata } from "@/lib/validations/secret";
+import { DEFAULT_AGENT_NAME } from "@/lib/constants";
+import { generateAccessToken } from "@/lib/services/agent-service";
 import { logger } from "@/lib/logger";
 
 const GATEWAY_PORT = process.env.GATEWAY_PORT ?? "10255";
@@ -33,10 +35,12 @@ export async function GET(request: NextRequest) {
     const auth = await resolveApiAuth(request);
     if (!auth) return unauthorized();
 
-    // Look up agent: by identifier if provided, otherwise default
+    // Look up agent: by identifier if provided, otherwise default.
+    // Auto-creates the default agent on first call so `docker run` works
+    // without needing to open the dashboard first.
     const agentIdentifier = request.nextUrl.searchParams.get("agent");
 
-    const agent = agentIdentifier
+    let agent = agentIdentifier
       ? await db.agent.findFirst({
           where: { userId: auth.userId, identifier: agentIdentifier },
           select: { id: true, accessToken: true, secretMode: true },
@@ -46,15 +50,23 @@ export async function GET(request: NextRequest) {
           select: { id: true, accessToken: true, secretMode: true },
         });
 
-    if (!agent) {
+    if (!agent && agentIdentifier) {
       return NextResponse.json(
-        {
-          error: agentIdentifier
-            ? "Agent with the given identifier not found."
-            : "No default agent found. Please create one first.",
-        },
+        { error: "Agent with the given identifier not found." },
         { status: 404 },
       );
+    }
+
+    if (!agent) {
+      agent = await db.agent.create({
+        data: {
+          name: DEFAULT_AGENT_NAME,
+          accessToken: generateAccessToken(),
+          isDefault: true,
+          userId: auth.userId,
+        },
+        select: { id: true, accessToken: true, secretMode: true },
+      });
     }
 
     const gatewayHost = getGatewayHost();


### PR DESCRIPTION
## Summary

When `GET /api/container-config` is called with valid auth and no default agent exists for the user, auto-create one instead of returning 404.

This allows `docker run` workflows to work without opening the dashboard first — the SDK's first call to `/api/container-config` bootstraps the default agent automatically.

Only applies to the default agent path. Explicit agent lookups (`?agent=xyz`) still return 404 if not found.

## Test plan

- [ ] Call `/api/container-config` with API key before any agent exists → agent created, config returned
- [ ] Call again → same agent returned (idempotent)
- [ ] Call with `?agent=nonexistent` → still returns 404