### PR TITLE
chore: upgrade PostgreSQL from 17 to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check migration drift
         if: steps.prisma-changes.outputs.changed != '0'
         run: |
-          docker run -d --name shadow-db -e POSTGRES_USER=ci -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=shadow -p 5433:5432 postgres:17-alpine
+          docker run -d --name shadow-db -e POSTGRES_USER=ci -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=shadow -p 5433:5432 postgres:18-alpine
           until docker exec shadow-db pg_isready; do sleep 1; done
           pnpm --filter @onecli/db exec prisma migrate diff \
             --from-migrations ./prisma/migrations \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-onecli}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-onecli}


### PR DESCRIPTION
## Summary
- Upgrade `postgres:17-alpine` to `postgres:18-alpine` in docker-compose and CI shadow database

## Test plan
- [ ] Verify `pnpm db:up && pnpm db:migrate` works with PostgreSQL 18
- [ ] CI migration drift check passes with new image