### PR TITLE
feat: add "Request an app" card to apps grid

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -24,6 +24,7 @@ const nextConfig = {
           "@/lib/auth/login-content": "@/cloud/auth/login-content",
           "@/lib/user-plan": "@/cloud/user-plan",
           "@/lib/auth/session-hooks": "@/cloud/auth/session-hooks",
+          "@/lib/components/request-app-slot": "@/cloud/apps/request-app-slot",
         }
       : {},
   },

--- a/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
@@ -63,7 +63,7 @@ export const GetStartedDialog = ({
     if (installInfo.appUrl !== "https://app.onecli.sh") {
       params.push(`url=${encodeURIComponent(installInfo.appUrl)}`);
     }
-    return `curl -fsSL ${installInfo.appUrl}/api/install/${path}?${params.join("&")} | sh`;
+    return `curl -fsSL "${installInfo.appUrl}/api/install/${path}?${params.join("&")}" | sh`;
   };
 
   const installCommand = buildCurlCommand("nanoclaw");

--- a/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronRight } from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
@@ -13,6 +13,7 @@ import {
   getAvailableEnvDefaults,
 } from "@/lib/actions/app-config";
 import { apps } from "@/lib/apps/registry";
+import { RequestAppSlot } from "@/lib/components/request-app-slot";
 import { useAppMessages } from "@/hooks/use-app-connected";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { AppIcon } from "./app-icon";
@@ -82,10 +83,14 @@ export const AppsTab = () => {
   };
 
   // Derived set for backward-compat with useConnectParam
-  const connectedProviders = new Set(
-    [...connectionCounts.entries()]
-      .filter(([, count]) => count > 0)
-      .map(([provider]) => provider),
+  const connectedProviders = useMemo(
+    () =>
+      new Set(
+        [...connectionCounts.entries()]
+          .filter(([, count]) => count > 0)
+          .map(([provider]) => provider),
+      ),
+    [connectionCounts],
   );
 
   // Handle ?connect=<provider> URL param
@@ -116,6 +121,7 @@ export const AppsTab = () => {
   return (
     <>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <RequestAppSlot />
         {apps.map((app) => {
           const count = connectionCounts.get(app.id) ?? 0;
           return (

--- a/apps/web/src/lib/components/request-app-slot.tsx
+++ b/apps/web/src/lib/components/request-app-slot.tsx
@@ -1,0 +1,45 @@
+import { Plus } from "lucide-react";
+
+/**
+ * OSS default "Request an app" slot — links to the OSS repo's issue form
+ * pre-labeled `app-request`.
+ *
+ * Cloud aliases this module to `@/cloud/apps/request-app-slot` via
+ * turbopack `resolveAlias` in `next.config.js`. The cloud override opens
+ * an in-app dialog that collects the request and emails the user an
+ * acknowledgment via Resend.
+ */
+
+const ISSUE_BODY_TEMPLATE = `**Website:**
+
+**How you'd use this with OneCLI:**
+`;
+
+const GITHUB_ISSUE_URL = `https://github.com/onecli/onecli/issues/new?${new URLSearchParams(
+  {
+    labels: "app request",
+    title: "App request: ",
+    body: ISSUE_BODY_TEMPLATE,
+  },
+).toString()}`;
+
+export const RequestAppSlot = () => (
+  <a
+    href={GITHUB_ISSUE_URL}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="group flex items-center justify-between rounded-xl border border-dashed border-muted-foreground/40 bg-card/40 px-4 py-3 transition-colors cursor-pointer hover:bg-accent/50 hover:border-solid"
+  >
+    <div className="flex items-center gap-3">
+      <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+        <Plus className="size-4 text-muted-foreground transition-colors group-hover:text-foreground" />
+      </div>
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">Request an app</span>
+        <span className="text-muted-foreground text-xs">
+          Open an issue on GitHub
+        </span>
+      </div>
+    </div>
+  </a>
+);


### PR DESCRIPTION
## Summary

- Add a "Request an app" slot as the first item in the apps grid, linking to a pre-filled GitHub issue form labeled `app request`
- Fix quoting in the install curl command to prevent zsh glob errors on URLs with query params

## Test plan

- [ ] Verify "Request an app" card appears first in the apps grid
- [ ] Click it — should open a new GitHub issue with pre-filled labels and template
- [ ] Verify the dashed border style distinguishes it from real app cards
- [ ] Test install curl command in zsh — no glob errors