### PR TITLE
refactor: add session hooks extension point and user tracking fields

### DIFF
--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { db } from "@onecli/db";
 import { getServerSession } from "@/lib/auth/server";
 import { cryptoService } from "@/lib/crypto";
@@ -10,6 +10,7 @@ import {
 } from "@/lib/constants";
 import { generateApiKey } from "@/lib/services/api-key-service";
 import { generateAccessToken } from "@/lib/services/agent-service";
+import { getSessionAttributes, onUserCreated } from "@/lib/auth/session-hooks";
 
 /**
  * GET /api/auth/session
@@ -24,12 +25,14 @@ import { generateAccessToken } from "@/lib/services/agent-service";
  * Called by the login page after auth and by the dashboard layout on mount.
  * Returns 401 if no valid session exists.
  */
-export const GET = async () => {
+export const GET = async (request: NextRequest) => {
   try {
     const session = await getServerSession();
     if (!session || !session.email) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
+
+    const extra = getSessionAttributes(request);
 
     // Upsert user by email — creates on first login, updates on subsequent.
     const user = await db.user.upsert({
@@ -38,10 +41,14 @@ export const GET = async () => {
         externalAuthId: session.id,
         email: session.email,
         name: session.name,
+        lastLoginAt: new Date(),
+        ...extra,
       },
       update: {
         externalAuthId: session.id,
         name: session.name,
+        lastLoginAt: new Date(),
+        ...extra,
       },
       select: {
         id: true,
@@ -92,6 +99,8 @@ export const GET = async () => {
         accountId: account.id,
         account: { demoSeeded: account.demoSeeded },
       };
+
+      onUserCreated({ email: user.email, name: user.name });
     }
 
     const accountId = membership.accountId;

--- a/apps/web/src/lib/auth/session-hooks.ts
+++ b/apps/web/src/lib/auth/session-hooks.ts
@@ -1,0 +1,10 @@
+import type {
+  GetSessionAttributes,
+  OnUserCreated,
+} from "@/lib/auth/session-types";
+
+export type { SessionUser, SessionAttributes } from "@/lib/auth/session-types";
+
+export const getSessionAttributes: GetSessionAttributes = () => ({});
+
+export const onUserCreated: OnUserCreated = () => {};

--- a/apps/web/src/lib/auth/session-types.ts
+++ b/apps/web/src/lib/auth/session-types.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+
+export type SessionUser = {
+  email: string;
+  name: string | null;
+};
+
+/** Extra attributes to spread into the user upsert (create + update). */
+export type SessionAttributes = Record<string, unknown>;
+
+export type GetSessionAttributes = (request: NextRequest) => SessionAttributes;
+
+export type OnUserCreated = (user: SessionUser) => void;

--- a/packages/db/prisma/migrations/20260326064538_add_user_geo_and_last_login/migration.sql
+++ b/packages/db/prisma/migrations/20260326064538_add_user_geo_and_last_login/migration.sql
@@ -1,0 +1,49 @@
+-- Add country_code, country, last_login_at to users table
+-- Recreate table to maintain correct column order:
+-- identity → geo → activity → timestamps
+
+-- 1. Drop all foreign keys referencing users
+ALTER TABLE "account_members" DROP CONSTRAINT "account_members_user_id_fkey";
+ALTER TABLE "accounts" DROP CONSTRAINT "accounts_created_by_user_id_fkey";
+ALTER TABLE "agent_secrets" DROP CONSTRAINT "agent_secrets_created_by_user_id_fkey";
+ALTER TABLE "agent_secrets" DROP CONSTRAINT "agent_secrets_updated_by_user_id_fkey";
+ALTER TABLE "api_keys" DROP CONSTRAINT "api_keys_user_id_fkey";
+ALTER TABLE "audit_logs" DROP CONSTRAINT "audit_logs_user_id_fkey";
+ALTER TABLE "onboarding_surveys" DROP CONSTRAINT "onboarding_surveys_user_id_fkey";
+
+-- 2. Create new table with desired column order
+CREATE TABLE "users_new" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "external_auth_id" TEXT NOT NULL,
+    "country_code" TEXT,
+    "country" TEXT,
+    "last_login_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "users_new_pkey" PRIMARY KEY ("id")
+);
+
+-- 3. Copy data
+INSERT INTO "users_new" ("id", "email", "name", "external_auth_id", "created_at", "updated_at")
+SELECT "id", "email", "name", "external_auth_id", "created_at", "updated_at"
+FROM "users";
+
+-- 4. Drop old table, rename new table, rename PK constraint
+DROP TABLE "users";
+ALTER TABLE "users_new" RENAME TO "users";
+ALTER INDEX "users_new_pkey" RENAME TO "users_pkey";
+
+-- 5. Recreate indexes
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+CREATE UNIQUE INDEX "users_external_auth_id_key" ON "users"("external_auth_id");
+
+-- 6. Restore foreign keys
+ALTER TABLE "account_members" ADD CONSTRAINT "account_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "agent_secrets" ADD CONSTRAINT "agent_secrets_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "agent_secrets" ADD CONSTRAINT "agent_secrets_updated_by_user_id_fkey" FOREIGN KEY ("updated_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "onboarding_surveys" ADD CONSTRAINT "onboarding_surveys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -50,12 +50,15 @@ model AccountMember {
 }
 
 model User {
-  id             String   @id @default(uuid())
-  email          String   @unique
+  id             String    @id @default(uuid())
+  email          String    @unique
   name           String?
-  externalAuthId String   @unique @map("external_auth_id")
-  createdAt      DateTime @default(now()) @map("created_at")
-  updatedAt      DateTime @updatedAt @map("updated_at")
+  externalAuthId String    @unique @map("external_auth_id")
+  countryCode    String?   @map("country_code")
+  country        String?   @map("country")
+  lastLoginAt    DateTime? @map("last_login_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
 
   memberships         AccountMember[]
   apiKeys             ApiKey[]

--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,9 @@
     "LOG_LEVEL",
     "LOG_FORMAT",
     "AUTH_MODE",
-    "MAILERCHECK_API_KEY"
+    "MAILERCHECK_API_KEY",
+    "DISCORD_WEBHOOK_URL",
+    "ENVIRONMENT"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- Add session-hooks extension point (`getSessionAttributes`, `onUserCreated`) for cloud-specific behavior at login time
- Extract shared types into `session-types.ts` to avoid circular imports with turbopack aliases
- Add `countryCode`, `country`, `lastLoginAt` fields to User model
- Track `lastLoginAt` on every login
- Session route spreads extra attributes from the hook into the user upsert

## Extension point design

```
lib/auth/session-types.ts     ← shared types (never aliased)
lib/auth/session-hooks.ts     ← OSS no-op (aliased in cloud builds)
cloud/auth/session-hooks.ts   ← Cloud implementation (geo + notifications)
```

OSS returns empty attributes. Cloud populates geo from CloudFront headers and fires Discord notifications on signup.