### PR TITLE
fix: enable automatic container restart on failure or system reboot

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:18-alpine
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-onecli}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-onecli}
@@ -20,6 +21,7 @@ services:
 
   app:
     image: ghcr.io/onecli/onecli:latest
+    restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature - Infrastructure/DevOps improvement

## What is the current behavior?

Docker containers do not automatically restart if the Docker daemon restarts or the host machine reboots. This results in service downtime until manual intervention is required to bring containers back online.

## What is the new behavior?

Added the `restart: unless-stopped` policy to both the `postgres` and `app` services in the docker-compose configuration.

**Benefits:**
- Containers automatically recover from crashes or unexpected exits
- Containers automatically restart after Docker daemon or system reboots
- Services are resilient and maintain high availability
- Exception: containers explicitly stopped via `docker stop` or `docker-compose down` remain stopped, allowing for controlled maintenance

## Additional context

This change aligns with production best practices for containerized services and follows Docker documentation recommendations for service resilience.

Changes made:
- Modified `docker/docker-compose.yml` to add `restart: unless-stopped` to postgres service
- Modified `docker/docker-compose.yml` to add `restart: unless-stopped` to app service