### PR TITLE
fix: add API key auth to gateway and server-side cache invalidation

### DIFF
--- a/apps/gateway/src/auth.rs
+++ b/apps/gateway/src/auth.rs
@@ -78,6 +78,14 @@ impl FromRequestParts<GatewayState> for AuthUser {
         parts: &mut Parts,
         state: &GatewayState,
     ) -> Result<Self, Self::Rejection> {
+        // Try API key auth first (Authorization: Bearer oc_...)
+        if let Some(api_key_user) =
+            validate_api_key(&state.policy_engine.pool, &parts.headers).await
+        {
+            return Ok(api_key_user);
+        }
+
+        // Fall back to session auth (cookies / JWT)
         let user_id = validate_request(&state.policy_engine.pool, &parts.headers).await?;
 
         // Resolve account from membership
@@ -99,7 +107,32 @@ impl FromRequestParts<GatewayState> for AuthUser {
     }
 }
 
-// ── Validation ───────────────────────────────────────────────────────────
+// ── API key auth ─────────────────────────────────────────────────────────
+
+/// Try to authenticate via `Authorization: Bearer oc_...` API key.
+/// Returns `None` if no API key is present (falls through to session auth).
+async fn validate_api_key(pool: &PgPool, headers: &HeaderMap) -> Option<AuthUser> {
+    let auth_header = headers.get(hyper::header::AUTHORIZATION)?.to_str().ok()?;
+    let token = auth_header
+        .strip_prefix("Bearer ")
+        .or_else(|| auth_header.strip_prefix("bearer "))?;
+
+    if !token.starts_with("oc_") {
+        return None;
+    }
+
+    let api_key = db::find_api_key(pool, token)
+        .await
+        .map_err(|e| warn!(error = %e, "api key auth: db error"))
+        .ok()??;
+
+    Some(AuthUser {
+        user_id: api_key.user_id,
+        account_id: api_key.account_id,
+    })
+}
+
+// ── Session auth ─────────────────────────────────────────────────────────
 
 /// Validate an incoming browser request and return the internal user ID.
 /// The caller resolves the account ID from the user's membership.

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -57,6 +57,13 @@ pub(crate) struct UserRow {
     pub id: String,
 }
 
+/// An API key row from the `api_keys` table.
+#[derive(Debug, FromRow)]
+pub(crate) struct ApiKeyRow {
+    pub user_id: String,
+    pub account_id: String,
+}
+
 /// A vault connection row from the `vault_connections` table.
 #[derive(Debug, FromRow)]
 #[allow(dead_code)]
@@ -95,6 +102,17 @@ pub(crate) async fn find_account_id_by_user(
             .context("querying account_members by user_id")?;
 
     Ok(row.map(|(id,)| id))
+}
+
+/// Look up an API key (`oc_...`) and return its user_id and account_id.
+pub(crate) async fn find_api_key(pool: &PgPool, key: &str) -> Result<Option<ApiKeyRow>> {
+    sqlx::query_as::<_, ApiKeyRow>(
+        r#"SELECT user_id, account_id FROM api_keys WHERE key = $1 LIMIT 1"#,
+    )
+    .bind(key)
+    .fetch_optional(pool)
+    .await
+    .context("querying api_keys by key")
 }
 
 /// Look up an agent by its access token.

--- a/apps/web/src/app/api/agents/[agentId]/regenerate-token/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/regenerate-token/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import { regenerateAgentToken } from "@/lib/services/agent-service";
 
 type Params = { params: Promise<{ agentId: string }> };
