### PR TITLE
feat: multi-account connections, credential_not_found and access_restricted

### DIFF
--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -18,6 +18,13 @@ use crate::policy::{PolicyAction, PolicyRule};
 /// How long to cache resolved connect responses before re-checking.
 const CACHE_TTL_SECS: u64 = 60;
 
+/// Header name for per-request app connection disambiguation (request).
+pub(crate) const CONNECTION_ID_HEADER: &str = "x-onecli-connection-id";
+/// Header name for listing available connections (response).
+pub(crate) const CONNECTIONS_HEADER: &str = "x-onecli-connections";
+/// Agent secret mode that restricts access to explicitly assigned credentials.
+pub(crate) const SECRET_MODE_SELECTIVE: &str = "selective";
+
 // ── Data types ──────────────────────────────────────────────────────────
 
 /// Result of policy resolution for a CONNECT request.
@@ -25,6 +32,8 @@ const CACHE_TTL_SECS: u64 = 60;
 pub(crate) struct ConnectResponse {
     pub intercept: bool,
     pub injection_rules: Vec<InjectionRule>,
+    #[serde(default)]
+    pub app_connections: Vec<db::AppConnectionRow>,
     pub policy_rules: Vec<PolicyRule>,
     pub account_id: Option<String>,
     pub agent_id: Option<String>,
@@ -35,6 +44,68 @@ pub(crate) struct ConnectResponse {
     /// a more helpful error ("grant access") instead of "connect the app".
     #[serde(default)]
     pub access_restricted: bool,
+}
+
+/// Result of per-request app connection resolution.
+pub(crate) enum AppConnectionResult {
+    /// Injection rules resolved from a single connection.
+    Rules(Vec<InjectionRule>),
+    /// No app connections available for this provider.
+    NoConnections,
+    /// Multiple connections exist and no header was provided — agent must pick.
+    Ambiguous { connections: Vec<ConnectionChoice> },
+    /// The requested connection ID was not found — return the valid options.
+    NotFound { connections: Vec<ConnectionChoice> },
+}
+
+/// A single app connection option returned in disambiguation responses.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ConnectionChoice {
+    pub id: String,
+    pub label: Option<String>,
+    pub provider: String,
+}
+
+impl ConnectionChoice {
+    pub fn from_row(row: &db::AppConnectionRow) -> Self {
+        Self {
+            id: row.id.clone(),
+            label: row.label.clone(),
+            provider: row.provider.clone(),
+        }
+    }
+}
+
+/// Extract the connection ID from request headers.
+pub(crate) fn extract_connection_id(headers: &hyper::HeaderMap) -> Option<String> {
+    headers
+        .get(CONNECTION_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+/// Inject the `x-onecli-connections` response header listing available connections.
+pub(crate) fn inject_connections_header<B>(
+    resp: &mut hyper::Response<B>,
+    app_connections: &[db::AppConnectionRow],
+) {
+    if app_connections.is_empty() {
+        return;
+    }
+    let choices: Vec<ConnectionChoice> = app_connections
+        .iter()
+        .map(ConnectionChoice::from_row)
+        .collect();
+    if let Ok(json) = serde_json::to_string(&choices) {
+        match hyper::header::HeaderValue::from_str(&json) {
+            Ok(val) => {
+                resp.headers_mut().insert(CONNECTIONS_HEADER, val);
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "failed to encode connections header");
+            }
+        }
+    }
 }
 
 /// Errors from the connect resolution.
@@ -70,19 +141,22 @@ impl PolicyEngine {
         agent: &db::AgentRow,
         hostname: &str,
     ) -> Result<ConnectResponse, ConnectError> {
-        let injection_rules = self.resolve_injections(agent, hostname).await?;
+        let injection_rules = self.resolve_secret_injections(agent, hostname).await?;
+        let app_connections = self.resolve_app_connections(agent, hostname).await?;
         let policy_rules = self.resolve_policy_rules(agent, hostname).await?;
-        let has_rules = !injection_rules.is_empty() || !policy_rules.is_empty();
+        let has_rules =
+            !injection_rules.is_empty() || !app_connections.is_empty() || !policy_rules.is_empty();
 
         // Check if the account has credentials (secrets or app connections) for this
         // host that the agent can't access (selective mode).
         let access_restricted = injection_rules.is_empty()
-            && agent.secret_mode == "selective"
+            && agent.secret_mode == SECRET_MODE_SELECTIVE
             && self.has_account_credentials(agent, hostname).await;
 
         Ok(ConnectResponse {
             intercept: has_rules || access_restricted,
             injection_rules,
+            app_connections,
             policy_rules,
             account_id: Some(agent.account_id.clone()),
             agent_id: Some(agent.id.clone()),
@@ -92,31 +166,13 @@ impl PolicyEngine {
         })
     }
 
-    /// Resolve all injection rules: secrets first, then app connections as fallback.
-    async fn resolve_injections(
-        &self,
-        agent: &db::AgentRow,
-        hostname: &str,
-    ) -> Result<Vec<InjectionRule>, ConnectError> {
-        let secret_rules = self.resolve_secret_injections(agent, hostname).await?;
-        if !secret_rules.is_empty() {
-            debug!(host = %hostname, count = secret_rules.len(), "resolve: using secrets");
-            return Ok(secret_rules);
-        }
-
-        // Secrets take priority — only try app connections when no secret matched.
-        let app_rules = self.resolve_app_injections(agent, hostname).await?;
-        debug!(host = %hostname, count = app_rules.len(), "resolve: using app connections");
-        Ok(app_rules)
-    }
-
     /// Build injection rules from secrets matching this host.
     async fn resolve_secret_injections(
         &self,
         agent: &db::AgentRow,
         hostname: &str,
     ) -> Result<Vec<InjectionRule>, ConnectError> {
-        let secrets = if agent.secret_mode == "selective" {
+        let secrets = if agent.secret_mode == SECRET_MODE_SELECTIVE {
             db::find_secrets_by_agent(&self.pool, &agent.id).await
         } else {
             db::find_secrets_by_account(&self.pool, &agent.account_id).await
@@ -151,17 +207,17 @@ impl PolicyEngine {
         Ok(rules)
     }
 
-    /// Build injection rules from app connections for this host.
-    /// Only called when no secret matched (secrets take priority).
+    /// Fetch app connections matching providers for this host (deferred resolution).
     ///
-    /// Multiple providers can share a host with different path prefixes
-    /// (e.g., Gmail on `/gmail/*` and Calendar on `/calendar/*`). Returns one
-    /// `InjectionRule` per matching connection, each scoped to its path pattern.
-    async fn resolve_app_injections(
+    /// Returns the raw `AppConnectionRow` values filtered to providers that match
+    /// the hostname. Decryption and injection rule building are deferred to
+    /// per-request time via [`resolve_app_injection_for_request`] so that
+    /// multi-account disambiguation can happen with the `x-onecli-connection-id` header.
+    async fn resolve_app_connections(
         &self,
         agent: &db::AgentRow,
         hostname: &str,
-    ) -> Result<Vec<InjectionRule>, ConnectError> {
+    ) -> Result<Vec<db::AppConnectionRow>, ConnectError> {
         let providers = apps::providers_for_host(hostname);
         if providers.is_empty() {
             debug!(host = %hostname, "app_connections: no provider for host");
@@ -169,46 +225,156 @@ impl PolicyEngine {
         }
         debug!(host = %hostname, providers = ?providers, "app_connections: matched providers");
 
-        let connections = if agent.secret_mode == "selective" {
+        let connections = if agent.secret_mode == SECRET_MODE_SELECTIVE {
             db::find_app_connections_by_agent(&self.pool, &agent.id).await
         } else {
             db::find_app_connections_by_account(&self.pool, &agent.account_id).await
         }
         .map_err(db_err)?;
 
-        let mut rules = Vec::new();
-        for provider in &providers {
-            let Some(conn) = connections.iter().find(|c| c.provider == *provider) else {
-                continue;
-            };
-            let Some(ref encrypted_creds) = conn.credentials else {
-                continue;
-            };
+        let matching: Vec<db::AppConnectionRow> = connections
+            .into_iter()
+            .filter(|c| providers.contains(&c.provider.as_str()))
+            .collect();
 
-            let decrypted_json = self
-                .crypto
-                .decrypt(encrypted_creds)
-                .await
-                .map_err(decrypt_err)?;
+        debug!(host = %hostname, count = matching.len(), "app_connections: deferred connections");
+        Ok(matching)
+    }
 
-            let Some(token) = self
-                .resolve_access_token(&decrypted_json, provider, &agent.account_id, &conn.id)
-                .await
-            else {
-                continue;
-            };
-
-            for (path_pattern, injections) in
-                apps::build_app_injection_rules(provider, hostname, &token)
-            {
-                rules.push(InjectionRule {
-                    path_pattern,
-                    injections,
-                });
-            }
+    /// Resolve app connection injection rules for a single request.
+    /// Called per-request with the cached `app_connections` (already filtered to
+    /// providers matching the hostname at cache time by `resolve_app_connections`).
+    pub(crate) async fn resolve_app_injection_for_request(
+        &self,
+        app_connections: &[db::AppConnectionRow],
+        hostname: &str,
+        connection_id: Option<&str>,
+        account_id: &str,
+        cache: &dyn CacheStore,
+    ) -> Result<AppConnectionResult, ConnectError> {
+        if app_connections.is_empty() {
+            return Ok(AppConnectionResult::NoConnections);
         }
 
-        Ok(rules)
+        // If a specific connection ID is requested, use that one
+        if let Some(conn_id) = connection_id {
+            let Some(conn) = app_connections.iter().find(|c| c.id == conn_id) else {
+                // Connection was removed or access revoked — return the valid options
+                return Ok(AppConnectionResult::NotFound {
+                    connections: app_connections
+                        .iter()
+                        .map(ConnectionChoice::from_row)
+                        .collect(),
+                });
+            };
+            return self
+                .resolve_connection_injections(conn, hostname, account_id, cache)
+                .await;
+        }
+
+        // Single connection — use it directly
+        if app_connections.len() == 1 {
+            return self
+                .resolve_connection_injections(&app_connections[0], hostname, account_id, cache)
+                .await;
+        }
+
+        // Multiple connections — check for ambiguity per provider
+        // Group by provider; if each provider has exactly 1 connection, no ambiguity
+        let mut by_provider: std::collections::HashMap<&str, Vec<&db::AppConnectionRow>> =
+            std::collections::HashMap::new();
+        for conn in app_connections {
+            by_provider
+                .entry(conn.provider.as_str())
+                .or_default()
+                .push(conn);
+        }
+
+        if by_provider.values().all(|conns| conns.len() == 1) {
+            // Each provider has exactly one connection — no ambiguity, resolve all
+            let mut rules = Vec::new();
+            for conn in app_connections {
+                if let AppConnectionResult::Rules(r) = self
+                    .resolve_connection_injections(conn, hostname, account_id, cache)
+                    .await?
+                {
+                    rules.extend(r);
+                }
+            }
+            return Ok(AppConnectionResult::Rules(rules));
+        }
+
+        // Truly ambiguous — return all connections for the caller to report
+        Ok(AppConnectionResult::Ambiguous {
+            connections: app_connections
+                .iter()
+                .map(ConnectionChoice::from_row)
+                .collect(),
+        })
+    }
+
+    /// Resolve injection rules from a single app connection, with caching.
+    /// Decrypts credentials, resolves/refreshes the access token, and builds
+    /// injection rules. Results are cached per-connection to avoid redundant
+    /// decryption on subsequent requests.
+    async fn resolve_connection_injections(
+        &self,
+        conn: &db::AppConnectionRow,
+        hostname: &str,
+        account_id: &str,
+        cache: &dyn CacheStore,
+    ) -> Result<AppConnectionResult, ConnectError> {
+        let cache_key = format!("app_injection:{account_id}:{}", conn.id);
+
+        // Check injection cache — skip decryption if we have cached rules
+        if let Some(cached) = cache.get::<Vec<InjectionRule>>(&cache_key).await {
+            debug!(connection_id = %conn.id, "app injection: cache hit");
+            return Ok(AppConnectionResult::Rules(cached));
+        }
+
+        let Some(ref encrypted_creds) = conn.credentials else {
+            return Ok(AppConnectionResult::NoConnections);
+        };
+
+        let decrypted_json = self
+            .crypto
+            .decrypt(encrypted_creds)
+            .await
+            .map_err(decrypt_err)?;
+        let Some((token, expires_at)) = self
+            .resolve_access_token(&decrypted_json, &conn.provider, account_id, &conn.id)
+            .await
+        else {
+            return Ok(AppConnectionResult::NoConnections);
+        };
+
+        let mut rules = Vec::new();
+        for (path_pattern, injections) in
+            apps::build_app_injection_rules(&conn.provider, hostname, &token)
+        {
+            rules.push(InjectionRule {
+                path_pattern,
+                injections,
+            });
+        }
+
+        // Cache with TTL = min(CACHE_TTL, token remaining lifetime).
+        // Skip caching if token is already expired — the stale token would cause
+        // upstream 401s, and re-resolving gives a chance to refresh.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_secs() as i64;
+        let ttl = match expires_at {
+            Some(exp) if exp > now => ((exp - now) as u64).min(CACHE_TTL_SECS),
+            Some(_) => 0, // expired — don't cache
+            None => CACHE_TTL_SECS,
+        };
+        if ttl > 0 {
+            cache.set(&cache_key, &rules, ttl).await;
+        }
+
+        Ok(AppConnectionResult::Rules(rules))
     }
 
     /// Check if the account has any credentials (secrets or app connections) for this
@@ -299,13 +465,15 @@ impl PolicyEngine {
     /// Extract access token from decrypted credentials JSON, refreshing if expired.
     /// Resolves BYOC client credentials from AppConfig if available, falls back to env vars.
     /// On successful refresh, persists the new credentials back to the database.
+    /// Extract the access token from decrypted credentials, refreshing if expired.
+    /// Returns `(token, expires_at)` — the effective token and its expiry timestamp.
     async fn resolve_access_token(
         &self,
         json: &str,
         provider: &str,
         account_id: &str,
         connection_id: &str,
-    ) -> Option<String> {
+    ) -> Option<(String, Option<i64>)> {
         let mut creds: serde_json::Value = serde_json::from_str(json).ok()?;
 
         let mut token = creds
@@ -313,8 +481,10 @@ impl PolicyEngine {
             .and_then(|v| v.as_str())
             .map(String::from);
 
+        let mut effective_expires_at = creds.get("expires_at").and_then(|v| v.as_i64());
+
         // Check if token is expired and needs refresh
-        if let Some(expires_at) = creds.get("expires_at").and_then(|v| v.as_i64()) {
+        if let Some(expires_at) = effective_expires_at {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("system clock before UNIX epoch")
@@ -323,7 +493,6 @@ impl PolicyEngine {
             if expires_at < now {
                 if let Some(refresh_token) = creds.get("refresh_token").and_then(|v| v.as_str()) {
                     if let Some(config) = apps::refresh_config(provider) {
-                        // Resolve client credentials: BYOC AppConfig first, env vars as fallback
                         let byoc = self.resolve_byoc_credentials(account_id, provider).await;
                         let (byoc_id, byoc_secret) = match &byoc {
                             Some((id, secret)) => (Some(id.as_str()), Some(secret.as_str())),
@@ -341,9 +510,8 @@ impl PolicyEngine {
                             Ok((new_token, new_expires_at)) => {
                                 debug!(provider = %provider, "refreshed expired token");
                                 token = Some(new_token.clone());
+                                effective_expires_at = Some(new_expires_at);
 
-                                // Persist refreshed credentials to DB so subsequent
-                                // requests don't re-refresh until the new token expires.
                                 creds["access_token"] = serde_json::Value::String(new_token);
                                 creds["expires_at"] = serde_json::json!(new_expires_at);
                                 self.persist_refreshed_credentials(connection_id, provider, &creds)
@@ -358,7 +526,7 @@ impl PolicyEngine {
             }
         }
 
-        token
+        token.map(|t| (t, effective_expires_at))
     }
 
     /// Encrypt and persist refreshed credentials back to the database.
@@ -429,11 +597,11 @@ impl PolicyEngine {
 // ── Error helpers ──────────────────────────────────────────────────────
 
 fn db_err(e: anyhow::Error) -> ConnectError {
-    ConnectError::Internal(format!("db error: {e}"))
+    ConnectError::Internal(format!("db error: {e:#}"))
 }
 
 fn decrypt_err(e: anyhow::Error) -> ConnectError {
-    ConnectError::Internal(format!("decrypt error: {e}"))
+    ConnectError::Internal(format!("decrypt error: {e:#}"))
 }
 
 // ── Cached resolution ───────────────────────────────────────────────────
@@ -592,6 +760,7 @@ mod tests {
         let response = ConnectResponse {
             intercept: true,
             injection_rules: vec![],
+            app_connections: vec![],
             policy_rules: vec![],
             account_id: None,
             agent_id: None,
@@ -632,6 +801,7 @@ mod tests {
                 path_pattern: "*".to_string(),
                 injections: vec![],
             }],
+            app_connections: vec![],
             policy_rules: vec![],
             account_id: Some("acc_1".to_string()),
             agent_id: Some("agent_1".to_string()),
@@ -664,6 +834,7 @@ mod tests {
         let response = ConnectResponse {
             intercept: true,
             injection_rules: vec![],
+            app_connections: vec![],
             policy_rules: vec![],
             account_id: Some("acc_restricted".to_string()),
             agent_id: Some("agent_selective".to_string()),

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -207,11 +207,13 @@ pub(crate) async fn find_app_config(
 // ── App connection queries ─────────────────────────────────────────────
 
 /// An app connection row from the `app_connections` table.
-#[derive(Debug, FromRow)]
+#[derive(Debug, Clone, PartialEq, FromRow, serde::Serialize, serde::Deserialize)]
 pub(crate) struct AppConnectionRow {
     pub id: String,
     pub provider: String,
     pub credentials: Option<String>,
+    pub label: Option<String>,
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Find all connected app connections for a given account.
@@ -220,7 +222,7 @@ pub(crate) async fn find_app_connections_by_account(
     account_id: &str,
 ) -> Result<Vec<AppConnectionRow>> {
     sqlx::query_as::<_, AppConnectionRow>(
-        r#"SELECT id, provider, credentials FROM app_connections WHERE account_id = $1 AND status = 'connected'"#,
+        r#"SELECT id, provider, credentials, label, metadata FROM app_connections WHERE account_id = $1 AND status = 'connected'"#,
     )
     .bind(account_id)
     .fetch_all(pool)
@@ -234,7 +236,7 @@ pub(crate) async fn find_app_connections_by_agent(
     agent_id: &str,
 ) -> Result<Vec<AppConnectionRow>> {
     sqlx::query_as::<_, AppConnectionRow>(
-        r#"SELECT ac.id, ac.provider, ac.credentials
+        r#"SELECT ac.id, ac.provider, ac.credentials, ac.label, ac.metadata
            FROM app_connections ac
            INNER JOIN agent_app_connections aac ON ac.id = aac.app_connection_id
            WHERE aac.agent_id = $1 AND ac.status = 'connected'"#,

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -38,7 +38,7 @@ use crate::approval::{ApprovalDecision, ApprovalStore, APPROVAL_TIMEOUT_SECS};
 use crate::auth::AuthUser;
 use crate::ca::CertificateAuthority;
 use crate::cache::CacheStore;
-use crate::connect::{self, ConnectError, PolicyEngine};
+use crate::connect::{self, AppConnectionResult, ConnectError, PolicyEngine};
 use crate::inject;
 use crate::vault;
 
@@ -253,6 +253,11 @@ async fn invalidate_cache(
     auth: AuthUser,
     State(state): State<GatewayState>,
 ) -> impl axum::response::IntoResponse {
+    // Clear injection cache first, then connect cache. This ordering ensures
+    // a concurrent request that re-resolves the connect cache also re-resolves
+    // injections (since injection cache is already cleared).
+    let injection_prefix = format!("app_injection:{}:", auth.account_id);
+    state.cache.del_by_prefix(&injection_prefix).await;
     let prefix = format!("connect:{}:", auth.account_id);
     state.cache.del_by_prefix(&prefix).await;
     (
@@ -454,9 +459,7 @@ async fn handle_connect(
             }
             Err(ConnectError::Internal(e)) => {
                 warn!(peer = %peer_addr, host = %host, error = %e, "CONNECT rejected: internal error");
-                let mut resp = Response::new(axum::body::Body::empty());
-                *resp.status_mut() = StatusCode::BAD_GATEWAY;
-                return Ok(resp);
+                return Ok(response::bad_gateway());
             }
         }
     } else {
@@ -570,6 +573,8 @@ async fn handle_http_proxy(
 
     let agent_token = inject::extract_agent_token(&req).filter(|t| !t.is_empty());
 
+    let connection_id = connect::extract_connection_id(req.headers());
+
     let mut resolved = if let Some(ref token) = agent_token {
         match connect::resolve(token, &hostname, &state.policy_engine, &*state.cache).await {
             Ok(resp) => resp,
@@ -579,14 +584,42 @@ async fn handle_http_proxy(
             }
             Err(ConnectError::Internal(e)) => {
                 warn!(peer = %peer_addr, host = %authority, error = %e, "HTTP proxy rejected: internal error");
-                let mut resp = Response::new(axum::body::Body::empty());
-                *resp.status_mut() = StatusCode::BAD_GATEWAY;
-                return Ok(resp);
+                return Ok(response::bad_gateway());
             }
         }
     } else {
         connect::ConnectResponse::default()
     };
+
+    // Per-request app connection disambiguation
+    if resolved.injection_rules.is_empty() && !resolved.app_connections.is_empty() {
+        let aid = resolved.account_id.as_deref().unwrap_or("");
+        match state
+            .policy_engine
+            .resolve_app_injection_for_request(
+                &resolved.app_connections,
+                &hostname,
+                connection_id.as_deref(),
+                aid,
+                &*state.cache,
+            )
+            .await
+        {
+            Ok(AppConnectionResult::Rules(rules)) => resolved.injection_rules = rules,
+            Ok(AppConnectionResult::Ambiguous { connections }) => {
+                return Ok(response::multiple_connections_axum(&connections));
+            }
+            Ok(AppConnectionResult::NotFound { connections }) => {
+                let cid = connection_id.as_deref().unwrap_or("");
+                return Ok(response::connection_not_found_axum(cid, &connections));
+            }
+            Ok(AppConnectionResult::NoConnections) => {}
+            Err(e) => {
+                warn!(peer = %peer_addr, host = %authority, error = ?e, "HTTP proxy: app connection resolution failed");
+                return Ok(response::bad_gateway());
+            }
+        }
+    }
 
     // Vault fallback
     if resolved.injection_rules.is_empty() {
@@ -623,7 +656,7 @@ async fn handle_http_proxy(
         access_restricted: resolved.access_restricted,
     };
 
-    let resp = forward::forward_request(
+    let mut resp = forward::forward_request(
         req,
         &authority,
         "http",
@@ -634,6 +667,8 @@ async fn handle_http_proxy(
         &state.approval_store,
     )
     .await?;
+
+    connect::inject_connections_header(&mut resp, &resolved.app_connections);
 
     // Convert the response body type to match the axum::body::Body return type
     Ok(resp.map(axum::body::Body::new))

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -46,7 +46,7 @@ const HOP_BY_HOP_HEADERS: &[&str] = &[
 /// `content-length` (recalculated by reqwest from the body).
 fn is_forwarded_request_header(name: &HeaderName) -> bool {
     let s = name.as_str();
-    if s == "host" || s == "content-length" {
+    if s == "host" || s == "content-length" || s == crate::connect::CONNECTION_ID_HEADER {
         return false;
     }
     !HOP_BY_HOP_HEADERS.contains(&s)
@@ -354,7 +354,30 @@ pub(crate) async fn forward_request(
 
         if body_indicates_auth_error(check_slice) {
             let hostname = super::strip_port(host);
-            info!(method = %method, url = %url, status = 400, "auth-related 400");
+
+            // Mirror the 401/403 logic: access_restricted → app_not_connected → credential_not_found
+            if rules.access_restricted {
+                let (provider, display_name) = apps::provider_for_host_and_path(hostname, &path)
+                    .unwrap_or((hostname, hostname));
+                info!(method = %method, url = %url, status = 400, "auth-related 400 — access restricted");
+                return Ok(response::access_restricted(
+                    StatusCode::BAD_REQUEST,
+                    provider,
+                    display_name,
+                    proxy_ctx.agent_id.as_deref(),
+                ));
+            }
+            if let Some((provider, display_name)) =
+                apps::provider_for_host_and_path(hostname, &path)
+            {
+                info!(method = %method, url = %url, status = 400, provider = %provider, "auth-related 400 — app not connected");
+                return Ok(response::app_not_connected(
+                    StatusCode::BAD_REQUEST,
+                    provider,
+                    display_name,
+                ));
+            }
+            info!(method = %method, url = %url, status = 400, "auth-related 400 — credential not found");
             return Ok(response::credential_not_found(
                 StatusCode::BAD_REQUEST,
                 hostname,
@@ -417,6 +440,10 @@ fn body_indicates_auth_error(body: &[u8]) -> bool {
         "authentication",
         "credentials",
         "access denied",
+        "permission denied",
+        "invalid token",
+        "token expired",
+        "not authenticated",
     ];
     AUTH_KEYWORDS.iter().any(|kw| lower.contains(kw))
 }
@@ -447,6 +474,13 @@ mod tests {
         )));
         assert!(!is_forwarded_request_header(&HeaderName::from_static(
             "content-length"
+        )));
+    }
+
+    #[test]
+    fn request_header_strips_connection_id() {
+        assert!(!is_forwarded_request_header(&HeaderName::from_static(
+            crate::connect::CONNECTION_ID_HEADER
         )));
     }
 

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -18,7 +18,8 @@ use tracing::warn;
 use crate::approval::ApprovalStore;
 use crate::ca::CertificateAuthority;
 use crate::cache::CacheStore;
-use crate::connect::{self, PolicyEngine};
+use crate::connect::{self, AppConnectionResult, ConnectionChoice, PolicyEngine};
+use crate::db;
 use crate::inject::InjectionRule;
 
 use super::forward;
@@ -80,23 +81,49 @@ pub(super) async fn mitm(
                 let engine = Arc::clone(&policy_engine);
                 let vault_rules = Arc::clone(&vault_injection_rules);
                 async move {
+                    let connection_id = connect::extract_connection_id(req.headers());
+
                     // Re-resolve rules from cache on each request so that
                     // secret/rule changes take effect without a reconnect.
                     let hostname = super::strip_port(&host);
-                    let rules = match resolve_rules(&ctx, hostname, &engine, &*cache, &vault_rules)
-                        .await
-                    {
-                        Ok(r) => r,
-                        Err(e) => {
-                            warn!(host = %host, error = ?e, "rule resolution failed mid-session");
-                            return Ok(response::resolution_failed());
-                        }
-                    };
-
-                    forward::forward_request(
-                        req, &host, "https", client, &rules, &*cache, &ctx, &approvals,
+                    match resolve_rules(
+                        &ctx,
+                        hostname,
+                        &engine,
+                        &*cache,
+                        &vault_rules,
+                        connection_id.as_deref(),
                     )
                     .await
+                    {
+                        Ok(ResolveResult::Resolved {
+                            rules,
+                            app_connections,
+                        }) => {
+                            match forward::forward_request(
+                                req, &host, "https", client, &rules, &*cache, &ctx, &approvals,
+                            )
+                            .await
+                            {
+                                Ok(mut resp) => {
+                                    connect::inject_connections_header(&mut resp, &app_connections);
+                                    Ok(resp)
+                                }
+                                Err(e) => Err(e),
+                            }
+                        }
+                        Ok(ResolveResult::Ambiguous(connections)) => {
+                            Ok(response::multiple_connections(&connections))
+                        }
+                        Ok(ResolveResult::NotFound {
+                            connection_id: cid,
+                            connections,
+                        }) => Ok(response::connection_not_found(&cid, &connections)),
+                        Err(e) => {
+                            warn!(host = %host, error = ?e, "rule resolution failed mid-session");
+                            Ok(response::resolution_failed())
+                        }
+                    }
                 }
             }),
         )
@@ -112,30 +139,78 @@ pub(crate) struct ResolvedRules {
     pub access_restricted: bool,
 }
 
-/// Resolve injection + policy rules from cache, falling back to vault rules
-/// if no DB secrets or app connections are configured for this host.
+/// Result of per-request rule resolution including app connection disambiguation.
+enum ResolveResult {
+    /// Rules resolved successfully, with the raw app connections for the response header.
+    Resolved {
+        rules: ResolvedRules,
+        app_connections: Vec<db::AppConnectionRow>,
+    },
+    /// Multiple connections exist and no header was provided.
+    Ambiguous(Vec<ConnectionChoice>),
+    /// The requested connection ID was not found.
+    NotFound {
+        connection_id: String,
+        connections: Vec<ConnectionChoice>,
+    },
+}
+
+/// Resolve injection + policy rules from cache, with per-request app connection
+/// disambiguation. Falls back to vault rules if no DB secrets or app connections
+/// are configured for this host.
 async fn resolve_rules(
     ctx: &ProxyContext,
     hostname: &str,
     engine: &PolicyEngine,
     cache: &dyn CacheStore,
     vault_rules: &[InjectionRule],
-) -> Result<ResolvedRules, crate::connect::ConnectError> {
+    connection_id: Option<&str>,
+) -> Result<ResolveResult, crate::connect::ConnectError> {
     let account_id = ctx.account_id.as_deref().unwrap_or("");
     let agent_token = ctx.agent_token.as_deref().unwrap_or("");
 
     let resp =
         connect::resolve_from_cache(account_id, agent_token, hostname, engine, cache).await?;
 
-    let injection_rules = if resp.injection_rules.is_empty() && !vault_rules.is_empty() {
-        vault_rules.to_vec()
-    } else {
-        resp.injection_rules
-    };
+    let mut injection_rules = resp.injection_rules; // from secrets
 
-    Ok(ResolvedRules {
-        injection_rules,
-        policy_rules: resp.policy_rules,
-        access_restricted: resp.access_restricted,
+    // If no secret rules, try app connections (per-request disambiguation)
+    if injection_rules.is_empty() && !resp.app_connections.is_empty() {
+        match engine
+            .resolve_app_injection_for_request(
+                &resp.app_connections,
+                hostname,
+                connection_id,
+                account_id,
+                cache,
+            )
+            .await?
+        {
+            AppConnectionResult::Rules(rules) => injection_rules = rules,
+            AppConnectionResult::Ambiguous { connections } => {
+                return Ok(ResolveResult::Ambiguous(connections));
+            }
+            AppConnectionResult::NotFound { connections } => {
+                return Ok(ResolveResult::NotFound {
+                    connection_id: connection_id.unwrap_or("").to_string(),
+                    connections,
+                });
+            }
+            AppConnectionResult::NoConnections => {}
+        }
+    }
+
+    // Vault fallback
+    if injection_rules.is_empty() && !vault_rules.is_empty() {
+        injection_rules = vault_rules.to_vec();
+    }
+
+    Ok(ResolveResult::Resolved {
+        rules: ResolvedRules {
+            injection_rules,
+            policy_rules: resp.policy_rules,
+            access_restricted: resp.access_restricted,
+        },
+        app_connections: resp.app_connections,
     })
 }

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -21,22 +21,71 @@ pub(super) fn proxy_auth_required() -> Response<axum::body::Body> {
 pub(crate) type ForwardBody<S> = Either<Full<Bytes>, S>;
 
 /// Resolve the OneCLI dashboard base URL from `APP_URL`,
-/// falling back to `http://localhost:10254`.
-fn dashboard_url() -> String {
-    std::env::var("APP_URL")
-        .unwrap_or_else(|_| "http://localhost:10254".to_string())
-        .trim_end_matches('/')
-        .to_string()
+/// falling back to `http://localhost:10254`. Cached after first call.
+fn dashboard_url() -> &'static str {
+    static URL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    URL.get_or_init(|| {
+        std::env::var("APP_URL")
+            .unwrap_or_else(|_| "http://localhost:10254".to_string())
+            .trim_end_matches('/')
+            .to_string()
+    })
 }
 
 /// Build a JSON error response with the given status code and body.
+/// Used by `forward_request` (MITM and HTTP proxy forwarding path).
 fn json_error<S>(status: StatusCode, body: serde_json::Value) -> Response<ForwardBody<S>> {
-    let mut response = Response::new(Either::Left(Full::new(Bytes::from(body.to_string()))));
+    let json = body.to_string();
+    let mut response = Response::new(Either::Left(Full::new(Bytes::from(json))));
     *response.status_mut() = status;
     response
         .headers_mut()
         .insert("content-type", HeaderValue::from_static("application/json"));
     response
+}
+
+/// Build a JSON error response with `axum::body::Body`.
+/// Used by `handle_connect` and `handle_http_proxy` (before forwarding).
+fn json_error_axum(status: StatusCode, body: serde_json::Value) -> Response<axum::body::Body> {
+    let json = body.to_string();
+    let mut response = Response::new(axum::body::Body::from(json));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert("content-type", HeaderValue::from_static("application/json"));
+    response
+}
+
+/// 502 Bad Gateway — generic internal error (axum body).
+pub(super) fn bad_gateway() -> Response<axum::body::Body> {
+    json_error_axum(
+        StatusCode::BAD_GATEWAY,
+        serde_json::json!({
+            "error": "bad_gateway",
+            "message": "OneCLI gateway internal error.",
+        }),
+    )
+}
+
+/// Build the shared JSON body for multiple-connections responses.
+fn multiple_connections_json(
+    connections: &[crate::connect::ConnectionChoice],
+) -> serde_json::Value {
+    let hdr = crate::connect::CONNECTION_ID_HEADER;
+    serde_json::json!({
+        "error": "multiple_connections",
+        "message": format!("Multiple connections exist for this provider. Specify which one to use with the {hdr} header."),
+        "connections": connections,
+        "header": hdr,
+        "example": format!("{hdr}: {}", connections.first().map(|c| c.id.as_str()).unwrap_or("CONNECTION_ID")),
+    })
+}
+
+/// 409 Conflict — multiple connections, agent must specify which one (axum body).
+pub(super) fn multiple_connections_axum(
+    connections: &[crate::connect::ConnectionChoice],
+) -> Response<axum::body::Body> {
+    json_error_axum(StatusCode::CONFLICT, multiple_connections_json(connections))
 }
 
 /// JSON error response for requests to a known app that has no credentials configured.
@@ -129,6 +178,47 @@ pub(crate) fn credential_not_found<S>(
             "hostname": hostname,
             "path": path,
             "secret_url": secret_url,
+        }),
+    )
+}
+
+/// 409 Conflict — multiple connections exist for the same provider, agent must specify which one.
+pub(crate) fn multiple_connections<S>(
+    connections: &[crate::connect::ConnectionChoice],
+) -> Response<ForwardBody<S>> {
+    json_error(StatusCode::CONFLICT, multiple_connections_json(connections))
+}
+
+/// 404 Not Found — the requested connection ID does not exist.
+pub(crate) fn connection_not_found<S>(
+    connection_id: &str,
+    connections: &[crate::connect::ConnectionChoice],
+) -> Response<ForwardBody<S>> {
+    let hdr = crate::connect::CONNECTION_ID_HEADER;
+    json_error(
+        StatusCode::NOT_FOUND,
+        serde_json::json!({
+            "error": "connection_not_found",
+            "message": format!("Connection '{connection_id}' was not found or has been removed. Choose from the available connections."),
+            "connections": connections,
+            "header": hdr,
+        }),
+    )
+}
+
+/// 404 Not Found — the requested connection ID does not exist (axum body).
+pub(super) fn connection_not_found_axum(
+    connection_id: &str,
+    connections: &[crate::connect::ConnectionChoice],
+) -> Response<axum::body::Body> {
+    let hdr = crate::connect::CONNECTION_ID_HEADER;
+    json_error_axum(
+        StatusCode::NOT_FOUND,
+        serde_json::json!({
+            "error": "connection_not_found",
+            "message": format!("Connection '{connection_id}' was not found or has been removed. Choose from the available connections."),
+            "connections": connections,
+            "header": hdr,
         }),
     )
 }
@@ -405,6 +495,58 @@ mod tests {
         assert!(
             !secret_url.contains("method="),
             "method should not be in URL"
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_connections_returns_409_with_choices() {
+        type TestBody = ForwardBody<
+            futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+        >;
+        let connections = vec![
+            crate::connect::ConnectionChoice {
+                id: "conn_1".to_string(),
+                label: Some("alice@gmail.com".to_string()),
+                provider: "gmail".to_string(),
+            },
+            crate::connect::ConnectionChoice {
+                id: "conn_2".to_string(),
+                label: Some("alice.work@company.com".to_string()),
+                provider: "gmail".to_string(),
+            },
+        ];
+        let resp: Response<TestBody> = multiple_connections(&connections);
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        use http_body_util::BodyExt;
+        let body = match resp.into_body() {
+            Either::Left(full) => full.collect().await.expect("collect").to_bytes(),
+            Either::Right(_) => panic!("expected Left"),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert_eq!(json["error"], "multiple_connections");
+        assert_eq!(json["header"], crate::connect::CONNECTION_ID_HEADER);
+        let conns = json["connections"].as_array().unwrap();
+        assert_eq!(conns.len(), 2);
+        assert_eq!(conns[0]["id"], "conn_1");
+        assert_eq!(conns[0]["label"], "alice@gmail.com");
+        assert_eq!(conns[1]["id"], "conn_2");
+        let example = json["example"].as_str().unwrap();
+        assert!(example.contains(crate::connect::CONNECTION_ID_HEADER));
+        assert!(example.contains("conn_1"));
+    }
+
+    #[test]
+    fn multiple_connections_empty_list() {
+        let resp: Response<
+            ForwardBody<
+                futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>,
+            >,
+        > = multiple_connections(&[]);
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "application/json"
         );
     }
 }

--- a/apps/web/src/app/(connect)/app-connect/[provider]/page.tsx
+++ b/apps/web/src/app/(connect)/app-connect/[provider]/page.tsx
@@ -5,12 +5,16 @@ import { ConnectFlow } from "../_components/connect-flow";
 
 interface Props {
   params: Promise<{ provider: string }>;
-  searchParams: Promise<{ status?: string; message?: string }>;
+  searchParams: Promise<{
+    status?: string;
+    message?: string;
+    connectionId?: string;
+  }>;
 }
 
 export default async function ConnectPage({ params, searchParams }: Props) {
   const { provider } = await params;
-  const { status, message } = await searchParams;
+  const { status, message, connectionId } = await searchParams;
 
   const app = getApp(provider);
   if (!app || !app.available) notFound();
@@ -45,8 +49,9 @@ export default async function ConnectPage({ params, searchParams }: Props) {
             : undefined,
       }}
       hasDefaults={hasEnvDefaults || hasAppConfig}
-      status={status as "success" | "error" | undefined}
+      status={status === "success" || status === "error" ? status : undefined}
       errorMessage={message}
+      connectionId={connectionId}
     />
   );
 }

--- a/apps/web/src/app/(connect)/app-connect/_components/connect-flow.tsx
+++ b/apps/web/src/app/(connect)/app-connect/_components/connect-flow.tsx
@@ -28,6 +28,7 @@ interface ConnectFlowProps {
   hasDefaults: boolean;
   status?: "success" | "error";
   errorMessage?: string;
+  connectionId?: string;
 }
 
 export const ConnectFlow = ({
@@ -35,6 +36,7 @@ export const ConnectFlow = ({
   hasDefaults,
   status,
   errorMessage,
+  connectionId,
 }: ConnectFlowProps) => {
   const [state, setState] = useState<FlowState>(
     status === "success" ? "success" : status === "error" ? "error" : "ready",
@@ -47,8 +49,11 @@ export const ConnectFlow = ({
     if (redirectedRef.current) return;
     redirectedRef.current = true;
     setState("redirecting");
-    window.location.href = `/api/apps/${app.id}/authorize`;
-  }, [app.id]);
+    const authorizeUrl = connectionId
+      ? `/api/apps/${app.id}/authorize?connectionId=${connectionId}`
+      : `/api/apps/${app.id}/authorize`;
+    window.location.href = authorizeUrl;
+  }, [app.id, connectionId]);
 
   // Countdown timer for auto-redirect
   useEffect(() => {
@@ -93,6 +98,7 @@ export const ConnectFlow = ({
       <ApiKeyFlow
         app={app}
         fields={app.fields}
+        connectionId={connectionId}
         onSuccess={() => setState("success")}
         onError={(msg) => {
           setError(msg);
@@ -220,7 +226,9 @@ export const ConnectFlow = ({
           </p>
           {isRedirecting ? null : (
             <p className="text-sm text-muted-foreground mt-0.5">
-              Please authenticate to continue
+              {connectionId
+                ? "Re-authenticate to refresh your credentials"
+                : "Please authenticate to continue"}
             </p>
           )}
         </div>
@@ -257,11 +265,18 @@ interface ApiKeyFlowProps {
     description?: string;
     placeholder: string;
   }[];
+  connectionId?: string;
   onSuccess: () => void;
   onError: (message: string) => void;
 }
 
-const ApiKeyFlow = ({ app, fields, onSuccess, onError }: ApiKeyFlowProps) => {
+const ApiKeyFlow = ({
+  app,
+  fields,
+  connectionId,
+  onSuccess,
+  onError,
+}: ApiKeyFlowProps) => {
   const [values, setValues] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
 
@@ -274,7 +289,7 @@ const ApiKeyFlow = ({ app, fields, onSuccess, onError }: ApiKeyFlowProps) => {
       const resp = await fetch(`/api/apps/${app.id}/connect`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ fields: values }),
+        body: JSON.stringify({ fields: values, connectionId }),
       });
       if (!resp.ok) {
         const data = (await resp.json()) as { error?: string };

--- a/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
@@ -43,6 +43,7 @@ export const GetStartedDialog = ({
   const [activeSection, setActiveSection] = useState<
     "install" | "gateway" | null
   >("install");
+  const [installMode, setInstallMode] = useState<"new" | "migrate">("new");
 
   useEffect(() => {
     if (!open) return;
@@ -56,14 +57,17 @@ export const GetStartedDialog = ({
       .finally(() => setLoading(false));
   }, [open]);
 
-  const installCommand = (() => {
+  const buildCurlCommand = (path: string) => {
     if (!installInfo?.apiKey || !IS_CLOUD) return null;
     const params = [`key=${installInfo.apiKey}`];
     if (installInfo.appUrl !== "https://app.onecli.sh") {
       params.push(`url=${encodeURIComponent(installInfo.appUrl)}`);
     }
-    return `curl -fsSL ${installInfo.appUrl}/api/install/nanoclaw?${params.join("&")} | sh`;
-  })();
+    return `curl -fsSL ${installInfo.appUrl}/api/install/${path}?${params.join("&")} | sh`;
+  };
+
+  const installCommand = buildCurlCommand("nanoclaw");
+  const migrateCommand = buildCurlCommand("cloud");
 
   const demoCommand = demoInfo
     ? `curl -k -x http://x:${demoInfo.agentToken}@${demoInfo.gatewayUrl} -H "Authorization: Bearer FAKE_TOKEN" https://httpbin.org/anything`
@@ -118,34 +122,79 @@ export const GetStartedDialog = ({
             <div className="mt-4">
               {activeSection === "install" && (
                 <div className="space-y-3">
-                  {installCommand ? (
+                  {IS_CLOUD && (installCommand || migrateCommand) ? (
                     <>
-                      <p className="text-muted-foreground text-xs">
-                        Run this in your terminal:
-                      </p>
-                      <TryDemoCommand command={installCommand} />
-                      <div className="text-muted-foreground space-y-1 text-xs">
-                        <p>Then complete setup:</p>
-                        <ol className="list-inside list-decimal space-y-0.5 pl-1">
-                          <li>
-                            <code className="bg-muted rounded px-1 py-0.5 text-[10px]">
-                              cd nanoclaw
-                            </code>
-                          </li>
-                          <li>
-                            <code className="bg-muted rounded px-1 py-0.5 text-[10px]">
-                              claude
-                            </code>
-                          </li>
-                          <li>
-                            Type{" "}
-                            <code className="bg-muted rounded px-1 py-0.5 text-[10px]">
-                              /setup
-                            </code>{" "}
-                            and follow the prompts
-                          </li>
-                        </ol>
+                      <div className="flex gap-1 rounded-md border p-0.5">
+                        <button
+                          type="button"
+                          onClick={() => setInstallMode("new")}
+                          className={cn(
+                            "flex-1 rounded-sm px-2 py-1 text-xs font-medium transition-colors",
+                            installMode === "new"
+                              ? "bg-muted text-foreground"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          New install
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setInstallMode("migrate")}
+                          className={cn(
+                            "flex-1 rounded-sm px-2 py-1 text-xs font-medium transition-colors",
+                            installMode === "migrate"
+                              ? "bg-muted text-foreground"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          Migrate from local
+                        </button>
                       </div>
+
+                      {installMode === "new" && installCommand && (
+                        <>
+                          <p className="text-muted-foreground text-xs">
+                            Run this in your terminal:
+                          </p>
+                          <TryDemoCommand command={installCommand} />
+                          <div className="text-muted-foreground space-y-1 text-xs">
+                            <p>Then complete setup:</p>
+                            <ol className="list-inside list-decimal space-y-0.5 pl-1">
+                              <li>
+                                <code className="bg-muted rounded px-1 py-0.5 text-[10px]">
+                                  cd nanoclaw
+                                </code>
+                              </li>
+                              <li>
+                                <code className="bg-muted rounded px-1 py-0.5 text-[10px]">
+                                  claude
+                                </code>
+                              </li>
+                              <li>
+                                Type{" "}
+                                <code className="bg-muted rounded px-1 py-0.5 text-[10px]">
+                                  /setup
+                                </code>{" "}
+                                and follow the prompts
+                              </li>
+                            </ol>
+                          </div>
+                        </>
+                      )}
+
+                      {installMode === "migrate" && migrateCommand && (
+                        <>
+                          <p className="text-muted-foreground text-xs">
+                            Already running OneCLI locally? Migrate to cloud:
+                          </p>
+                          <TryDemoCommand command={migrateCommand} />
+                          <p className="text-muted-foreground text-xs">
+                            This updates your CLI config, NanoClaw .env, and
+                            restarts the service. Secrets and app connections
+                            need to be re-added in the dashboard.
+                          </p>
+                        </>
+                      )}
                     </>
                   ) : IS_CLOUD ? (
                     <div className="flex items-center justify-center py-6">

--- a/apps/web/src/app/(dashboard)/agents/_components/manage-access-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/manage-access-dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useState, useCallback, useMemo } from "react";
-import Image from "next/image";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
+import { AppIcon } from "@/app/(dashboard)/connections/_components/app-icon";
 import {
   KeyRound,
   Loader2,
@@ -35,6 +35,7 @@ import {
   updateAgentAppConnections,
 } from "@/lib/actions/agents";
 import { getApp } from "@/lib/apps/registry";
+import { extractLabel } from "@/lib/services/connection-service";
 import type { SecretMode } from "@/lib/services/agent-service";
 
 interface ManageAccessDialogProps {
@@ -119,14 +120,29 @@ export const ManageAccessDialog = ({
     return appConnections.filter((c) => {
       const app = getApp(c.provider);
       const name = app?.name ?? c.provider;
-      const meta = c.metadata as { username?: string } | null;
+      const meta = c.metadata as {
+        username?: string;
+        email?: string;
+        name?: string;
+      } | null;
       return (
         name.toLowerCase().includes(q) ||
         c.provider.toLowerCase().includes(q) ||
-        (meta?.username?.toLowerCase().includes(q) ?? false)
+        (c.label?.toLowerCase().includes(q) ?? false) ||
+        (meta?.email?.toLowerCase().includes(q) ?? false) ||
+        (meta?.username?.toLowerCase().includes(q) ?? false) ||
+        (meta?.name?.toLowerCase().includes(q) ?? false)
       );
     });
   }, [appConnections, search]);
+
+  const providerCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    appConnections.forEach((c) =>
+      counts.set(c.provider, (counts.get(c.provider) ?? 0) + 1),
+    );
+    return counts;
+  }, [appConnections]);
 
   const toggleSecret = (secretId: string) => {
     setSelectedSecretIds((prev) => {
@@ -362,9 +378,19 @@ export const ManageAccessDialog = ({
                         </div>
                         {filteredAppConnections.map((conn) => {
                           const app = getApp(conn.provider);
-                          const meta = conn.metadata as {
-                            username?: string;
-                          } | null;
+                          const meta = conn.metadata as Record<
+                            string,
+                            unknown
+                          > | null;
+                          const label =
+                            conn.label ?? extractLabel(meta ?? undefined);
+                          const baseName = app?.name ?? conn.provider;
+                          const hasMultiple =
+                            (providerCounts.get(conn.provider) ?? 0) > 1;
+                          const displayName =
+                            hasMultiple && label
+                              ? `${baseName} - ${label}`
+                              : baseName;
                           return (
                             <label
                               key={conn.id}
@@ -378,21 +404,20 @@ export const ManageAccessDialog = ({
                               />
                               <div className="flex min-w-0 flex-1 items-center gap-2.5">
                                 {app?.icon && (
-                                  <Image
-                                    src={app.icon}
-                                    alt=""
-                                    width={16}
-                                    height={16}
-                                    className="size-4 shrink-0"
+                                  <AppIcon
+                                    icon={app.icon}
+                                    darkIcon={app.darkIcon}
+                                    name={baseName}
+                                    size={16}
                                   />
                                 )}
                                 <div className="min-w-0">
                                   <p className="truncate text-sm font-medium">
-                                    {app?.name ?? conn.provider}
+                                    {displayName}
                                   </p>
-                                  {meta?.username && (
+                                  {!hasMultiple && label && (
                                     <p className="text-muted-foreground truncate text-xs">
-                                      {meta.username}
+                                      {label}
                                     </p>
                                   )}
                                 </div>
@@ -401,7 +426,7 @@ export const ManageAccessDialog = ({
                                 variant="secondary"
                                 className="shrink-0 text-xs"
                               >
-                                {conn.provider}
+                                {app?.name ?? conn.provider}
                               </Badge>
                             </label>
                           );

--- a/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
@@ -3,21 +3,9 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, Loader2 } from "lucide-react";
-import { toast } from "sonner";
 import { Button } from "@onecli/ui/components/button";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@onecli/ui/components/alert-dialog";
 import { Skeleton } from "@onecli/ui/components/skeleton";
-import { getAppConnections, disconnectApp } from "@/lib/actions/connections";
+import { getAppConnections } from "@/lib/actions/connections";
 import { checkAppConfigExists } from "@/lib/actions/app-config";
 import { useAppMessages } from "@/hooks/use-app-connected";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
@@ -25,6 +13,7 @@ import type { OAuthPermission } from "@/lib/apps/types";
 import { AppIcon } from "./app-icon";
 import { AppConfigForm } from "./app-config-form";
 import { ConfigureCredentialsDialog } from "./configure-credentials-dialog";
+import { ConnectionCard } from "./connection-card";
 import { PermissionsList } from "./permissions-list";
 
 interface AppDetailProps {
@@ -54,6 +43,7 @@ interface AppDetailProps {
 
 interface ConnectionData {
   id: string;
+  label: string | null;
   provider: string;
   status: string;
   scopes: string[];
@@ -67,26 +57,22 @@ export const AppDetail = ({
   hasEnvDefaults,
   hasAppConfig,
 }: AppDetailProps) => {
-  const [connection, setConnection] = useState<ConnectionData | null>(null);
+  const [connections, setConnections] = useState<ConnectionData[]>([]);
   const [loading, setLoading] = useState(true);
   const [configDialogOpen, setConfigDialogOpen] = useState(false);
   const [configVersion, setConfigVersion] = useState(0);
   const [appConfigured, setAppConfigured] = useState(hasAppConfig);
 
-  const fetchConnection = useCallback(async () => {
+  const fetchConnections = useCallback(async () => {
     try {
-      const connections = await getAppConnections();
-      const match = connections.find(
-        (c) => c.provider === app.id && c.status === "connected",
-      );
-      setConnection(
-        match
-          ? {
-              ...match,
-              metadata: match.metadata as Record<string, unknown> | null,
-            }
-          : null,
-      );
+      const allConnections = await getAppConnections();
+      const matches = allConnections
+        .filter((c) => c.provider === app.id && c.status === "connected")
+        .map((c) => ({
+          ...c,
+          metadata: c.metadata as Record<string, unknown> | null,
+        }));
+      setConnections(matches);
     } catch {
       // Connection fetch failed — show as disconnected
     } finally {
@@ -95,38 +81,41 @@ export const AppDetail = ({
   }, [app.id]);
 
   useEffect(() => {
-    fetchConnection();
-  }, [fetchConnection]);
+    fetchConnections();
+  }, [fetchConnections]);
 
   const invalidateCache = useInvalidateGatewayCache();
 
   const handleConnected = useCallback(() => {
-    fetchConnection();
+    fetchConnections();
     invalidateCache();
-  }, [fetchConnection, invalidateCache]);
+  }, [fetchConnections, invalidateCache]);
 
   useAppMessages({ onConnected: handleConnected });
 
   const refreshConfigStatus = useCallback(async () => {
-    fetchConnection();
+    fetchConnections();
     try {
       const exists = await checkAppConfigExists(app.id);
       setAppConfigured(exists);
     } catch {
       // ignore
     }
-  }, [app.id, fetchConnection]);
+  }, [app.id, fetchConnections]);
 
   const hasCredentials = hasEnvDefaults || appConfigured;
 
-  const openConnectPopup = () => {
+  const openConnectPopup = (connectionId?: string) => {
     const w = 520;
     const h = 700;
     const left = Math.round(window.screenX + (window.outerWidth - w) / 2);
     const top = Math.round(window.screenY + (window.outerHeight - h) / 2);
+    const url = connectionId
+      ? `/app-connect/${app.id}?connectionId=${connectionId}`
+      : `/app-connect/${app.id}`;
     window.open(
-      `/app-connect/${app.id}`,
-      `connect-${app.id}`,
+      url,
+      `connect-${app.id}-${connectionId ?? "new"}`,
       `width=${w},height=${h},left=${left},top=${top},scrollbars=yes,resizable=yes`,
     );
   };
@@ -139,18 +128,8 @@ export const AppDetail = ({
     openConnectPopup();
   };
 
-  const handleDisconnect = async () => {
-    try {
-      await disconnectApp(app.id);
-      setConnection(null);
-      invalidateCache();
-      toast.success(`${app.name} disconnected`);
-    } catch {
-      toast.error("Failed to disconnect");
-    }
-  };
-
-  const isConnected = !!connection;
+  const connectionCount = connections.length;
+  const isConnected = connectionCount > 0;
 
   return (
     <div className="space-y-6">
@@ -183,7 +162,9 @@ export const AppDetail = ({
                 <div className="flex items-center gap-1.5">
                   <span className="size-2 rounded-full bg-brand" />
                   <span className="text-xs font-medium text-brand">
-                    Connected
+                    {connectionCount > 1
+                      ? `${connectionCount} accounts connected`
+                      : "Connected"}
                   </span>
                 </div>
               )}
@@ -200,43 +181,9 @@ export const AppDetail = ({
         ) : (
           <div className="flex items-center gap-2 shrink-0">
             {isConnected ? (
-              <>
-                <Button variant="outline" size="sm" onClick={handleConnect}>
-                  Reconnect
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                    >
-                      Disconnect
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>
-                        Disconnect {app.name}?
-                      </AlertDialogTitle>
-                      <AlertDialogDescription>
-                        This will revoke access and remove the stored
-                        credentials. Agents using this connection will no longer
-                        be able to authenticate with {app.name}.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={handleDisconnect}
-                        variant="destructive"
-                      >
-                        Disconnect
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </>
+              <Button variant="outline" size="sm" onClick={handleConnect}>
+                Connect Another Account
+              </Button>
             ) : (
               <Button size="sm" onClick={handleConnect}>
                 Connect {app.name}
@@ -252,11 +199,27 @@ export const AppDetail = ({
         </div>
       ) : (
         <>
-          {isConnected && <ConnectionInfo connection={connection} />}
+          {isConnected && (
+            <div className="space-y-2">
+              {connections.map((conn) => (
+                <ConnectionCard
+                  key={conn.id}
+                  connection={conn}
+                  appName={app.name}
+                  onReconnect={openConnectPopup}
+                  onDisconnected={fetchConnections}
+                />
+              ))}
+            </div>
+          )}
           {app.permissions.length > 0 && (
             <PermissionsList
               permissions={app.permissions}
-              grantedScopes={isConnected ? connection.scopes : undefined}
+              grantedScopes={
+                isConnected
+                  ? [...new Set(connections.flatMap((c) => c.scopes))]
+                  : undefined
+              }
             />
           )}
         </>
@@ -291,34 +254,6 @@ export const AppDetail = ({
           }}
         />
       )}
-    </div>
-  );
-};
-
-const ConnectionInfo = ({ connection }: { connection: ConnectionData }) => {
-  const username =
-    (connection.metadata?.username as string) ??
-    (connection.metadata?.name as string);
-
-  return (
-    <div className="space-y-5">
-      {/* Key-value metadata */}
-      <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
-        {username && (
-          <>
-            <span className="text-muted-foreground">Account</span>
-            <span className="font-medium">{username}</span>
-          </>
-        )}
-        <span className="text-muted-foreground">Connected</span>
-        <span className="font-medium">
-          {new Date(connection.connectedAt).toLocaleDateString("en-US", {
-            month: "long",
-            day: "numeric",
-            year: "numeric",
-          })}
-        </span>
-      </div>
     </div>
   );
 };

--- a/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
@@ -22,8 +22,8 @@ import { useConnectParam } from "./use-connect-param";
 
 export const AppsTab = () => {
   const router = useRouter();
-  const [connectedProviders, setConnectedProviders] = useState<Set<string>>(
-    () => new Set(),
+  const [connectionCounts, setConnectionCounts] = useState<Map<string, number>>(
+    () => new Map(),
   );
   const [configuredProviders, setConfiguredProviders] = useState<Set<string>>(
     () => new Set(),
@@ -42,13 +42,11 @@ export const AppsTab = () => {
         getAvailableEnvDefaults(),
         getConfiguredProviders().catch(() => [] as string[]),
       ]);
-      setConnectedProviders(
-        new Set(
-          connections
-            .filter((c) => c.status === "connected")
-            .map((c) => c.provider),
-        ),
-      );
+      const counts = new Map<string, number>();
+      for (const c of connections.filter((c) => c.status === "connected")) {
+        counts.set(c.provider, (counts.get(c.provider) ?? 0) + 1);
+      }
+      setConnectionCounts(counts);
       setEnvDefaultProviders(new Set(availableDefaults));
       setConfiguredProviders(new Set(configured));
     } catch {
@@ -83,6 +81,13 @@ export const AppsTab = () => {
     );
   };
 
+  // Derived set for backward-compat with useConnectParam
+  const connectedProviders = new Set(
+    [...connectionCounts.entries()]
+      .filter(([, count]) => count > 0)
+      .map(([provider]) => provider),
+  );
+
   // Handle ?connect=<provider> URL param
   useConnectParam({
     loading,
@@ -100,7 +105,7 @@ export const AppsTab = () => {
     if (
       app.configurable?.fields &&
       !hasCredentials &&
-      !connectedProviders.has(app.id)
+      (connectionCounts.get(app.id) ?? 0) === 0
     ) {
       setConfigApp(app);
       return;
@@ -112,14 +117,14 @@ export const AppsTab = () => {
     <>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {apps.map((app) => {
-          const isConnected = connectedProviders.has(app.id);
+          const count = connectionCounts.get(app.id) ?? 0;
           return (
             <AppRow
               key={app.id}
               name={app.name}
               icon={app.icon}
               darkIcon={app.darkIcon}
-              connected={isConnected}
+              connectionCount={count}
               loading={loading}
               onConnect={(e) => handleConnect(e, app)}
               onClick={() => router.push(`/connections/apps/${app.id}`)}
@@ -173,7 +178,7 @@ interface AppRowProps {
   name: string;
   icon: string;
   darkIcon?: string;
-  connected: boolean;
+  connectionCount: number;
   loading: boolean;
   onConnect: (e: React.MouseEvent) => void;
   onClick: () => void;
@@ -183,11 +188,12 @@ const AppRow = ({
   name,
   icon,
   darkIcon,
-  connected,
+  connectionCount,
   loading,
   onConnect,
   onClick,
 }: AppRowProps) => {
+  const connected = connectionCount > 0;
   return (
     <div
       className={cn(
@@ -209,7 +215,9 @@ const AppRow = ({
         ) : connected ? (
           <div className="flex items-center gap-1.5">
             <span className="size-2 rounded-full bg-brand" />
-            <span className="text-xs font-medium text-brand">Connected</span>
+            <span className="text-xs font-medium text-brand">
+              Connected{connectionCount > 1 ? ` (${connectionCount})` : ""}
+            </span>
           </div>
         ) : (
           <Button size="xs" onClick={onConnect}>

--- a/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
@@ -12,17 +12,20 @@ import {
 import { getSecrets } from "@/lib/actions/secrets";
 import { getApp } from "@/lib/apps/registry";
 import { useAppMessages } from "@/hooks/use-app-connected";
+import { extractLabel } from "@/lib/services/connection-service";
 import { AppIcon } from "./app-icon";
 import { SecretDialog } from "./secret-dialog";
 
 interface ConnectedItem {
   id: string;
   name: string;
+  label?: string | null;
   icon: string | null;
   darkIcon?: string;
   type: "app" | "secret" | "vault";
   typeLabel: string;
   detail: string;
+  providerCount?: number;
   href?: string;
   secretData?: {
     id: string;
@@ -52,25 +55,39 @@ export const ConnectedTab = () => {
         getVaultConnections(),
       ]);
 
-      const appItems: ConnectedItem[] = connections
-        .filter((c) => c.status === "connected")
-        .map((c) => {
-          const appDef = getApp(c.provider);
-          const metadata = c.metadata as Record<string, unknown> | null;
-          return {
-            id: `app-${c.provider}`,
-            name: appDef?.name ?? c.provider,
-            icon: appDef?.icon ?? null,
-            darkIcon: appDef?.darkIcon,
-            type: "app" as const,
-            typeLabel:
-              appDef?.connectionMethod.type === "oauth" ? "OAuth" : "API Key",
-            detail: metadata?.username
-              ? `Connected as ${metadata.username}`
-              : `${c.scopes.length} scope${c.scopes.length !== 1 ? "s" : ""} granted`,
-            href: `/connections/apps/${c.provider}`,
-          };
-        });
+      const connectedApps = connections.filter((c) => c.status === "connected");
+      const providerCounts = new Map<string, number>();
+      connectedApps.forEach((c) =>
+        providerCounts.set(
+          c.provider,
+          (providerCounts.get(c.provider) ?? 0) + 1,
+        ),
+      );
+
+      const appItems: ConnectedItem[] = connectedApps.map((c) => {
+        const appDef = getApp(c.provider);
+        const metadata = c.metadata as Record<string, unknown> | null;
+        const label = c.label ?? extractLabel(metadata ?? undefined);
+        const baseName = appDef?.name ?? c.provider;
+        const hasMultiple = (providerCounts.get(c.provider) ?? 0) > 1;
+        return {
+          id: `app-${c.id}`,
+          name: hasMultiple && label ? `${baseName} - ${label}` : baseName,
+          label,
+          icon: appDef?.icon ?? null,
+          darkIcon: appDef?.darkIcon,
+          type: "app" as const,
+          typeLabel:
+            appDef?.connectionMethod.type === "oauth" ? "OAuth" : "API Key",
+          detail: label
+            ? `Connected as ${label}`
+            : `${c.scopes.length} scope${c.scopes.length !== 1 ? "s" : ""} granted`,
+          href: `/connections/apps/${c.provider}`,
+          providerCount: hasMultiple
+            ? providerCounts.get(c.provider)
+            : undefined,
+        };
+      });
 
       const secretItems: ConnectedItem[] = secrets.map((s) => ({
         id: `secret-${s.id}`,
@@ -191,7 +208,11 @@ export const ConnectedTab = () => {
                 <div className="flex items-center gap-1.5">
                   <span className="size-2 rounded-full bg-brand" />
                   <span className="text-xs text-brand font-medium">
-                    {item.type === "secret" ? "Active" : "Connected"}
+                    {item.type === "secret"
+                      ? "Active"
+                      : item.providerCount
+                        ? `Connected (${item.providerCount})`
+                        : "Connected"}
                   </span>
                 </div>
                 <ChevronRight className="size-3.5 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground" />

--- a/apps/web/src/app/(dashboard)/connections/_components/connection-card.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/connection-card.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { Button } from "@onecli/ui/components/button";
+import { Card } from "@onecli/ui/components/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@onecli/ui/components/alert-dialog";
+import { disconnectAppConnection } from "@/lib/actions/connections";
+import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
+import { extractLabel } from "@/lib/services/connection-service";
+
+interface ConnectionCardProps {
+  connection: {
+    id: string;
+    label: string | null;
+    status: string;
+    scopes: string[];
+    metadata: Record<string, unknown> | null;
+    connectedAt: Date;
+  };
+  appName: string;
+  onReconnect: (connectionId: string) => void;
+  onDisconnected: () => void;
+}
+
+export const ConnectionCard = ({
+  connection,
+  appName,
+  onReconnect,
+  onDisconnected,
+}: ConnectionCardProps) => {
+  const [disconnecting, setDisconnecting] = useState(false);
+  const invalidateCache = useInvalidateGatewayCache();
+
+  const displayName =
+    connection.label ??
+    extractLabel(connection.metadata ?? undefined) ??
+    "Unknown account";
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await disconnectAppConnection(connection.id);
+      invalidateCache();
+      onDisconnected();
+      toast.success(`${appName} account disconnected`);
+    } catch {
+      toast.error("Failed to disconnect");
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  return (
+    <Card className="flex-row items-center justify-between gap-3 px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">{displayName}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Connected{" "}
+          {new Date(connection.connectedAt).toLocaleDateString("en-US", {
+            month: "long",
+            day: "numeric",
+            year: "numeric",
+          })}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onReconnect(connection.id)}
+        >
+          Reconnect
+        </Button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+              disabled={disconnecting}
+            >
+              {disconnecting ? (
+                <>
+                  <Loader2 className="size-3.5 animate-spin" />
+                  Disconnecting...
+                </>
+              ) : (
+                "Disconnect"
+              )}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Disconnect {displayName}?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will revoke access and remove the stored credentials for
+                this {appName} account. Agents using this connection will no
+                longer be able to authenticate.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDisconnect}
+                variant="destructive"
+                disabled={disconnecting}
+              >
+                {disconnecting ? (
+                  <>
+                    <Loader2 className="size-3.5 animate-spin" />
+                    Disconnecting...
+                  </>
+                ) : (
+                  "Disconnect"
+                )}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </Card>
+  );
+};

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -324,7 +324,7 @@ export const SecretDialog = ({
                 </div>
               </div>
 
-              {type === "generic" && (
+              {type === "generic" && !prefill && (
                 <div className="space-y-2">
                   <Label htmlFor="secret-host">Host pattern</Label>
                   <Input
@@ -345,7 +345,12 @@ export const SecretDialog = ({
                 </div>
               )}
 
-              <Accordion type="single" collapsible className="border-none">
+              <Accordion
+                type="single"
+                collapsible
+                className="border-none"
+                defaultValue={undefined}
+              >
                 <AccordionItem value="advanced" className="border-t border-b-0">
                   <AccordionTrigger className="py-3 hover:no-underline">
                     <span className="text-muted-foreground flex items-center gap-2 text-xs font-normal">
@@ -355,7 +360,8 @@ export const SecretDialog = ({
                   </AccordionTrigger>
                   <AccordionContent className="pb-0">
                     <div className="space-y-4">
-                      {type === "anthropic" && (
+                      {(type === "anthropic" ||
+                        (type === "generic" && !!prefill)) && (
                         <div className="space-y-2">
                           <Label htmlFor="secret-host">Host pattern</Label>
                           <Input
@@ -363,6 +369,7 @@ export const SecretDialog = ({
                             placeholder="e.g. api.example.com or *.example.com"
                             value={hostPattern}
                             onChange={(e) => setHostPattern(e.target.value)}
+                            disabled={!!prefill}
                           />
                           {hostPatternError ? (
                             <p className="text-xs text-red-500">

--- a/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
@@ -45,7 +45,21 @@ export const SecretsContent = () => {
     if (paramHandled.current || loading) return;
     const createType = searchParams.get("create");
     const host = searchParams.get("host");
-    if (createType === "generic" && host) {
+    const action = searchParams.get("action");
+    if (action === "new") {
+      paramHandled.current = true;
+      setCreateOpen(true);
+      router.replace(window.location.pathname, { scroll: false });
+    } else if (createType === "anthropic") {
+      paramHandled.current = true;
+      setPrefill({
+        type: "anthropic",
+        hostPattern: "api.anthropic.com",
+        name: "Anthropic Token",
+      });
+      setCreateOpen(true);
+      router.replace(window.location.pathname, { scroll: false });
+    } else if (createType === "generic" && host) {
       paramHandled.current = true;
       setPrefill({
         type: "generic",

--- a/apps/web/src/app/api/apps/[provider]/authorize/route.ts
+++ b/apps/web/src/app/api/apps/[provider]/authorize/route.ts
@@ -32,11 +32,13 @@ export const GET = async (request: NextRequest, { params }: Params) => {
 
   const redirectUri = `${APP_URL}/api/apps/${provider}/callback`;
   const scopes = app.connectionMethod.defaultScopes ?? [];
+  const connectionId = request.nextUrl.searchParams.get("connectionId");
 
   const state = signOAuthState({
     accountId: auth.accountId,
     provider,
     nonce: generateNonce(),
+    ...(connectionId ? { connectionId } : {}),
   });
 
   const authUrl = app.connectionMethod.buildAuthUrl({

--- a/apps/web/src/app/api/apps/[provider]/callback/route.ts
+++ b/apps/web/src/app/api/apps/[provider]/callback/route.ts
@@ -3,7 +3,12 @@ import { getApp } from "@/lib/apps/registry";
 import { resolveOAuthCredentials } from "@/lib/apps/resolve-credentials";
 import { APP_URL } from "@/lib/env";
 import { verifyOAuthState } from "@/lib/oauth-state";
-import { upsertConnection } from "@/lib/services/connection-service";
+import {
+  createConnection,
+  reconnectConnection,
+  listConnectionsByProvider,
+  extractLabel,
+} from "@/lib/services/connection-service";
 import { logger } from "@/lib/logger";
 
 type Params = { params: Promise<{ provider: string }> };
@@ -48,10 +53,46 @@ export const GET = async (request: NextRequest, { params }: Params) => {
         redirectUri,
       });
 
-    await upsertConnection(state.accountId, provider, credentials, {
-      scopes,
-      metadata,
-    });
+    // Determine if we should reconnect an existing connection:
+    // 1. Explicit reconnect via connectionId in state (user clicked Reconnect)
+    // 2. Duplicate detection: same identity already connected for this provider
+    let reconnectId = state.connectionId as string | undefined;
+
+    if (!reconnectId) {
+      const identity = extractLabel(metadata)?.toLowerCase().trim();
+      if (identity) {
+        const existing = await listConnectionsByProvider(
+          state.accountId,
+          provider,
+        );
+        const duplicate = existing.find((c) => {
+          if (
+            !c.metadata ||
+            typeof c.metadata !== "object" ||
+            Array.isArray(c.metadata)
+          )
+            return false;
+          const existingIdentity = extractLabel(
+            c.metadata as Record<string, unknown>,
+          );
+          return existingIdentity?.toLowerCase().trim() === identity;
+        });
+        if (duplicate) reconnectId = duplicate.id;
+      }
+    }
+
+    if (reconnectId) {
+      await reconnectConnection(state.accountId, reconnectId, credentials, {
+        scopes,
+        metadata,
+      });
+    } else {
+      await createConnection(state.accountId, provider, credentials, {
+        scopes,
+        metadata,
+      });
+    }
+
     // Cache invalidation happens client-side: the success page sends
     // postMessage("app-connected") to the parent window, which calls
     // invalidateCache() via useInvalidateGatewayCache. We can't do it

--- a/apps/web/src/app/api/apps/[provider]/connect/route.ts
+++ b/apps/web/src/app/api/apps/[provider]/connect/route.ts
@@ -3,7 +3,11 @@ import { resolveApiAuth } from "@/lib/api-auth";
 import { handleServiceError, unauthorized } from "@/lib/api-utils";
 import { invalidateGatewayCache } from "@/lib/gateway-invalidate";
 import { getApp } from "@/lib/apps/registry";
-import { upsertConnection } from "@/lib/services/connection-service";
+import {
+  createConnection,
+  listConnectionsByProvider,
+  reconnectConnection,
+} from "@/lib/services/connection-service";
 
 type Params = { params: Promise<{ provider: string }> };
 
@@ -30,7 +34,10 @@ export const POST = async (request: NextRequest, { params }: Params) => {
       );
     }
 
-    const body = (await request.json()) as { fields?: Record<string, string> };
+    const body = (await request.json()) as {
+      fields?: Record<string, string>;
+      connectionId?: string;
+    };
     if (!body.fields) {
       return NextResponse.json(
         { error: "Missing fields in request body" },
@@ -52,7 +59,19 @@ export const POST = async (request: NextRequest, { params }: Params) => {
       access_token: body.fields[primaryField!.name],
     };
 
-    await upsertConnection(auth.accountId, provider, credentials);
+    if (body.connectionId) {
+      await reconnectConnection(auth.accountId, body.connectionId, credentials);
+    } else {
+      const existing = await listConnectionsByProvider(
+        auth.accountId,
+        provider,
+      );
+      if (existing.length > 0) {
+        await reconnectConnection(auth.accountId, existing[0]!.id, credentials);
+      } else {
+        await createConnection(auth.accountId, provider, credentials);
+      }
+    }
     invalidateGatewayCache(request);
 
     return NextResponse.json({ success: true });

--- a/apps/web/src/app/api/apps/[provider]/connection/route.ts
+++ b/apps/web/src/app/api/apps/[provider]/connection/route.ts
@@ -11,8 +11,17 @@ export const DELETE = async (request: NextRequest, { params }: Params) => {
     const auth = await resolveApiAuth(request);
     if (!auth) return unauthorized();
 
-    const { provider } = await params;
-    await deleteConnection(auth.accountId, provider);
+    await params; // consume params (required by Next.js)
+    const connectionId = request.nextUrl.searchParams.get("connectionId");
+
+    if (!connectionId) {
+      return NextResponse.json(
+        { error: "connectionId query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    await deleteConnection(auth.accountId, connectionId);
     invalidateGatewayCache(request);
     return new NextResponse(null, { status: 204 });
   } catch (err) {

--- a/apps/web/src/app/api/apps/[provider]/route.ts
+++ b/apps/web/src/app/api/apps/[provider]/route.ts
@@ -26,13 +26,14 @@ export const GET = async (request: NextRequest, { params }: Params) => {
 
     const [config, connection] = await Promise.all([
       getAppConfig(auth.accountId, provider),
-      db.appConnection.findUnique({
-        where: { accountId_provider: { accountId: auth.accountId, provider } },
+      db.appConnection.findFirst({
+        where: { accountId: auth.accountId, provider },
         select: {
           status: true,
           scopes: true,
           connectedAt: true,
         },
+        orderBy: { connectedAt: "desc" },
       }),
     ]);
 

--- a/apps/web/src/lib/actions/connections.ts
+++ b/apps/web/src/lib/actions/connections.ts
@@ -9,12 +9,18 @@ import {
 } from "@/lib/services/audit-service";
 import {
   listConnections,
+  listConnectionsByProvider,
   deleteConnection,
 } from "@/lib/services/connection-service";
 
 export const getAppConnections = async () => {
   const { accountId } = await resolveUser();
   return listConnections(accountId);
+};
+
+export const getAppConnectionsByProvider = async (provider: string) => {
+  const { accountId } = await resolveUser();
+  return listConnectionsByProvider(accountId, provider);
 };
 
 export const getVaultConnections = async () => {
@@ -32,18 +38,18 @@ export const getVaultConnections = async () => {
   });
 };
 
-export const disconnectApp = async (provider: string) => {
+export const disconnectAppConnection = async (connectionId: string) => {
   const { userId, userEmail, accountId } = await resolveUser();
 
   return withAudit(
-    () => deleteConnection(accountId, provider),
+    () => deleteConnection(accountId, connectionId),
     () => ({
       accountId,
       userId,
       userEmail,
       action: AUDIT_ACTIONS.DISCONNECT,
       service: AUDIT_SERVICES.APP_CONNECTION,
-      metadata: { provider },
+      metadata: { connectionId },
     }),
   );
 };

--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -3,7 +3,7 @@
 import { db } from "@onecli/db";
 import { resolveUser } from "@/lib/actions/resolve-user";
 import { DEMO_SECRET_NAME } from "@/lib/constants";
-import { API_BASE_URL, APP_URL } from "@/lib/env";
+import { APP_URL, GATEWAY_BASE_URL } from "@/lib/env";
 import { seedDemoSecret as seedDemoSecretService } from "@/lib/services/secret-service";
 import {
   listSecrets,
@@ -71,7 +71,7 @@ export const getInstallInfo = async () => {
   return {
     apiKey: apiKey?.key ?? null,
     agentToken: agent?.accessToken ?? null,
-    gatewayUrl: API_BASE_URL,
+    gatewayUrl: GATEWAY_BASE_URL,
     appUrl: APP_URL,
   };
 };
@@ -99,7 +99,7 @@ export const getDemoInfo = async () => {
 
   return {
     agentToken: agent.accessToken,
-    gatewayUrl: API_BASE_URL,
+    gatewayUrl: GATEWAY_BASE_URL,
   };
 };
 

--- a/apps/web/src/lib/services/connection-service.ts
+++ b/apps/web/src/lib/services/connection-service.ts
@@ -3,6 +3,21 @@ import { cryptoService } from "@/lib/crypto";
 import { ServiceError } from "@/lib/services/errors";
 
 /**
+ * Extract a human-readable label from connection metadata.
+ */
+export const extractLabel = (
+  metadata?: Record<string, unknown>,
+): string | null => {
+  const email = metadata?.email;
+  const username = metadata?.username;
+  const name = metadata?.name;
+  if (typeof email === "string" && email) return email;
+  if (typeof username === "string" && username) return username;
+  if (typeof name === "string" && name) return name;
+  return null;
+};
+
+/**
  * List all app connections for an account (no credentials returned).
  */
 export const listConnections = async (accountId: string) => {
@@ -11,6 +26,7 @@ export const listConnections = async (accountId: string) => {
     select: {
       id: true,
       provider: true,
+      label: true,
       status: true,
       scopes: true,
       metadata: true,
@@ -21,9 +37,31 @@ export const listConnections = async (accountId: string) => {
 };
 
 /**
- * Create or update an app connection with encrypted credentials.
+ * List all app connections for an account filtered by provider.
  */
-export const upsertConnection = async (
+export const listConnectionsByProvider = async (
+  accountId: string,
+  provider: string,
+) => {
+  return db.appConnection.findMany({
+    where: { accountId, provider },
+    select: {
+      id: true,
+      provider: true,
+      label: true,
+      status: true,
+      scopes: true,
+      metadata: true,
+      connectedAt: true,
+    },
+    orderBy: { connectedAt: "desc" },
+  });
+};
+
+/**
+ * Create a new app connection with encrypted credentials.
+ */
+export const createConnection = async (
   accountId: string,
   provider: string,
   credentials: Record<string, unknown>,
@@ -33,32 +71,64 @@ export const upsertConnection = async (
     JSON.stringify(credentials),
   );
 
-  return db.appConnection.upsert({
-    where: { accountId_provider: { accountId, provider } },
-    create: {
+  return db.appConnection.create({
+    data: {
       accountId,
       provider,
       status: "connected",
+      label: extractLabel(options?.metadata),
       credentials: encryptedCredentials,
       scopes: options?.scopes ?? [],
       metadata: (options?.metadata as Prisma.InputJsonValue) ?? undefined,
     },
-    update: {
-      status: "connected",
-      credentials: encryptedCredentials,
-      scopes: options?.scopes ?? undefined,
-      metadata: (options?.metadata as Prisma.InputJsonValue) ?? undefined,
-    },
-    select: { id: true, provider: true, status: true },
+    select: { id: true, provider: true, status: true, label: true },
   });
 };
 
 /**
- * Delete an app connection.
+ * Reconnect an existing app connection by updating its credentials.
  */
-export const deleteConnection = async (accountId: string, provider: string) => {
-  const connection = await db.appConnection.findUnique({
-    where: { accountId_provider: { accountId, provider } },
+export const reconnectConnection = async (
+  accountId: string,
+  connectionId: string,
+  credentials: Record<string, unknown>,
+  options?: { scopes?: string[]; metadata?: Record<string, unknown> },
+) => {
+  const existing = await db.appConnection.findFirst({
+    where: { id: connectionId, accountId },
+    select: { id: true, label: true },
+  });
+
+  if (!existing) {
+    throw new ServiceError("NOT_FOUND", "Connection not found");
+  }
+
+  const encryptedCredentials = await cryptoService.encrypt(
+    JSON.stringify(credentials),
+  );
+
+  return db.appConnection.update({
+    where: { id: existing.id },
+    data: {
+      status: "connected",
+      label: extractLabel(options?.metadata) ?? existing.label,
+      credentials: encryptedCredentials,
+      scopes: options?.scopes ?? undefined,
+      metadata: (options?.metadata as Prisma.InputJsonValue) ?? undefined,
+    },
+    select: { id: true, provider: true, status: true, label: true },
+  });
+};
+
+/**
+ * Delete an app connection by id.
+ */
+export const deleteConnection = async (
+  accountId: string,
+  connectionId: string,
+) => {
+  const connection = await db.appConnection.findFirst({
+    where: { id: connectionId, accountId },
     select: { id: true },
   });
 
@@ -67,6 +137,6 @@ export const deleteConnection = async (accountId: string, provider: string) => {
   }
 
   await db.appConnection.delete({
-    where: { accountId_provider: { accountId, provider } },
+    where: { id: connection.id },
   });
 };

--- a/packages/db/prisma/migrations/20260413120000_add_multi_account_connections/migration.sql
+++ b/packages/db/prisma/migrations/20260413120000_add_multi_account_connections/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable: add label column
+ALTER TABLE "app_connections" ADD COLUMN "label" TEXT;
+
+-- Backfill labels from metadata
+UPDATE "app_connections" SET "label" = COALESCE(metadata->>'email', metadata->>'username', metadata->>'name') WHERE metadata IS NOT NULL;
+
+-- DropIndex: remove one-per-provider unique constraint (allow multiple connections per provider)
+DROP INDEX "app_connections_account_id_provider_key";
+
+-- CreateIndex: non-unique index for queries by account + provider
+CREATE INDEX "app_connections_account_id_provider_idx" ON "app_connections"("account_id", "provider");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -244,6 +244,7 @@ model AppConnection {
   id                  String               @id @default(uuid())
   accountId           String               @map("account_id")
   provider            String // "github", "gmail", "google-calendar", "google-drive", etc.
+  label               String?              @map("label") // auto-populated from metadata (email/username)
   status              String               @default("connected")
   credentials         String?              @map("credentials") // encrypted JSON (access_token, refresh_token, etc.)
   scopes              String[]             @default([])
@@ -253,7 +254,7 @@ model AppConnection {
   account             Account              @relation(fields: [accountId], references: [id])
   agentAppConnections AgentAppConnection[]
 
-  @@unique([accountId, provider])
+  @@index([accountId, provider])
   @@map("app_connections")
 }
 


### PR DESCRIPTION
## Summary

- **Multi-account connections**: Support multiple connections per app provider (e.g., two GitHub accounts). Per-request disambiguation via `x-onecli-connection-id` header. Drops the one-per-provider unique constraint, adds `label` column auto-populated from metadata.
- **credential_not_found response**: When an agent hits an unknown host with no matching secret or app connection, returns a structured response with a direct link to create a secret for that hostname.
- **access_restricted broadened**: Now covers both secrets and app connections (previously only checked app connections).
- **MITM all authenticated traffic**: Gateway now intercepts all requests from authenticated agents (not just known app hosts), enabling auth error detection for any host.
- **Auth-related 400 inspection**: Scans response bodies of 400 responses for auth error keywords to catch providers that return 400 instead of 401/403.
- **Multi-account UI**: Connection cards, manage access dialog with per-connection controls, reconnect flow with visual indication, case-insensitive duplicate detection in OAuth callback.
- **Injection rule caching**: Caches decrypted app connection injection rules per-connection in CacheStore with TTL-aware expiration.

## Test plan

- [ ] Connect multiple accounts for the same provider (e.g., two GitHub accounts)
- [ ] Verify `x-onecli-connection-id` header disambiguates when multiple connections match
- [ ] Hit an unknown host with an authenticated agent — should get `credential_not_found`
- [ ] Verify `access_restricted` returned when agent lacks permission to existing connection
- [ ] Disconnect a connection and verify UI updates
- [ ] Reconnect a previously disconnected connection