### PR TITLE
fix: check HTTP status on OAuth token exchange before parsing response

### DIFF
--- a/apps/web/src/lib/apps/github.ts
+++ b/apps/web/src/lib/apps/github.ts
@@ -88,6 +88,12 @@ export const github: AppDefinition = {
         },
       );
 
+      if (!tokenRes.ok) {
+        throw new Error(
+          `GitHub token exchange failed: HTTP ${tokenRes.status} ${tokenRes.statusText}`,
+        );
+      }
+
       const tokenData = (await tokenRes.json()) as {
         access_token?: string;
         scope?: string;

--- a/apps/web/src/lib/apps/google-oauth.ts
+++ b/apps/web/src/lib/apps/google-oauth.ts
@@ -48,6 +48,12 @@ export const exchangeGoogleCode = async ({
     }),
   });
 
+  if (!tokenRes.ok) {
+    throw new Error(
+      `Google token exchange failed: HTTP ${tokenRes.status} ${tokenRes.statusText}`,
+    );
+  }
+
   const tokenData = (await tokenRes.json()) as {
     access_token?: string;
     refresh_token?: string;


### PR DESCRIPTION
## Problem

Was setting up a self-hosted OneCLI instance and ran into a confusing error when connecting GitHub — my OAuth app credentials had a typo in the client secret, so GitHub returned a 401. Instead of seeing something like "HTTP 401 Unauthorized", the error I got was about failing to exchange the code for a token, because the code tried to parse the 401 HTML error page as JSON.

Traced it to `github.ts` and `google-oauth.ts`: both call `fetch()` for the token exchange and immediately call `.json()` on the response without checking `response.ok` first. Interestingly, both files *do* check `userRes.ok` a few lines later when fetching user info — so the pattern exists, it was just missed on the token exchange call.

This also affects cases where the OAuth provider is temporarily down (5xx) or rate-limiting (429), which would produce similarly confusing errors.

## Changes

Added `if (!tokenRes.ok)` checks before parsing the response body, matching the existing `userRes.ok` pattern already used in both files:

- **`google-oauth.ts`** — `exchangeGoogleCode()` (line 49): added status check after the token endpoint fetch  
- **`github.ts`** — `exchangeCode()` (line 89): added status check after the token endpoint fetch

## Reference

Both files already use the correct pattern for the subsequent user info fetch:
```typescript
// google-oauth.ts:87
if (userRes.ok) { ... }

// github.ts:116
if (userRes.ok) { ... }
```