### PR TITLE
refactor: switch IDs to UUID and denormalize user emails

### DIFF
--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -61,12 +61,21 @@ export const GET = async () => {
 
     if (!membership) {
       const account = await db.account.create({
-        data: { name: user.name },
+        data: {
+          name: user.name,
+          createdByUserId: user.id,
+          createdByUserEmail: user.email,
+        },
         select: { id: true, demoSeeded: true },
       });
 
       await db.accountMember.create({
-        data: { accountId: account.id, userId: user.id, role: "owner" },
+        data: {
+          accountId: account.id,
+          userId: user.id,
+          userEmail: user.email,
+          role: "owner",
+        },
       });
 
       // Create API key for this user in the new account
@@ -74,6 +83,7 @@ export const GET = async () => {
         data: {
           key: generateApiKey(),
           userId: user.id,
+          userEmail: user.email,
           accountId: account.id,
         },
       });

--- a/apps/web/src/lib/auth/auth-server.ts
+++ b/apps/web/src/lib/auth/auth-server.ts
@@ -35,18 +35,28 @@ const ensureLocalUser = async () => {
 
   if (!membership) {
     const account = await db.account.create({
-      data: { name: LOCAL_USER.name },
+      data: {
+        name: LOCAL_USER.name,
+        createdByUserId: user.id,
+        createdByUserEmail: LOCAL_USER.email,
+      },
       select: { id: true },
     });
 
     await db.accountMember.create({
-      data: { accountId: account.id, userId: user.id, role: "owner" },
+      data: {
+        accountId: account.id,
+        userId: user.id,
+        userEmail: LOCAL_USER.email,
+        role: "owner",
+      },
     });
 
     await db.apiKey.create({
       data: {
         key: generateApiKey(),
         userId: user.id,
+        userEmail: LOCAL_USER.email,
         accountId: account.id,
       },
     });

--- a/apps/web/src/lib/services/api-key-service.ts
+++ b/apps/web/src/lib/services/api-key-service.ts
@@ -35,8 +35,12 @@ export const regenerateApiKey = async (userId: string, accountId: string) => {
       data: { key },
     });
   } else {
+    const user = await db.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { email: true },
+    });
     await db.apiKey.create({
-      data: { key, userId, accountId },
+      data: { key, userId, userEmail: user.email, accountId },
     });
   }
 

