### PR TITLE
fix: invalidate gateway cache on secret and rule mutations

### DIFF
--- a/apps/gateway/src/cache.rs
+++ b/apps/gateway/src/cache.rs
@@ -34,6 +34,9 @@ pub(crate) trait CacheStore: Send + Sync {
     #[allow(dead_code)]
     async fn del(&self, key: &str);
 
+    /// Delete all keys matching a prefix.
+    async fn del_by_prefix(&self, prefix: &str);
+
     /// Atomically increment a counter at `key`.
     /// Sets TTL only on first increment (new key / expired key).
     /// Returns the new count, or `None` on error (graceful fallback).
@@ -125,6 +128,10 @@ impl CacheStore for InMemoryCacheStore {
         self.map.remove(key);
     }
 
+    async fn del_by_prefix(&self, prefix: &str) {
+        self.map.retain(|key, _| !key.starts_with(prefix));
+    }
+
     async fn incr(&self, key: &str, ttl_secs: u64) -> Option<u64> {
         let now = Instant::now();
         let ttl = Duration::from_secs(ttl_secs);
@@ -189,6 +196,37 @@ mod tests {
         store.del("key1").await;
         let result: Option<String> = store.get("key1").await;
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn del_by_prefix_removes_matching_entries() {
+        let store = new_store();
+        store.set("connect:acc1:tok1:host1", &"v1", 60).await;
+        store.set("connect:acc1:tok2:host2", &"v2", 60).await;
+        store.set("connect:acc2:tok3:host3", &"v3", 60).await;
+        store.set("rate:rule1:tok1:123", &"1", 60).await;
+
+        store.del_by_prefix("connect:acc1:").await;
+
+        assert!(store
+            .get::<String>("connect:acc1:tok1:host1")
+            .await
+            .is_none());
+        assert!(store
+            .get::<String>("connect:acc1:tok2:host2")
+            .await
+            .is_none());
+        assert_eq!(
+            store
+                .get::<String>("connect:acc2:tok3:host3")
+                .await
+                .as_deref(),
+            Some("v3")
+        );
+        assert_eq!(
+            store.get::<String>("rate:rule1:tok1:123").await.as_deref(),
+            Some("1")
+        );
     }
 
     #[tokio::test]

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -45,19 +45,21 @@ pub(crate) struct PolicyEngine {
 }
 
 impl PolicyEngine {
+    /// Look up agent by access token.
+    async fn find_agent(&self, agent_token: &str) -> Result<db::AgentRow, ConnectError> {
+        db::find_agent_by_token(&self.pool, agent_token)
+            .await
+            .map_err(|e| ConnectError::Internal(format!("db error: {e}")))?
+            .ok_or(ConnectError::InvalidToken)
+    }
+
     /// Resolve what to do for an agent + host combination (without caching).
     async fn resolve_uncached(
         &self,
-        agent_token: &str,
+        agent: &db::AgentRow,
         hostname: &str,
     ) -> Result<ConnectResponse, ConnectError> {
-        // 1. Agent lookup
-        let agent = db::find_agent_by_token(&self.pool, agent_token)
-            .await
-            .map_err(|e| ConnectError::Internal(format!("db error: {e}")))?
-            .ok_or(ConnectError::InvalidToken)?;
-
-        // 2. Secret lookup — branch on agent's secret mode
+        // 1. Secret lookup — branch on agent's secret mode
         let secrets = if agent.secret_mode == "selective" {
             db::find_secrets_by_agent(&self.pool, &agent.id).await
         } else {
@@ -142,7 +144,7 @@ impl PolicyEngine {
             intercept: true,
             injection_rules,
             policy_rules: matching_policy_rules,
-            account_id: Some(agent.account_id),
+            account_id: Some(agent.account_id.clone()),
         })
     }
 }
@@ -151,24 +153,26 @@ impl PolicyEngine {
 
 /// Resolve with caching. Checks the generic `CacheStore` first, then
 /// queries the DB if needed. The cache key is namespaced as
-/// `connect:{agent_token}:{hostname}`.
+/// `connect:{account_id}:{agent_token}:{hostname}` so that cache
+/// invalidation can target all entries for an account by prefix.
 pub(crate) async fn resolve(
     agent_token: &str,
     hostname: &str,
     policy_engine: &PolicyEngine,
     cache: &dyn CacheStore,
 ) -> Result<ConnectResponse, ConnectError> {
-    let cache_key = format!("connect:{agent_token}:{hostname}");
+    // Look up agent first — needed for account_id in cache key.
+    let agent = policy_engine.find_agent(agent_token).await?;
+
+    let cache_key = format!("connect:{}:{agent_token}:{hostname}", agent.account_id);
 
     // Check cache
     if let Some(response) = cache.get::<ConnectResponse>(&cache_key).await {
         return Ok(response);
     }
 
-    // Query the database
-    let response = policy_engine
-        .resolve_uncached(agent_token, hostname)
-        .await?;
+    // Query the database (agent already resolved, avoids re-querying)
+    let response = policy_engine.resolve_uncached(&agent, hostname).await?;
 
     // Cache the response
     cache.set(&cache_key, &response, CACHE_TTL_SECS).await;
@@ -275,11 +279,16 @@ mod tests {
         };
 
         store
-            .set("connect:aoc_token1:api.anthropic.com", &response, 60)
+            .set(
+                "connect:acc_123:aoc_token1:api.anthropic.com",
+                &response,
+                60,
+            )
             .await;
 
-        let cached: Option<ConnectResponse> =
-            store.get("connect:aoc_token1:api.anthropic.com").await;
+        let cached: Option<ConnectResponse> = store
+            .get("connect:acc_123:aoc_token1:api.anthropic.com")
+            .await;
         assert_eq!(cached, Some(response));
     }
 

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -11,6 +11,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use axum::extract::State;
 use axum::Router;
 use futures_util::TryStreamExt;
 use http_body_util::{Either, Full, StreamBody};
@@ -129,6 +130,10 @@ impl GatewayServer {
                 "/api/vault/{provider}/pair",
                 axum::routing::delete(vault::api::vault_disconnect),
             )
+            .route(
+                "/api/cache/invalidate",
+                axum::routing::post(invalidate_cache),
+            )
             .layer(cors_layer)
             .fallback(fallback)
             .with_state(self.state.clone());
@@ -156,6 +161,21 @@ async fn healthz() -> StatusCode {
 /// Protected: returns the authenticated user's ID.
 async fn me(auth: AuthUser) -> String {
     auth.user_id
+}
+
+/// Invalidate all cached CONNECT responses for the authenticated account.
+/// Called by the web app after secret/rule mutations so agents pick up
+/// changes immediately instead of waiting for the 60-second TTL.
+async fn invalidate_cache(
+    auth: AuthUser,
+    State(state): State<GatewayState>,
+) -> impl axum::response::IntoResponse {
+    let prefix = format!("connect:{}:", auth.account_id);
+    state.cache.del_by_prefix(&prefix).await;
+    (
+        StatusCode::OK,
+        axum::Json(serde_json::json!({ "invalidated": true })),
+    )
 }
 
 /// Reject non-CONNECT requests to unknown routes with 400 Bad Request.

--- a/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import {
   MoreHorizontal,
   RotateCw,
@@ -60,6 +61,7 @@ interface AgentCardProps {
 }
 
 export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
+  const invalidateCache = useInvalidateGatewayCache();
   const [deleting, setDeleting] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
   const [renaming, setRenaming] = useState(false);
@@ -74,6 +76,7 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
     try {
       await regenerateAgentToken(agent.id);
       onUpdate();
+      invalidateCache();
       toast.success("Token regenerated");
     } catch {
       toast.error("Failed to regenerate token");
@@ -87,6 +90,7 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
     try {
       await deleteAgent(agent.id);
       onUpdate();
+      invalidateCache();
       toast.success("Agent deleted");
     } catch {
       toast.error("Failed to delete agent");

--- a/apps/web/src/app/(dashboard)/agents/_components/manage-secrets-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/manage-secrets-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useMemo } from "react";
+import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { KeyRound, Loader2, Search, Globe, ListChecks } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -43,6 +44,7 @@ export const ManageSecretsDialog = ({
   onOpenChange,
   onUpdated,
 }: ManageSecretsDialogProps) => {
+  const invalidateCache = useInvalidateGatewayCache();
   const [mode, setMode] = useState<SecretMode>(
     agent.secretMode === "selective" ? "selective" : "all",
   );
@@ -107,6 +109,7 @@ export const ManageSecretsDialog = ({
       }
       onUpdated();
       onOpenChange(false);
+      invalidateCache();
       toast.success("Secret permissions updated");
     } catch {
       toast.error("Failed to update secret permissions");

--- a/apps/web/src/app/(dashboard)/rules/_components/rule-card.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/rule-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@onecli/ui/components/card";
@@ -29,6 +30,7 @@ interface RuleCardProps {
 }
 
 export const RuleCard = ({ rule, agents, onUpdate }: RuleCardProps) => {
+  const invalidateCache = useInvalidateGatewayCache();
   const [deleting, setDeleting] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [toggling, setToggling] = useState(false);
@@ -52,6 +54,7 @@ export const RuleCard = ({ rule, agents, onUpdate }: RuleCardProps) => {
     try {
       await deleteRule(rule.id);
       onUpdate();
+      invalidateCache();
       toast.success("Rule deleted");
     } catch {
       toast.error("Failed to delete rule");
@@ -65,6 +68,7 @@ export const RuleCard = ({ rule, agents, onUpdate }: RuleCardProps) => {
     try {
       await updateRule(rule.id, { enabled });
       onUpdate();
+      invalidateCache();
     } catch {
       toast.error("Failed to update rule");
     } finally {

--- a/apps/web/src/app/(dashboard)/rules/_components/rule-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/rule-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { toast } from "sonner";
 import { ShieldBan, Gauge, Check, Settings2 } from "lucide-react";
 import {
@@ -72,6 +73,7 @@ export const RuleDialog = ({
   rule,
 }: RuleDialogProps) => {
   const isEdit = !!rule;
+  const invalidateCache = useInvalidateGatewayCache();
   const [saving, setSaving] = useState(false);
   const [step, setStep] = useState<Step>("endpoint");
   const [name, setName] = useState("");
@@ -157,6 +159,7 @@ export const RuleDialog = ({
       }
       onSaved();
       handleClose(false);
+      invalidateCache();
     } catch {
       toast.error(isEdit ? "Failed to update rule" : "Failed to create rule");
     } finally {

--- a/apps/web/src/app/(dashboard)/secrets/_components/secret-card.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/secret-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@onecli/ui/components/card";
@@ -40,6 +41,7 @@ interface SecretCardProps {
 }
 
 export const SecretCard = ({ secret, onUpdate }: SecretCardProps) => {
+  const invalidateCache = useInvalidateGatewayCache();
   const [deleting, setDeleting] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
 
@@ -48,6 +50,7 @@ export const SecretCard = ({ secret, onUpdate }: SecretCardProps) => {
     try {
       await deleteSecret(secret.id);
       onUpdate();
+      invalidateCache();
       toast.success("Secret deleted");
     } catch {
       toast.error("Failed to delete secret");

--- a/apps/web/src/app/(dashboard)/secrets/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/secrets/_components/secret-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { toast } from "sonner";
 import { ArrowLeft, Bot, Key, Settings2 } from "lucide-react";
 import {
@@ -87,6 +88,7 @@ export const SecretDialog = ({
   secret,
 }: SecretDialogProps) => {
   const isEdit = !!secret;
+  const invalidateCache = useInvalidateGatewayCache();
   const [step, setStep] = useState<"type" | "form">("type");
   const [saving, setSaving] = useState(false);
 
@@ -184,6 +186,7 @@ export const SecretDialog = ({
       }
       onSaved();
       onOpenChange(false);
+      invalidateCache();
     } catch {
       toast.error(
         isEdit ? "Failed to update secret" : "Failed to create secret",

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -100,7 +100,7 @@ export const GET = async (request: NextRequest) => {
         account: { demoSeeded: account.demoSeeded },
       };
 
-      onUserCreated({ email: user.email, name: user.name });
+      onUserCreated({ email: user.email, name: user.name }, extra);
     }
 
     const accountId = membership.accountId;

--- a/apps/web/src/hooks/use-invalidate-cache.ts
+++ b/apps/web/src/hooks/use-invalidate-cache.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+import { getGatewayFetchOptions } from "@/lib/gateway-auth";
+
+const GATEWAY_URL =
+  process.env.NEXT_PUBLIC_GATEWAY_URL ?? "http://localhost:10255";
+
+/**
+ * Returns a fire-and-forget function that invalidates the gateway's
+ * CONNECT cache for the current account. Call after any mutation that
+ * changes secrets, policy rules, or agent-secret assignments so that
+ * agents pick up changes immediately instead of waiting for the
+ * 60-second cache TTL.
+ */
+export const useInvalidateGatewayCache = () => {
+  return useCallback(async () => {
+    try {
+      const { headers, credentials } = await getGatewayFetchOptions();
+      await fetch(`${GATEWAY_URL}/api/cache/invalidate`, {
+        method: "POST",
+        headers,
+        credentials,
+      });
+    } catch {
+      // Fire-and-forget — don't break UI if gateway is unreachable
+    }
+  }, []);
+};

--- a/apps/web/src/lib/auth/session-types.ts
+++ b/apps/web/src/lib/auth/session-types.ts
@@ -10,4 +10,7 @@ export type SessionAttributes = Record<string, unknown>;
 
 export type GetSessionAttributes = (request: NextRequest) => SessionAttributes;
 
-export type OnUserCreated = (user: SessionUser) => void;
+export type OnUserCreated = (
+  user: SessionUser,
+  attributes: SessionAttributes,
+) => void;


### PR DESCRIPTION
## Summary

Credentials added via the dashboard were not immediately available to agents due to the gateway's 60-second CONNECT response cache. This adds cache invalidation so changes take effect instantly.

## Changes

**Gateway (Rust):**
- Add `del_by_prefix` method to `CacheStore` trait (both InMemory and Redis implementations)
- Include `account_id` in cache key format: `connect:{account_id}:{token}:{host}`
- Add `POST /api/cache/invalidate` endpoint (authenticated, scoped to caller's account)

**Web app (TypeScript):**
- Add `useInvalidateGatewayCache` hook for client-side cache busting
- Call it after every secret create/update/delete, rule create/update/delete/toggle, agent token regeneration, agent deletion, and agent secret assignment changes

## How it works

1. User mutates a secret/rule/agent in the dashboard
2. Server action saves to DB
3. Client fires `POST /api/cache/invalidate` to the gateway (fire-and-forget)
4. Gateway clears all cached CONNECT responses for that account
5. Next agent request hits the DB and gets fresh data

Fixes #116