### PR TITLE
feat: access_restricted for selective mode, ResolvedRules struct, gateway cache auth

### DIFF
--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -21,7 +21,7 @@ const CACHE_TTL_SECS: u64 = 60;
 // ── Data types ──────────────────────────────────────────────────────────
 
 /// Result of policy resolution for a CONNECT request.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ConnectResponse {
     pub intercept: bool,
     pub injection_rules: Vec<InjectionRule>,
@@ -30,6 +30,11 @@ pub(crate) struct ConnectResponse {
     pub agent_id: Option<String>,
     pub agent_name: Option<String>,
     pub agent_identifier: Option<String>,
+    /// True when the account has credentials (secrets or app connections) for
+    /// this host but the agent can't access them (selective mode). Used to show
+    /// a more helpful error ("grant access") instead of "connect the app".
+    #[serde(default)]
+    pub access_restricted: bool,
 }
 
 /// Errors from the connect resolution.
@@ -69,14 +74,21 @@ impl PolicyEngine {
         let policy_rules = self.resolve_policy_rules(agent, hostname).await?;
         let has_rules = !injection_rules.is_empty() || !policy_rules.is_empty();
 
+        // Check if the account has credentials (secrets or app connections) for this
+        // host that the agent can't access (selective mode).
+        let access_restricted = injection_rules.is_empty()
+            && agent.secret_mode == "selective"
+            && self.has_account_credentials(agent, hostname).await;
+
         Ok(ConnectResponse {
-            intercept: has_rules,
+            intercept: has_rules || access_restricted,
             injection_rules,
             policy_rules,
             account_id: Some(agent.account_id.clone()),
             agent_id: Some(agent.id.clone()),
             agent_name: Some(agent.name.clone()),
             agent_identifier: agent.identifier.clone(),
+            access_restricted,
         })
     }
 
@@ -197,6 +209,41 @@ impl PolicyEngine {
         }
 
         Ok(rules)
+    }
+
+    /// Check if the account has any credentials (secrets or app connections) for this
+    /// host that the agent can't access. Used to distinguish "not connected" from
+    /// "connected but agent lacks access" in selective mode.
+    async fn has_account_credentials(&self, agent: &db::AgentRow, hostname: &str) -> bool {
+        // Check 1: account has manual secrets matching this host
+        match db::find_secrets_by_account(&self.pool, &agent.account_id).await {
+            Ok(secrets) => {
+                if secrets
+                    .iter()
+                    .any(|s| host_matches(hostname, &s.host_pattern))
+                {
+                    return true;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "has_account_credentials: secrets query failed");
+            }
+        }
+
+        // Check 2: account has app connections for this host
+        let providers = apps::providers_for_host(hostname);
+        if providers.is_empty() {
+            return false;
+        }
+        match db::find_app_connections_by_account(&self.pool, &agent.account_id).await {
+            Ok(connections) => connections
+                .iter()
+                .any(|c| providers.contains(&c.provider.as_str())),
+            Err(e) => {
+                tracing::warn!(error = %e, "has_account_credentials: app connections query failed");
+                false
+            }
+        }
     }
 
     /// Resolve policy rules (block / rate-limit) for this agent + host.
@@ -550,6 +597,7 @@ mod tests {
             agent_id: None,
             agent_name: None,
             agent_identifier: None,
+            access_restricted: false,
         };
 
         store
@@ -589,6 +637,7 @@ mod tests {
             agent_id: Some("agent_1".to_string()),
             agent_name: Some("Test".to_string()),
             agent_identifier: None,
+            access_restricted: false,
         };
 
         // Pre-populate cache with the key format that resolve() uses