--- a/packages/db/prisma/migrations/20260325115851_uuid_and_denormalize/migration.sql
+++ b/packages/db/prisma/migrations/20260325115851_uuid_and_denormalize/migration.sql
@@ -1,0 +1,49 @@
+/*
+  Warnings:
+
+  - Added the required column `user_email` to the `account_members` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `agent_secrets` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `api_keys` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `user_email` to the `api_keys` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `user_email` to the `audit_logs` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `onboarding_surveys` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `user_email` to the `onboarding_surveys` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `user_id` to the `onboarding_surveys` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "account_members" ADD COLUMN     "user_email" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "accounts" ADD COLUMN     "created_by_user_email" TEXT,
+ADD COLUMN     "created_by_user_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "agent_secrets" ADD COLUMN     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "created_by_user_id" TEXT,
+ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "updated_by_user_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "api_keys" ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "user_email" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "audit_logs" ADD COLUMN     "user_email" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "onboarding_surveys" ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "user_email" TEXT NOT NULL,
+ADD COLUMN     "user_id" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "agent_secrets" ADD CONSTRAINT "agent_secrets_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "agent_secrets" ADD CONSTRAINT "agent_secrets_updated_by_user_id_fkey" FOREIGN KEY ("updated_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "onboarding_surveys" ADD CONSTRAINT "onboarding_surveys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10,14 +10,17 @@ datasource db {
 // ── Account & User ──────────────────────────────────────────────────────
 
 model Account {
-  id                 String   @id @default(cuid())
+  id                 String   @id @default(uuid())
   name               String?
   stripeCustomerId   String?  @unique @map("stripe_customer_id")
   subscriptionStatus String   @default("free") @map("subscription_status")
   demoSeeded         Boolean  @default(false) @map("demo_seeded")
+  createdByUserId    String?  @map("created_by_user_id")
+  createdByUserEmail String?  @map("created_by_user_email")
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 
+  createdByUser     User?              @relation("AccountCreator", fields: [createdByUserId], references: [id])
   members           AccountMember[]
   apiKeys           ApiKey[]
   agents            Agent[]
@@ -34,6 +37,7 @@ model Account {
 model AccountMember {
   accountId String   @map("account_id")
   userId    String   @map("user_id")
+  userEmail String   @map("user_email")
   role      String // "owner" | "admin" | "member"
   createdAt DateTime @default(now()) @map("created_at")
 
@@ -46,27 +50,33 @@ model AccountMember {
 }
 
 model User {
-  id             String   @id @default(cuid())
+  id             String   @id @default(uuid())
   email          String   @unique
   name           String?
   externalAuthId String   @unique @map("external_auth_id")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 
-  memberships AccountMember[]
-  apiKeys     ApiKey[]
-  auditLogs   AuditLog[]
+  memberships         AccountMember[]
+  apiKeys             ApiKey[]
+  auditLogs           AuditLog[]
+  createdAccounts     Account[]          @relation("AccountCreator")
+  onboardingSurveys   OnboardingSurvey[]
+  createdAgentSecrets AgentSecret[]      @relation("AgentSecretCreator")
+  updatedAgentSecrets AgentSecret[]      @relation("AgentSecretUpdater")
 
   @@map("users")
 }
 
 model ApiKey {
-  id        String   @id @default(cuid())
-  key       String   @unique // "oc_..." prefix, used for API auth
-  userId    String   @map("user_id")
+  id        String   @id @default(uuid())
   accountId String   @map("account_id")
+  userId    String   @map("user_id")
+  userEmail String   @map("user_email")
+  key       String   @unique // "oc_..." prefix, used for API auth
   name      String? // "My CLI key", "CI/CD key", etc.
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   user    User    @relation(fields: [userId], references: [id])
   account Account @relation(fields: [accountId], references: [id])
@@ -78,7 +88,7 @@ model ApiKey {
 // ── Workspace data (scoped by accountId) ────────────────────────────────
 
 model Agent {
-  id          String   @id @default(cuid())
+  id          String   @id @default(uuid())
   accountId   String   @map("account_id")
   name        String
   identifier  String? // user-provided machine-readable ID, unique per account
@@ -98,7 +108,7 @@ model Agent {
 }
 
 model Secret {
-  id              String   @id @default(cuid())
+  id              String   @id @default(uuid())
   accountId       String   @map("account_id")
   name            String
   type            String // "anthropic", "generic"
@@ -118,15 +128,15 @@ model Secret {
 }
 
 model PolicyRule {
-  id              String   @id @default(cuid())
+  id              String   @id @default(uuid())
   accountId       String   @map("account_id")
+  agentId         String?  @map("agent_id") // null = all agents, set = one agent only
   name            String
   hostPattern     String   @map("host_pattern") // "gmail.googleapis.com" or "*.googleapis.com"
   pathPattern     String?  @map("path_pattern") // "/gmail/v1/users/me/messages/send" or "/gmail/*"
   method          String? // "POST", null = all methods
   action          String // "block" | "rate_limit"
   enabled         Boolean
-  agentId         String?  @map("agent_id") // null = all agents, set = one agent only
   rateLimit       Int?     @map("rate_limit") // max requests per window (only for rate_limit action)
   rateLimitWindow String?  @map("rate_limit_window") // "minute" | "hour" | "day"
   createdAt       DateTime @default(now()) @map("created_at")
@@ -139,17 +149,23 @@ model PolicyRule {
 }
 
 model AgentSecret {
-  agentId  String @map("agent_id")
-  secretId String @map("secret_id")
-  agent    Agent  @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  secret   Secret @relation(fields: [secretId], references: [id], onDelete: Cascade)
+  agentId         String   @map("agent_id")
+  secretId        String   @map("secret_id")
+  createdByUserId String?  @map("created_by_user_id")
+  updatedByUserId String?  @map("updated_by_user_id")
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
+  agent           Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  secret          Secret   @relation(fields: [secretId], references: [id], onDelete: Cascade)
+  createdByUser   User?    @relation("AgentSecretCreator", fields: [createdByUserId], references: [id])
+  updatedByUser   User?    @relation("AgentSecretUpdater", fields: [updatedByUserId], references: [id])
 
   @@id([agentId, secretId])
   @@map("agent_secrets")
 }
 
 model ConnectedService {
-  id           String    @id @default(cuid())
+  id           String    @id @default(uuid())
   accountId    String    @map("account_id")
   provider     String
   status       String    @default("connected")
@@ -167,9 +183,10 @@ model ConnectedService {
 }
 
 model AuditLog {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid())
   accountId String   @map("account_id")
   userId    String   @map("user_id") // who performed the action (kept permanently)
+  userEmail String   @map("user_email")
   action    String
   service   String
   status    String
@@ -184,7 +201,7 @@ model AuditLog {
 }
 
 model VaultConnection {
-  id              String    @id @default(cuid())
+  id              String    @id @default(uuid())
   accountId       String    @map("account_id")
   provider        String
   name            String?
@@ -200,12 +217,16 @@ model VaultConnection {
 }
 
 model OnboardingSurvey {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid())
   accountId String   @unique @map("account_id")
+  userId    String   @map("user_id")
+  userEmail String   @map("user_email")
   useCase   String?  @map("use_case")
   discovery String[] @default([])
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
   account   Account  @relation(fields: [accountId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
 
   @@map("onboarding_surveys")
 }
@@ -213,7 +234,7 @@ model OnboardingSurvey {
 // ── Standalone (no account scoping) ─────────────────────────────────────
 
 model ResendBadEmail {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid())
   email     String
   eventType String   @map("event_type") // "email.bounced" or "email.complained"
   createdAt DateTime @default(now()) @map("created_at")
@@ -223,7 +244,7 @@ model ResendBadEmail {
 }
 
 model ResendWebhook {
-  id           String   @id @default(cuid())
+  id           String   @id @default(uuid())
   eventType    String   @map("event_type") // "email.sent", "email.bounced", "email.complained", etc.
   emailSubject String?  @map("email_subject")
   emailFrom    String?  @map("email_from")


### PR DESCRIPTION
## Summary

- Switch all model IDs from `cuid()` to `uuid()` for consistency
- Denormalize `userEmail` onto AccountMember, ApiKey, AuditLog, and OnboardingSurvey
- Add `createdByUserId`/`createdByUserEmail` to Account for audit trail
- Add `createdByUserId`/`updatedByUserId` to AgentSecret for tracking
- Add `userId` + `userEmail` to OnboardingSurvey
- Add `updatedAt` to ApiKey, AgentSecret, OnboardingSurvey
- Single migration that recreates tables with new column order and backfills denormalized data

## Migration strategy

One migration that drops all FKs, recreates each table with the new schema (backfilling denormalized fields from joins), restores all constraints, then converts existing cuid IDs to UUIDs via `ON UPDATE CASCADE`.