@@ -12,6 +13,7 @@ export const POST = async (request: NextRequest, { params }: Params) => {
 
     const { agentId } = await params;
     const result = await regenerateAgentToken(auth.accountId, agentId);
+    invalidateGatewayCache(request);
     return NextResponse.json(result);
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import { renameAgent, deleteAgent } from "@/lib/services/agent-service";
 import { renameAgentSchema } from "@/lib/validations/agent";
 
@@ -35,6 +36,7 @@ export const DELETE = async (request: NextRequest, { params }: Params) => {
 
     const { agentId } = await params;
     await deleteAgent(auth.accountId, agentId);
+    invalidateGatewayCache(request);
     return new NextResponse(null, { status: 204 });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/agents/[agentId]/secret-mode/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/secret-mode/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import { updateAgentSecretMode } from "@/lib/services/agent-service";
 import { secretModeSchema } from "@/lib/validations/agent";
 
@@ -22,6 +23,7 @@ export const PATCH = async (request: NextRequest, { params }: Params) => {
     }
 
     await updateAgentSecretMode(auth.accountId, agentId, parsed.data.mode);
+    invalidateGatewayCache(request);
     return NextResponse.json({ success: true });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/agents/[agentId]/secrets/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/secrets/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import {
   getAgentSecrets,
   updateAgentSecrets,
@@ -38,6 +39,7 @@ export const PUT = async (request: NextRequest, { params }: Params) => {
     }
 
     await updateAgentSecrets(auth.accountId, agentId, parsed.data.secretIds);
+    invalidateGatewayCache(request);
     return NextResponse.json({ success: true });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import { listAgents, createAgent } from "@/lib/services/agent-service";
 import { createAgentSchema } from "@/lib/validations/agent";
 
@@ -35,6 +36,7 @@ export const POST = async (request: NextRequest) => {
       parsed.data.name,
       parsed.data.identifier,
     );
+    invalidateGatewayCache(request);
     return NextResponse.json(agent, { status: 201 });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/rules/[ruleId]/route.ts
+++ b/apps/web/src/app/api/rules/[ruleId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import {
   updatePolicyRule,
   deletePolicyRule,
@@ -25,6 +26,7 @@ export const PATCH = async (request: NextRequest, { params }: Params) => {
     }
 
     await updatePolicyRule(auth.accountId, ruleId, parsed.data);
+    invalidateGatewayCache(request);
     return NextResponse.json({ success: true });
   } catch (err) {
     return handleServiceError(err);
@@ -38,6 +40,7 @@ export const DELETE = async (request: NextRequest, { params }: Params) => {
 
     const { ruleId } = await params;
     await deletePolicyRule(auth.accountId, ruleId);
+    invalidateGatewayCache(request);
     return new NextResponse(null, { status: 204 });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/rules/route.ts
+++ b/apps/web/src/app/api/rules/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import {
   listPolicyRules,
   createPolicyRule,
@@ -34,6 +35,7 @@ export const POST = async (request: NextRequest) => {
     }
 
     const rule = await createPolicyRule(auth.accountId, parsed.data);
+    invalidateGatewayCache(request);
     return NextResponse.json(rule, { status: 201 });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/secrets/[secretId]/route.ts
+++ b/apps/web/src/app/api/secrets/[secretId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import { updateSecret, deleteSecret } from "@/lib/services/secret-service";
 import { updateSecretSchema } from "@/lib/validations/secret";
 
@@ -22,6 +23,7 @@ export const PATCH = async (request: NextRequest, { params }: Params) => {
     }
 
     await updateSecret(auth.accountId, secretId, parsed.data);
+    invalidateGatewayCache(request);
     return NextResponse.json({ success: true });
   } catch (err) {
     return handleServiceError(err);
@@ -35,6 +37,7 @@ export const DELETE = async (request: NextRequest, { params }: Params) => {
 
     const { secretId } = await params;
     await deleteSecret(auth.accountId, secretId);
+    invalidateGatewayCache(request);
     return new NextResponse(null, { status: 204 });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/app/api/secrets/route.ts
+++ b/apps/web/src/app/api/secrets/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
+import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import { listSecrets, createSecret } from "@/lib/services/secret-service";
 import { createSecretSchema } from "@/lib/validations/secret";
 
@@ -31,6 +32,7 @@ export const POST = async (request: NextRequest) => {
     }
 
     const secret = await createSecret(auth.accountId, parsed.data);
+    invalidateGatewayCache(request);
     return NextResponse.json(secret, { status: 201 });
   } catch (err) {
     return handleServiceError(err);

--- a/apps/web/src/lib/gateway-invalidate.ts
+++ b/apps/web/src/lib/gateway-invalidate.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server";
+
+const GATEWAY_URL =
+  process.env.NEXT_PUBLIC_GATEWAY_URL ?? "http://localhost:10255";
+
+/**
+ * Invalidate the gateway's CONNECT response cache for the current user's
+ * account. Forwards the request's auth headers (API key or session cookie)
+ * to the gateway so it can resolve the account.
+ *
+ * Fire-and-forget — failures are silently ignored. The cache will expire
+ * naturally via TTL if the gateway is unreachable.
+ */
+export const invalidateGatewayCache = (request: NextRequest) => {
+  const authorization = request.headers.get("authorization");
+  const cookie = request.headers.get("cookie");
+
+  const headers: Record<string, string> = {};
+  if (authorization) headers["authorization"] = authorization;
+  if (cookie) headers["cookie"] = cookie;
+
+  fetch(`${GATEWAY_URL}/api/cache/invalidate`, {
+    method: "POST",
+    headers,
+  }).catch(() => {});
+};


### PR DESCRIPTION
## Summary

Extends cache invalidation to cover CLI and API calls (not just browser).

**Gateway (Rust):**
- Add `oc_...` API key validation to `AuthUser` extractor, falling back to session cookie auth
- Add `find_api_key` DB query for the `api_keys` table

**Web app (TypeScript):**
- Add `gateway-invalidate.ts` utility that forwards request auth headers to the gateway
- Call it from all mutation API routes (secrets, rules, agents)

## How it works

CLI sends mutation with `Authorization: Bearer oc_...` → API route saves to DB → forwards auth header to gateway → gateway validates API key, resolves account → clears cache → next agent request gets fresh data.