@@ -607,6 +656,32 @@ mod tests {
             .await;
         assert!(cached.is_some());
         assert_eq!(cached.unwrap().injection_rules.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_round_trip_with_access_restricted() {
+        let store = new_store().await;
+        let response = ConnectResponse {
+            intercept: true,
+            injection_rules: vec![],
+            policy_rules: vec![],
+            account_id: Some("acc_restricted".to_string()),
+            agent_id: Some("agent_selective".to_string()),
+            agent_name: Some("Selective Agent".to_string()),
+            agent_identifier: None,
+            access_restricted: true,
+        };
+
+        store
+            .set("connect:acc_restricted:aoc_t:api.resend.com", &response, 60)
+            .await;
+
+        let cached: Option<ConnectResponse> = store
+            .get("connect:acc_restricted:aoc_t:api.resend.com")
+            .await;
+        let cached = cached.expect("should be cached");
+        assert!(cached.access_restricted);
+        assert_eq!(cached.account_id.as_deref(), Some("acc_restricted"));
     }
 
     // ── host_matches ────────────────────────────────────────────────────

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -572,39 +572,31 @@ async fn handle_http_proxy(
 
     let agent_token = inject::extract_agent_token(&req).filter(|t| !t.is_empty());
 
-    let (mut injection_rules, policy_rules, account_id, agent_id, agent_name, agent_identifier) =
-        if let Some(ref token) = agent_token {
-            match connect::resolve(token, &hostname, &state.policy_engine, &*state.cache).await {
-                Ok(resp) => (
-                    resp.injection_rules,
-                    resp.policy_rules,
-                    resp.account_id,
-                    resp.agent_id,
-                    resp.agent_name,
-                    resp.agent_identifier,
-                ),
-                Err(ConnectError::InvalidToken) => {
-                    warn!(peer = %peer_addr, host = %authority, "HTTP proxy rejected: invalid agent token");
-                    return Ok(response::proxy_auth_required());
-                }
-                Err(ConnectError::Internal(e)) => {
-                    warn!(peer = %peer_addr, host = %authority, error = %e, "HTTP proxy rejected: internal error");
-                    let mut resp = Response::new(axum::body::Body::empty());
-                    *resp.status_mut() = StatusCode::BAD_GATEWAY;
-                    return Ok(resp);
-                }
+    let mut resolved = if let Some(ref token) = agent_token {
+        match connect::resolve(token, &hostname, &state.policy_engine, &*state.cache).await {
+            Ok(resp) => resp,
+            Err(ConnectError::InvalidToken) => {
+                warn!(peer = %peer_addr, host = %authority, "HTTP proxy rejected: invalid agent token");
+                return Ok(response::proxy_auth_required());
             }
-        } else {
-            (vec![], vec![], None, None, None, None)
-        };
+            Err(ConnectError::Internal(e)) => {
+                warn!(peer = %peer_addr, host = %authority, error = %e, "HTTP proxy rejected: internal error");
+                let mut resp = Response::new(axum::body::Body::empty());
+                *resp.status_mut() = StatusCode::BAD_GATEWAY;
+                return Ok(resp);
+            }
+        }
+    } else {
+        connect::ConnectResponse::default()
+    };
 
     // Vault fallback
-    if injection_rules.is_empty() {
-        if let Some(ref aid) = account_id {
+    if resolved.injection_rules.is_empty() {
+        if let Some(ref aid) = resolved.account_id {
             if let Some(cred) = state.vault_service.request_credential(aid, &hostname).await {
                 let vault_rules = inject::vault_credential_to_rules(&hostname, &cred);
                 if !vault_rules.is_empty() {
-                    injection_rules = vault_rules;
+                    resolved.injection_rules = vault_rules;
                     info!(host = %hostname, account_id = %aid, "http_proxy: using vault credential");
                 }
             }
@@ -614,17 +606,23 @@ async fn handle_http_proxy(
     info!(
         peer = %peer_addr,
         host = %authority,
-        injection_count = injection_rules.len(),
-        policy_count = policy_rules.len(),
+        injection_count = resolved.injection_rules.len(),
+        policy_count = resolved.policy_rules.len(),
         "HTTP_PROXY"
     );
 
     let proxy_ctx = ProxyContext {
-        account_id,
-        agent_id,
-        agent_name,
-        agent_identifier,
+        account_id: resolved.account_id,
+        agent_id: resolved.agent_id,
+        agent_name: resolved.agent_name,
+        agent_identifier: resolved.agent_identifier,
         agent_token: agent_token.clone(),
+    };
+
+    let rules = mitm::ResolvedRules {
+        injection_rules: resolved.injection_rules,
+        policy_rules: resolved.policy_rules,
+        access_restricted: resolved.access_restricted,
     };
 
     let resp = forward::forward_request(
@@ -632,8 +630,7 @@ async fn handle_http_proxy(
         &authority,
         "http",
         state.http_client.clone(),
-        &injection_rules,
-        &policy_rules,
+        &rules,
         &*state.cache,
         &proxy_ctx,
         &state.approval_store,

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -18,9 +18,10 @@ use crate::approval::{
 };
 use crate::apps;
 use crate::cache::CacheStore;
-use crate::inject::{self, InjectionRule};
-use crate::policy::{self, PolicyDecision, PolicyRule};
+use crate::inject;
+use crate::policy::{self, PolicyDecision};
 
+use super::mitm::ResolvedRules;
 use super::response;
 use super::ProxyContext;
 
@@ -86,8 +87,7 @@ pub(crate) async fn forward_request(
     host: &str,
     scheme: &str,
     http_client: reqwest::Client,
-    injection_rules: &[InjectionRule],
-    policy_rules: &[PolicyRule],
+    rules: &ResolvedRules,
     cache: &dyn CacheStore,
     proxy_ctx: &ProxyContext,
     approval_store: &Arc<dyn ApprovalStore>,
@@ -109,7 +109,14 @@ pub(crate) async fn forward_request(
     let agent_token = proxy_ctx.agent_token.as_deref().unwrap_or("");
 
     // Check policy rules before forwarding
-    let decision = policy::evaluate(method.as_str(), &path, policy_rules, agent_token, cache).await;
+    let decision = policy::evaluate(
+        method.as_str(),
+        &path,
+        &rules.policy_rules,
+        agent_token,
+        cache,
+    )
+    .await;
 
     // ── Early return for block / rate-limit (no body needed) ─────
     match &decision {
@@ -182,7 +189,7 @@ pub(crate) async fn forward_request(
     };
 
     // Apply injection rules matching this request path
-    let injection_count = inject::apply_injections(&mut headers, &path, injection_rules);
+    let injection_count = inject::apply_injections(&mut headers, &path, &rules.injection_rules);
 
     // ── ManualApproval: prepare body, store, wait for decision ─────
     let forward_body = if let PolicyDecision::ManualApproval { rule_id } = &decision {
@@ -325,12 +332,27 @@ pub(crate) async fn forward_request(
     let resp_headers = upstream_resp.headers().clone();
 
     // If no credentials were injected and upstream returned 401/403,
-    // check if this host belongs to a known app that needs connecting.
+    // check if this host belongs to a known app that needs connecting or access granting.
     if injection_count == 0
         && (status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN)
     {
         let hostname = super::strip_port(host);
         if let Some((provider, display_name)) = apps::provider_for_host_and_path(hostname, &path) {
+            if rules.access_restricted {
+                info!(
+                    method = %method,
+                    url = %url,
+                    status = %status.as_u16(),
+                    provider = %provider,
+                    "access restricted - agent lacks permission"
+                );
+                return Ok(response::access_restricted(
+                    status,
+                    provider,
+                    display_name,
+                    proxy_ctx.agent_id.as_deref(),
+                ));
+            }
             info!(
                 method = %method,
                 url = %url,

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -70,16 +70,10 @@ pub(super) async fn mitm(
                     // Re-resolve rules from cache on each request so that
                     // secret/rule changes take effect without a reconnect.
                     let hostname = super::strip_port(&host);
-                    let (inj_rules, pol_rules) = match resolve_rules(
-                        &ctx,
-                        hostname,
-                        &engine,
-                        &*cache,
-                        &vault_rules,
-                    )
-                    .await
+                    let rules = match resolve_rules(&ctx, hostname, &engine, &*cache, &vault_rules)
+                        .await
                     {
-                        Ok(rules) => rules,
+                        Ok(r) => r,
                         Err(e) => {
                             warn!(host = %host, error = ?e, "rule resolution failed mid-session");
                             return Ok(response::resolution_failed());
@@ -87,8 +81,7 @@ pub(super) async fn mitm(
                     };
 
                     forward::forward_request(
-                        req, &host, "https", client, &inj_rules, &pol_rules, &*cache, &ctx,
-                        &approvals,
+                        req, &host, "https", client, &rules, &*cache, &ctx, &approvals,
                     )
                     .await
                 }
@@ -96,6 +89,13 @@ pub(super) async fn mitm(
         )
         .await
         .context("serving MITM connection")
+}
+
+/// Per-request resolved rules, bundled for passing to `forward_request`.
+pub(crate) struct ResolvedRules {
+    pub injection_rules: Vec<InjectionRule>,
+    pub policy_rules: Vec<crate::policy::PolicyRule>,
+    pub access_restricted: bool,
 }
 
 /// Resolve injection + policy rules from cache, falling back to vault rules
@@ -106,7 +106,7 @@ async fn resolve_rules(
     engine: &PolicyEngine,
     cache: &dyn CacheStore,
     vault_rules: &[InjectionRule],
-) -> Result<(Vec<InjectionRule>, Vec<crate::policy::PolicyRule>), crate::connect::ConnectError> {
+) -> Result<ResolvedRules, crate::connect::ConnectError> {
     let account_id = ctx.account_id.as_deref().unwrap_or("");
     let agent_token = ctx.agent_token.as_deref().unwrap_or("");
 
@@ -119,5 +119,9 @@ async fn resolve_rules(
         resp.injection_rules
     };
 
-    Ok((injection_rules, resp.policy_rules))
+    Ok(ResolvedRules {
+        injection_rules,
+        policy_rules: resp.policy_rules,
+        access_restricted: resp.access_restricted,
+    })
 }

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -25,6 +25,16 @@ fn dashboard_url() -> String {
     std::env::var("APP_URL").unwrap_or_else(|_| "http://localhost:10254".to_string())
 }
 
+/// Build a JSON error response with the given status code and body.
+fn json_error<S>(status: StatusCode, body: serde_json::Value) -> Response<ForwardBody<S>> {
+    let mut response = Response::new(Either::Left(Full::new(Bytes::from(body.to_string()))));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert("content-type", HeaderValue::from_static("application/json"));
+    response
+}
+
 /// JSON error response for requests to a known app that has no credentials configured.
 ///
 /// Returned when `injection_count == 0` and the upstream returns 401/403 for a host
@@ -35,36 +45,51 @@ pub(crate) fn app_not_connected<S>(
     display_name: &str,
 ) -> Response<ForwardBody<S>> {
     let base = dashboard_url();
-    let body = serde_json::json!({
-        "error": "app_not_connected",
-        "message": format!("{display_name} is not connected in OneCLI. Ask the user to connect it."),
-        "provider": provider,
-        "connect_url": format!("{base}/connections?connect={provider}"),
-    })
-    .to_string();
+    let connect_url = format!("{base}/connections?connect={provider}");
+    json_error(
+        status,
+        serde_json::json!({
+            "error": "app_not_connected",
+            "message": format!("{display_name} is not connected in OneCLI. Ask the user to open this URL to connect it: {connect_url}"),
+            "provider": provider,
+            "connect_url": connect_url,
+        }),
+    )
+}
 
-    let mut response = Response::new(Either::Left(Full::new(Bytes::from(body))));
-    *response.status_mut() = status;
-    response
-        .headers_mut()
-        .insert("content-type", HeaderValue::from_static("application/json"));
-    response
+/// JSON error response when credentials exist for a host but the agent lacks access (selective mode).
+/// Covers both manual secrets and app connections.
+pub(crate) fn access_restricted<S>(
+    status: StatusCode,
+    provider: &str,
+    display_name: &str,
+    agent_id: Option<&str>,
+) -> Response<ForwardBody<S>> {
+    let base = dashboard_url();
+    let manage_url = match agent_id {
+        Some(id) => format!("{base}/agents?manage={}", id.get(..8).unwrap_or(id)),
+        None => format!("{base}/agents"),
+    };
+    json_error(
+        status,
+        serde_json::json!({
+            "error": "access_restricted",
+            "message": format!("{display_name} credentials exist in OneCLI but this agent does not have access. Ask the user to grant access: {manage_url}"),
+            "provider": provider,
+            "manage_url": manage_url,
+        }),
+    )
 }
 
 /// 502 Bad Gateway — rule resolution failed mid-session.
 pub(crate) fn resolution_failed<S>() -> Response<ForwardBody<S>> {
-    let body = serde_json::json!({
-        "error": "resolution_failed",
-        "message": "OneCLI gateway failed to resolve rules for this request.",
-    })
-    .to_string();
-
-    let mut response = Response::new(Either::Left(Full::new(Bytes::from(body))));
-    *response.status_mut() = StatusCode::BAD_GATEWAY;
-    response
-        .headers_mut()
-        .insert("content-type", HeaderValue::from_static("application/json"));
-    response
+    json_error(
+        StatusCode::BAD_GATEWAY,
+        serde_json::json!({
+            "error": "resolution_failed",
+            "message": "OneCLI gateway failed to resolve rules for this request.",
+        }),
+    )
 }
 
 /// 403 Forbidden — manual approval denied or timed out.
@@ -72,35 +97,25 @@ pub(crate) fn manual_approval_denied<S>(
     approval_id: &str,
     reason: &str,
 ) -> Response<ForwardBody<S>> {
-    let body = serde_json::json!({
-        "error": "manual_approval_denied",
-        "message": format!("This request was {reason} by an OneCLI manual approval policy."),
-        "approval_id": approval_id,
-    })
-    .to_string();
-
-    let mut response = Response::new(Either::Left(Full::new(Bytes::from(body))));
-    *response.status_mut() = StatusCode::FORBIDDEN;
-    response
-        .headers_mut()
-        .insert("content-type", HeaderValue::from_static("application/json"));
-    response
+    json_error(
+        StatusCode::FORBIDDEN,
+        serde_json::json!({
+            "error": "manual_approval_denied",
+            "message": format!("This request was {reason} by an OneCLI manual approval policy."),
+            "approval_id": approval_id,
+        }),
+    )
 }
 
 /// 502 Bad Gateway — approval store unavailable.
 pub(crate) fn approval_store_unavailable<S>() -> Response<ForwardBody<S>> {
-    let body = serde_json::json!({
-        "error": "approval_store_unavailable",
-        "message": "OneCLI manual approval service is temporarily unavailable.",
-    })
-    .to_string();
-
-    let mut response = Response::new(Either::Left(Full::new(Bytes::from(body))));
-    *response.status_mut() = StatusCode::BAD_GATEWAY;
-    response
-        .headers_mut()
-        .insert("content-type", HeaderValue::from_static("application/json"));
-    response
+    json_error(
+        StatusCode::BAD_GATEWAY,
+        serde_json::json!({
+            "error": "approval_store_unavailable",
+            "message": "OneCLI manual approval service is temporarily unavailable.",
+        }),
+    )
 }
 
 #[cfg(test)]
@@ -161,5 +176,89 @@ mod tests {
             .as_str()
             .unwrap()
             .ends_with("/connections?connect=github"),);
+    }
+
+    #[test]
+    fn access_restricted_preserves_status() {
+        let resp: Response<
+            ForwardBody<
+                futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+            >,
+        > = access_restricted(
+            StatusCode::FORBIDDEN,
+            "resend",
+            "Resend",
+            Some("abc12345-def"),
+        );
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+    }
+
+    #[tokio::test]
+    async fn access_restricted_body_with_agent_id() {
+        type TestBody = ForwardBody<
+            futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+        >;
+        let resp: Response<TestBody> = access_restricted(
+            StatusCode::UNAUTHORIZED,
+            "resend",
+            "Resend",
+            Some("abc12345-long-id"),
+        );
+        use http_body_util::BodyExt;
+        let body = match resp.into_body() {
+            Either::Left(full) => full.collect().await.expect("collect full body").to_bytes(),
+            Either::Right(_) => panic!("expected Left"),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert_eq!(json["error"], "access_restricted");
+        assert_eq!(json["provider"], "resend");
+        assert!(json["message"]
+            .as_str()
+            .unwrap()
+            .contains("does not have access"));
+        assert!(json["manage_url"]
+            .as_str()
+            .unwrap()
+            .contains("/agents?manage=abc12345"));
+    }
+
+    #[tokio::test]
+    async fn access_restricted_body_without_agent_id() {
+        type TestBody = ForwardBody<
+            futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+        >;
+        let resp: Response<TestBody> =
+            access_restricted(StatusCode::FORBIDDEN, "github", "GitHub", None);
+        use http_body_util::BodyExt;
+        let body = match resp.into_body() {
+            Either::Left(full) => full.collect().await.expect("collect full body").to_bytes(),
+            Either::Right(_) => panic!("expected Left"),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert_eq!(json["error"], "access_restricted");
+        assert!(json["manage_url"].as_str().unwrap().ends_with("/agents"));
+    }
+
+    #[tokio::test]
+    async fn access_restricted_short_agent_id() {
+        type TestBody = ForwardBody<
+            futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+        >;
+        let resp: Response<TestBody> =
+            access_restricted(StatusCode::FORBIDDEN, "resend", "Resend", Some("abc"));
+        use http_body_util::BodyExt;
+        let body = match resp.into_body() {
+            Either::Left(full) => full.collect().await.expect("collect full body").to_bytes(),
+            Either::Right(_) => panic!("expected Left"),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert!(json["manage_url"]
+            .as_str()
+            .unwrap()
+            .contains("/agents?manage=abc"));
     }
 }

--- a/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
@@ -58,9 +58,14 @@ interface AgentCardProps {
     _count: { agentSecrets: number; agentAppConnections: number };
   };
   onUpdate: () => void;
+  autoOpenAccess?: boolean;
 }
 
-export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
+export const AgentCard = ({
+  agent,
+  onUpdate,
+  autoOpenAccess,
+}: AgentCardProps) => {
   const invalidateCache = useInvalidateGatewayCache();
   const [deleting, setDeleting] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
@@ -69,7 +74,9 @@ export const AgentCard = ({ agent, onUpdate }: AgentCardProps) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [newName, setNewName] = useState("");
-  const [secretsDialogOpen, setSecretsDialogOpen] = useState(false);
+  const [secretsDialogOpen, setSecretsDialogOpen] = useState(
+    autoOpenAccess ?? false,
+  );
 
   const handleRegenerate = async () => {
     setRegenerating(true);

--- a/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import { Plus, Bot } from "lucide-react";
 import { getAgents } from "@/lib/actions/agents";
 import type { SecretMode } from "@/lib/services/agent-service";
@@ -22,6 +23,8 @@ interface Agent {
 }
 
 export const AgentsContent = () => {
+  const searchParams = useSearchParams();
+  const manageAgentId = searchParams.get("manage");
   const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
@@ -79,7 +82,14 @@ export const AgentsContent = () => {
         </Card>
       ) : (
         agents.map((agent) => (
-          <AgentCard key={agent.id} agent={agent} onUpdate={fetchAgents} />
+          <AgentCard
+            key={agent.id}
+            agent={agent}
+            onUpdate={fetchAgents}
+            autoOpenAccess={
+              !!manageAgentId && agent.id.startsWith(manageAgentId)
+            }
+          />
         ))
       )}
 

--- a/apps/web/src/hooks/use-invalidate-cache.ts
+++ b/apps/web/src/hooks/use-invalidate-cache.ts
@@ -1,8 +1,5 @@
 import { useCallback } from "react";
-import { getGatewayFetchOptions } from "@/lib/gateway-auth";
-import { API_URL } from "@/lib/env";
-
-const GATEWAY_URL = API_URL;
+import { invalidateGatewayCache } from "@/lib/actions/gateway-cache";
 
 /**
  * Returns a fire-and-forget function that invalidates the gateway's
@@ -14,12 +11,7 @@ const GATEWAY_URL = API_URL;
 export const useInvalidateGatewayCache = () => {
   return useCallback(async () => {
     try {
-      const { headers, credentials } = await getGatewayFetchOptions();
-      await fetch(`${GATEWAY_URL}/api/cache/invalidate`, {
-        method: "POST",
-        headers,
-        credentials,
-      });
+      await invalidateGatewayCache();
     } catch {
       // Fire-and-forget — don't break UI if gateway is unreachable
     }

--- a/apps/web/src/lib/actions/gateway-cache.ts
+++ b/apps/web/src/lib/actions/gateway-cache.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import { db } from "@onecli/db";
+import { cookies } from "next/headers";
+import { API_URL } from "@/lib/env";
+import { resolveUser } from "@/lib/actions/resolve-user";
+
+/**
+ * Invalidate the gateway's CONNECT response cache for the current account.
+ *
+ * Runs server-side so it can authenticate with the gateway properly.
+ * Tries API key auth first (works in all auth modes), falls back to
+ * forwarding session cookies (works in oauth mode).
+ */
+export const invalidateGatewayCache = async () => {
+  try {
+    const headers: Record<string, string> = {};
+
+    // Prefer API key auth — works regardless of gateway auth mode
+    const { accountId } = await resolveUser();
+    const apiKey = await db.apiKey.findFirst({
+      where: { accountId },
+      select: { key: true },
+    });
+
+    if (apiKey) {
+      headers["authorization"] = `Bearer ${apiKey.key}`;
+    } else {
+      // Fallback: forward session cookies (oauth mode only)
+      const cookieStore = await cookies();
+      headers["cookie"] = cookieStore
+        .getAll()
+        .map((c) => `${c.name}=${c.value}`)
+        .join("; ");
+    }
+
+    await fetch(`${API_URL}/api/cache/invalidate`, {
+      method: "POST",
+      headers,
+    });
+  } catch {
+    // Fire-and-forget — don't break UI if gateway is unreachable
+  }
+};


### PR DESCRIPTION
## Summary

- **Broaden access_restricted**: When an agent in selective mode calls a host where the account has credentials (secrets OR app connections) but the agent lacks access, the gateway now returns `access_restricted` instead of the misleading `app_not_connected`. Previously only checked app connections, now also checks manual secrets via `host_matches`.

- **ResolvedRules struct**: Replaced 3-tuple return from `resolve_rules` and 10-param `forward_request` with a named `ResolvedRules` struct bundling `injection_rules`, `policy_rules`, and `access_restricted`.

- **ConnectResponse used directly**: Replaced 7-element tuple destructuring in `handle_http_proxy` with using `ConnectResponse` struct directly. Added `Default` derive.

- **Shared JSON response builder**: Extracted `json_error()` helper used by all 5 response functions, eliminating duplicated response construction.

- **Gateway cache auth fix**: Moved gateway cache invalidation from client-side fetch to server action with API key auth (works in all auth modes, not just OAuth).

- **Safety fixes**: `id.get(..8).unwrap_or(id)` instead of byte-slicing (panic risk), `tracing::warn!` instead of `unwrap_or_default()` on DB errors.

- **Tests**: Added 5 new tests for `access_restricted` response and cache round-trip.