### PR TITLE
feat: credential_not_found for unknown hosts, MITM all authenticated traffic

### DIFF
--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -79,7 +79,7 @@ async-trait = "0.1"
 hex = "0.4"
 
 [features]
-cloud = ["dep:aws-sdk-kms", "dep:aws-config", "dep:redis", "dep:percent-encoding"]
+cloud = ["dep:aws-sdk-kms", "dep:aws-config", "dep:redis"]
 
 [dependencies.aws-sdk-kms]
 version = "1"
@@ -97,7 +97,6 @@ optional = true
 
 [dependencies.percent-encoding]
 version = "2"
-optional = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -35,7 +35,6 @@ use tower_http::cors::CorsLayer;
 use tracing::{info, warn};
 
 use crate::approval::{ApprovalDecision, ApprovalStore, APPROVAL_TIMEOUT_SECS};
-use crate::apps;
 use crate::auth::AuthUser;
 use crate::ca::CertificateAuthority;
 use crate::cache::CacheStore;
@@ -486,12 +485,11 @@ async fn handle_connect(
         }
     }
 
-    // App-not-connected fallback: if an authenticated agent has no credentials
-    // for a known app host, force MITM so forward_request can detect 401/403
-    // and return an actionable error instead of tunneling blindly.
-    if !intercept && agent_token.is_some() && apps::provider_for_host(&hostname).is_some() {
+    // Force MITM for all authenticated agent requests so the gateway can
+    // intercept auth errors (401/403/400) and provide actionable guidance
+    // (credential_not_found, app_not_connected, access_restricted).
+    if !intercept && agent_token.is_some() {
         intercept = true;
-        info!(host = %hostname, "forcing MITM for known app (no credentials)");
     }
 
     info!(
@@ -616,7 +614,7 @@ async fn handle_http_proxy(
         agent_id: resolved.agent_id,
         agent_name: resolved.agent_name,
         agent_identifier: resolved.agent_identifier,
-        agent_token: agent_token.clone(),
+        agent_token,
     };
 
     let rules = mitm::ResolvedRules {

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -81,6 +81,10 @@ fn is_forwarded_response_header(name: &HeaderName) -> bool {
 /// TCP pipe during the approval wait.
 const BODY_PREVIEW_BYTES: usize = 4096;
 
+/// Maximum response body to buffer when checking if a 400 is auth-related.
+/// Auth error messages are small JSON; no need to scan large bodies.
+const AUTH_CHECK_BODY_LIMIT: usize = 8192;
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn forward_request(
     req: Request<Incoming>,
@@ -122,19 +126,7 @@ pub(crate) async fn forward_request(
     match &decision {
         PolicyDecision::Blocked => {
             warn!(method = %method, url = %url, "BLOCKED by policy rule");
-            let body = serde_json::json!({
-                "error": "blocked_by_policy",
-                "message": "This request was blocked by an OneCLI policy rule. Check your rules at https://onecli.sh or your OneCLI dashboard.",
-                "method": method.as_str(),
-                "path": path,
-            })
-            .to_string();
-            let mut response = Response::new(Either::Left(Full::new(Bytes::from(body))));
-            *response.status_mut() = StatusCode::FORBIDDEN;
-            response
-                .headers_mut()
-                .insert("content-type", "application/json".parse().unwrap());
-            return Ok(response);
+            return Ok(response::blocked_by_policy(method.as_str(), &path));
         }
         PolicyDecision::RateLimited {
             limit,
@@ -142,22 +134,7 @@ pub(crate) async fn forward_request(
             retry_after_secs,
         } => {
             warn!(method = %method, url = %url, limit, window, "RATE LIMITED by policy rule");
-            let body = serde_json::json!({
-                "error": "rate_limited",
-                "message": "This request was rate-limited by an OneCLI policy rule.",
-                "limit": limit,
-                "window": window,
-            })
-            .to_string();
-            let mut response = Response::new(Either::Left(Full::new(Bytes::from(body))));
-            *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
-            response
-                .headers_mut()
-                .insert("content-type", "application/json".parse().unwrap());
-            response
-                .headers_mut()
-                .insert("retry-after", retry_after_secs.to_string().parse().unwrap());
-            return Ok(response);
+            return Ok(response::rate_limited(*limit, window, *retry_after_secs));
         }
         _ => {}
     }
@@ -332,36 +309,68 @@ pub(crate) async fn forward_request(
     let resp_headers = upstream_resp.headers().clone();
 
     // If no credentials were injected and upstream returned 401/403,
-    // check if this host belongs to a known app that needs connecting or access granting.
+    // guide the agent to connect/configure credentials in OneCLI.
     if injection_count == 0
         && (status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN)
+        && proxy_ctx.agent_token.is_some()
     {
         let hostname = super::strip_port(host);
+
+        // 1. Access restricted — agent in selective mode, credentials exist but not assigned.
+        //    Applies to ANY host (known apps AND manual secrets).
+        if rules.access_restricted {
+            let (provider, display_name) =
+                apps::provider_for_host_and_path(hostname, &path).unwrap_or((hostname, hostname));
+            info!(method = %method, url = %url, status = %status.as_u16(), "access restricted");
+            return Ok(response::access_restricted(
+                status,
+                provider,
+                display_name,
+                proxy_ctx.agent_id.as_deref(),
+            ));
+        }
+
+        // 2. Known app host — not connected.
         if let Some((provider, display_name)) = apps::provider_for_host_and_path(hostname, &path) {
-            if rules.access_restricted {
-                info!(
-                    method = %method,
-                    url = %url,
-                    status = %status.as_u16(),
-                    provider = %provider,
-                    "access restricted - agent lacks permission"
-                );
-                return Ok(response::access_restricted(
-                    status,
-                    provider,
-                    display_name,
-                    proxy_ctx.agent_id.as_deref(),
-                ));
-            }
-            info!(
-                method = %method,
-                url = %url,
-                status = %status.as_u16(),
-                provider = %provider,
-                "app not connected"
-            );
+            info!(method = %method, url = %url, status = %status.as_u16(), provider = %provider, "app not connected");
             return Ok(response::app_not_connected(status, provider, display_name));
         }
+
+        // 3. Unknown host — no credentials at all, guide user to create a secret.
+        info!(method = %method, url = %url, status = %status.as_u16(), "credential not found");
+        return Ok(response::credential_not_found(status, hostname, &path));
+    }
+
+    // Some APIs (e.g. Google) return 400 instead of 401 for invalid/missing API keys.
+    // Buffer the body and check for auth-related keywords before deciding.
+    if injection_count == 0 && status == StatusCode::BAD_REQUEST && proxy_ctx.agent_token.is_some()
+    {
+        let body_bytes = upstream_resp
+            .bytes()
+            .await
+            .context("reading 400 response body for auth check")?;
+
+        let check_slice = &body_bytes[..body_bytes.len().min(AUTH_CHECK_BODY_LIMIT)];
+
+        if body_indicates_auth_error(check_slice) {
+            let hostname = super::strip_port(host);
+            info!(method = %method, url = %url, status = 400, "auth-related 400");
+            return Ok(response::credential_not_found(
+                StatusCode::BAD_REQUEST,
+                hostname,
+                &path,
+            ));
+        }
+
+        // Not auth-related: forward the buffered 400 as-is.
+        let mut response = Response::new(Either::Left(Full::new(body_bytes)));
+        *response.status_mut() = status;
+        for (name, value) in resp_headers.iter() {
+            if is_forwarded_response_header(name) {
+                response.headers_mut().append(name.clone(), value.clone());
+            }
+        }
+        return Ok(response);
     }
 
     let content_type = resp_headers
@@ -392,6 +401,24 @@ pub(crate) async fn forward_request(
     }
 
     Ok(response)
+}
+
+/// Check if a response body contains auth-related error keywords,
+/// indicating a 400 is actually an authentication failure.
+fn body_indicates_auth_error(body: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(body);
+    let lower = text.to_ascii_lowercase();
+    const AUTH_KEYWORDS: &[&str] = &[
+        "api key",
+        "api_key",
+        "apikey",
+        "unauthorized",
+        "unauthenticated",
+        "authentication",
+        "credentials",
+        "access denied",
+    ];
+    AUTH_KEYWORDS.iter().any(|kw| lower.contains(kw))
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -480,5 +507,43 @@ mod tests {
                 "{name} should be forwarded in responses"
             );
         }
+    }
+
+    // ── body_indicates_auth_error ───────────────────────────────────────
+
+    #[test]
+    fn auth_error_detects_api_key() {
+        let body = br#"{"error": {"message": "API key not valid"}}"#;
+        assert!(body_indicates_auth_error(body));
+    }
+
+    #[test]
+    fn auth_error_detects_unauthenticated() {
+        let body = br#"{"error": "Request is missing required authentication credential."}"#;
+        assert!(body_indicates_auth_error(body));
+    }
+
+    #[test]
+    fn auth_error_case_insensitive() {
+        let body = br#"{"error": "UNAUTHORIZED access"}"#;
+        assert!(body_indicates_auth_error(body));
+    }
+
+    #[test]
+    fn auth_error_rejects_unrelated_400() {
+        let body = br#"{"error": "invalid_argument", "message": "Field 'email' is required"}"#;
+        assert!(!body_indicates_auth_error(body));
+    }
+
+    #[test]
+    fn auth_error_handles_empty_body() {
+        assert!(!body_indicates_auth_error(b""));
+    }
+
+    #[test]
+    fn auth_error_handles_non_utf8() {
+        // Invalid UTF-8 prefix + "api key"
+        let body = &[0xFF, 0xFE, 0x61, 0x70, 0x69, 0x20, 0x6B, 0x65, 0x79];
+        assert!(body_indicates_auth_error(body));
     }
 }

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
+use std::fmt;
 use tokio_rustls::TlsAcceptor;
 use tracing::warn;
 
@@ -23,6 +24,18 @@ use crate::inject::InjectionRule;
 use super::forward;
 use super::response;
 use super::ProxyContext;
+
+/// Typed error context for TLS handshake failures with the client.
+#[derive(Debug)]
+struct TlsHandshakeWithClient;
+
+impl fmt::Display for TlsHandshakeWithClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("TLS handshake with client")
+    }
+}
+
+impl std::error::Error for TlsHandshakeWithClient {}
 
 /// Terminate TLS with the client, then forward each HTTP request through
 /// [`forward::forward_request`] with freshly resolved rules from cache.
@@ -47,7 +60,7 @@ pub(super) async fn mitm(
     let tls_stream = acceptor
         .accept(client_io)
         .await
-        .context("TLS handshake with client")?;
+        .context(TlsHandshakeWithClient)?;
 
     let host_owned = host.to_string();
     let vault_injection_rules = Arc::new(vault_injection_rules);
@@ -92,6 +105,7 @@ pub(super) async fn mitm(
 }
 
 /// Per-request resolved rules, bundled for passing to `forward_request`.
+#[derive(Debug)]
 pub(crate) struct ResolvedRules {
     pub injection_rules: Vec<InjectionRule>,
     pub policy_rules: Vec<crate::policy::PolicyRule>,

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -4,6 +4,7 @@ use http_body_util::{Either, Full};
 use hyper::body::Bytes;
 use hyper::header::HeaderValue;
 use hyper::{Response, StatusCode};
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 /// 407 Proxy Authentication Required — agent token is missing or invalid.
 pub(super) fn proxy_auth_required() -> Response<axum::body::Body> {
@@ -22,7 +23,10 @@ pub(crate) type ForwardBody<S> = Either<Full<Bytes>, S>;
 /// Resolve the OneCLI dashboard base URL from `APP_URL`,
 /// falling back to `http://localhost:10254`.
 fn dashboard_url() -> String {
-    std::env::var("APP_URL").unwrap_or_else(|_| "http://localhost:10254".to_string())
+    std::env::var("APP_URL")
+        .unwrap_or_else(|_| "http://localhost:10254".to_string())
+        .trim_end_matches('/')
+        .to_string()
 }
 
 /// Build a JSON error response with the given status code and body.
@@ -81,6 +85,54 @@ pub(crate) fn access_restricted<S>(
     )
 }
 
+/// JSON error response when no credentials are configured for an unknown host.
+///
+/// Returned when `injection_count == 0`, upstream returns 401/403, the host is NOT a known
+/// app provider, and the agent is authenticated. Provides a link to create a generic secret
+/// with pre-populated host and path.
+pub(crate) fn credential_not_found<S>(
+    status: StatusCode,
+    hostname: &str,
+    path: &str,
+) -> Response<ForwardBody<S>> {
+    let base = dashboard_url();
+    let encoded_host = utf8_percent_encode(hostname, NON_ALPHANUMERIC);
+    let encoded_path = utf8_percent_encode(path, NON_ALPHANUMERIC);
+    let secret_url = format!(
+        "{base}/connections/secrets?create=generic&host={encoded_host}&path={encoded_path}"
+    );
+    json_error(
+        status,
+        serde_json::json!({
+            "error": "credential_not_found",
+            "message": format!(
+                "No credentials configured for {hostname} in OneCLI.\n\n\
+                 A pre-built link is provided in the `secret_url` field, pre-filled with:\n\
+                 - host: {hostname}\n\
+                 - path: {path}\n\n\
+                 Before sending this link to the user, consider whether to adjust it. \
+                 You can build a custom URL with any of these query parameters:\n\
+                 {base}/connections/secrets?create=generic&host=<host>&path=<path>&name=<name>&header=<header>&format=<format>\n\n\
+                 Available parameters:\n\
+                 - `host` (required): hostname to match (e.g., api.example.com or *.example.com)\n\
+                 - `path`: path pattern (e.g., /v1/* or /*). Defaults to the exact request path.\n\
+                 - `name`: display name for the secret (e.g., 'Example API Key')\n\
+                 - `header`: HTTP header name to inject (default: Authorization)\n\
+                 - `format`: value format with {{value}} placeholder (default: Bearer {{value}})\n\n\
+                 Examples of when to customize:\n\
+                 - Change path to `/*` if the credential covers all endpoints on the host\n\
+                 - Change header to `X-API-Key` if the API uses a custom header\n\
+                 - Change format to `{{value}}` (raw) if the API expects the token without a prefix\n\n\
+                 Once you've decided on the right link, ask the user to open it. \
+                 They will see a pre-filled form where they paste their API key or token."
+            ),
+            "hostname": hostname,
+            "path": path,
+            "secret_url": secret_url,
+        }),
+    )
+}
+
 /// 502 Bad Gateway — rule resolution failed mid-session.
 pub(crate) fn resolution_failed<S>() -> Response<ForwardBody<S>> {
     json_error(
@@ -105,6 +157,40 @@ pub(crate) fn manual_approval_denied<S>(
             "approval_id": approval_id,
         }),
     )
+}
+
+/// 403 Forbidden — request blocked by a policy rule.
+pub(crate) fn blocked_by_policy<S>(method: &str, path: &str) -> Response<ForwardBody<S>> {
+    json_error(
+        StatusCode::FORBIDDEN,
+        serde_json::json!({
+            "error": "blocked_by_policy",
+            "message": "This request was blocked by an OneCLI policy rule. Check your rules at https://onecli.sh or your OneCLI dashboard.",
+            "method": method,
+            "path": path,
+        }),
+    )
+}
+
+/// 429 Too Many Requests — request rate-limited by a policy rule.
+pub(crate) fn rate_limited<S>(
+    limit: u64,
+    window: &str,
+    retry_after_secs: u64,
+) -> Response<ForwardBody<S>> {
+    let mut resp = json_error(
+        StatusCode::TOO_MANY_REQUESTS,
+        serde_json::json!({
+            "error": "rate_limited",
+            "message": "This request was rate-limited by an OneCLI policy rule.",
+            "limit": limit,
+            "window": window,
+        }),
+    );
+    if let Ok(val) = HeaderValue::try_from(retry_after_secs.to_string()) {
+        resp.headers_mut().insert("retry-after", val);
+    }
+    resp
 }
 
 /// 502 Bad Gateway — approval store unavailable.
@@ -260,5 +346,65 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("/agents?manage=abc"));
+    }
+
+    #[tokio::test]
+    async fn credential_not_found_includes_host_and_secret_url() {
+        type TestBody = ForwardBody<
+            futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+        >;
+        let resp: Response<TestBody> = credential_not_found(
+            StatusCode::UNAUTHORIZED,
+            "api.custom-service.com",
+            "/v1/send",
+        );
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        use http_body_util::BodyExt;
+        let body = match resp.into_body() {
+            Either::Left(full) => full.collect().await.expect("collect full body").to_bytes(),
+            Either::Right(_) => panic!("expected Left"),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert_eq!(json["error"], "credential_not_found");
+        assert_eq!(json["hostname"], "api.custom-service.com");
+        assert_eq!(json["path"], "/v1/send");
+        assert!(json["secret_url"]
+            .as_str()
+            .unwrap()
+            .contains("create=generic"));
+        assert!(json["message"]
+            .as_str()
+            .unwrap()
+            .contains("api.custom-service.com"));
+    }
+
+    #[tokio::test]
+    async fn credential_not_found_encodes_special_characters() {
+        type TestBody = ForwardBody<
+            futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+        >;
+        let resp: Response<TestBody> = credential_not_found(
+            StatusCode::FORBIDDEN,
+            "api.example.com",
+            "/v1/send?to=user@test.com&subject=hello",
+        );
+        use http_body_util::BodyExt;
+        let body = match resp.into_body() {
+            Either::Left(full) => full.collect().await.expect("collect").to_bytes(),
+            Either::Right(_) => panic!("expected Left"),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        let secret_url = json["secret_url"].as_str().unwrap();
+        // The & and = in the path should be encoded so they don't break the query string
+        assert!(
+            !secret_url.contains("&subject="),
+            "path params must be encoded"
+        );
+        assert!(secret_url.contains("create=generic"));
+        assert!(
+            !secret_url.contains("method="),
+            "method should not be in URL"
+        );
     }
 }

--- a/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
@@ -229,7 +229,7 @@ export const AppDetail = ({
                       <AlertDialogCancel>Cancel</AlertDialogCancel>
                       <AlertDialogAction
                         onClick={handleDisconnect}
-                        className="bg-destructive text-white hover:bg-destructive/90"
+                        variant="destructive"
                       >
                         Disconnect
                       </AlertDialogAction>

--- a/apps/web/src/app/(dashboard)/connections/_components/connections-tabs.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/connections-tabs.tsx
@@ -70,7 +70,7 @@ export const ConnectionsTabs = () => {
   };
 
   return (
-    <AnimatedTabs defaultValue={activeTab} onValueChange={handleTabChange}>
+    <AnimatedTabs value={activeTab} onValueChange={handleTabChange}>
       <AnimatedTabList className="justify-between">
         <div className="flex">
           <AnimatedTabTrigger value="apps">Apps</AnimatedTabTrigger>

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { toast } from "sonner";
 import { ArrowLeft, Bot, Key, Settings2 } from "lucide-react";
@@ -72,12 +72,23 @@ export interface SecretItem {
   injectionConfig: unknown;
 }
 
+export interface SecretPrefill {
+  type: SecretType;
+  hostPattern: string;
+  name: string;
+  pathPattern?: string;
+  headerName?: string;
+  valueFormat?: string;
+}
+
 interface SecretDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSaved: () => void;
   /** Pass an existing secret to edit. Omit for create mode. */
   secret?: SecretItem;
+  /** Pre-populate fields and skip type selection step. */
+  prefill?: SecretPrefill;
 }
 
 export const SecretDialog = ({
@@ -85,9 +96,11 @@ export const SecretDialog = ({
   onOpenChange,
   onSaved,
   secret,
+  prefill,
 }: SecretDialogProps) => {
   const isEdit = !!secret;
   const invalidateCache = useInvalidateGatewayCache();
+  const valueInputRef = useRef<HTMLInputElement>(null);
   const [step, setStep] = useState<"type" | "form">("type");
   const [saving, setSaving] = useState(false);
 
@@ -111,7 +124,7 @@ export const SecretDialog = ({
     return null;
   })();
 
-  // When opening, populate from secret (edit) or reset (create)
+  // When opening, populate from secret (edit), prefill (create with defaults), or reset (create)
   useEffect(() => {
     if (open) {
       if (secret) {
@@ -124,6 +137,16 @@ export const SecretDialog = ({
         setPathPattern(secret.pathPattern ?? "");
         setHeaderName(config?.headerName ?? "Authorization");
         setValueFormat(config?.valueFormat ?? "Bearer {value}");
+      } else if (prefill) {
+        setStep("form");
+        setType(prefill.type);
+        setName(prefill.name);
+        setValue("");
+        setHostPattern(prefill.hostPattern);
+        setPathPattern(prefill.pathPattern ?? "");
+        setHeaderName(prefill.headerName ?? "Authorization");
+        setValueFormat(prefill.valueFormat ?? "Bearer {value}");
+        setTimeout(() => valueInputRef.current?.focus(), 100);
       } else {
         setStep("type");
         setType("anthropic");
@@ -135,7 +158,7 @@ export const SecretDialog = ({
         setValueFormat("Bearer {value}");
       }
     }
-  }, [open, secret]);
+  }, [open, secret, prefill]);
 
   const handleSelectType = (selected: SecretType) => {
     setType(selected);
@@ -255,6 +278,7 @@ export const SecretDialog = ({
                   )}
                 </Label>
                 <Input
+                  ref={valueInputRef}
                   id="secret-value"
                   type="password"
                   placeholder={

--- a/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { Plus, KeyRound } from "lucide-react";
 import { getSecrets } from "@/lib/actions/secrets";
 import { Button } from "@onecli/ui/components/button";
 import { Card } from "@onecli/ui/components/card";
 import { Skeleton } from "@onecli/ui/components/skeleton";
 import { SecretCard } from "./secret-card";
-import { SecretDialog } from "./secret-dialog";
+import { SecretDialog, type SecretPrefill } from "./secret-dialog";
 
 interface Secret {
   id: string;
@@ -21,9 +22,13 @@ interface Secret {
 }
 
 export const SecretsContent = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [secrets, setSecrets] = useState<Secret[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
+  const [prefill, setPrefill] = useState<SecretPrefill | undefined>();
+  const paramHandled = useRef(false);
 
   const fetchSecrets = useCallback(async () => {
     const result = await getSecrets();
@@ -34,6 +39,26 @@ export const SecretsContent = () => {
   useEffect(() => {
     fetchSecrets();
   }, [fetchSecrets]);
+
+  // Auto-open create dialog from URL params (e.g., ?create=generic&host=api.example.com)
+  useEffect(() => {
+    if (paramHandled.current || loading) return;
+    const createType = searchParams.get("create");
+    const host = searchParams.get("host");
+    if (createType === "generic" && host) {
+      paramHandled.current = true;
+      setPrefill({
+        type: "generic",
+        hostPattern: host,
+        pathPattern: searchParams.get("path") ?? undefined,
+        name: searchParams.get("name") ?? `${host} Secret`,
+        headerName: searchParams.get("header") ?? undefined,
+        valueFormat: searchParams.get("format") ?? undefined,
+      });
+      setCreateOpen(true);
+      router.replace(window.location.pathname, { scroll: false });
+    }
+  }, [searchParams, loading, router]);
 
   if (loading) {
     return (
@@ -84,8 +109,12 @@ export const SecretsContent = () => {
 
       <SecretDialog
         open={createOpen}
-        onOpenChange={setCreateOpen}
+        onOpenChange={(open) => {
+          setCreateOpen(open);
+          if (!open) setPrefill(undefined);
+        }}
         onSaved={fetchSecrets}
+        prefill={prefill}
       />
     </div>
   );

--- a/packages/ui/src/components/animated-tabs.tsx
+++ b/packages/ui/src/components/animated-tabs.tsx
@@ -33,7 +33,8 @@ const useTabsContext = () => {
 // ── Root ─────────────────────────────────────────────────────────────────
 
 interface AnimatedTabsProps {
-  defaultValue: string;
+  defaultValue?: string;
+  value?: string;
   onValueChange?: (value: string) => void;
   children: ReactNode;
   className?: string;
@@ -41,16 +42,18 @@ interface AnimatedTabsProps {
 
 export const AnimatedTabs = ({
   defaultValue,
+  value,
   onValueChange,
   children,
   className,
 }: AnimatedTabsProps) => {
-  const [activeTab, setActiveTabState] = useState(defaultValue);
+  const [internalTab, setInternalTab] = useState(value ?? defaultValue ?? "");
+  const activeTab = value ?? internalTab;
   const tabsRef = useRef<Map<string, HTMLButtonElement>>(new Map());
 
   const setActiveTab = useCallback(
     (id: string) => {
-      setActiveTabState(id);
+      setInternalTab(id);
       onValueChange?.(id);
     },
     [onValueChange],


### PR DESCRIPTION
## Summary

### Gateway
- **credential_not_found response**: When an authenticated agent gets 401/403 from an unknown host with no injected credentials, the gateway returns a JSON response with a `secret_url` linking to a pre-populated "Add Secret" form
- **Auth-related 400 handling**: Detects 400 responses with auth keywords (e.g. Google APIs return 400 for invalid API keys) and returns credential_not_found
- **MITM all authenticated traffic**: Forces MITM interception for all authenticated agent requests, not just known app hosts. Enables credential injection guidance for any host
- **access_restricted broadened**: Now checks both manual secrets and app connections (not just apps) when determining if credentials exist but the agent lacks access
- **Restructured 401/403 handling**: Priority order: access_restricted (any host) → app_not_connected (known app) → credential_not_found (unknown host)
- **ResolvedRules struct**: Replaced 3-tuple and reduced forward_request from 10 to 8 parameters
- **json_error helper**: Extracted shared response builder, added blocked_by_policy and rate_limited response functions
- **Safety fixes**: Replaced byte-slice panic risk with safe `str::get()`, added tracing::warn for swallowed DB errors, fixed dashboard_url trailing slash, removed unnecessary clone

### Web App
- **Secret dialog prefill**: Accepts URL params (`?create=generic&host=...&path=...&name=...&header=...&format=...`) to pre-populate the "Add Secret" form and auto-focus the value input
- **Secrets page URL handling**: Reads create params from URL, opens dialog with prefill, cleans URL after opening

### Dependencies
- Added `percent-encoding` for URL-safe encoding in credential_not_found response