### PR TITLE
fix: postgres18 data mount

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-onecli}
       POSTGRES_DB: ${POSTGRES_DB:-onecli}
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     healthcheck:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / docs update

## What is the current behavior?

The data mount path for PostgreSQL changed with v18. The current Docker compose file still uses the v17 path.

## What is the new behavior?

-

## Additional context

[-](https://hub.docker.com/_/postgres) / https://github.com/docker-library/postgres/pull/1259

