### PR TITLE
feat: add secret injection in query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OneCLI is an open-source gateway that sits between your AI agents and the servic
 
 - **[Rust Gateway](apps/gateway)**: fast HTTP gateway that intercepts outbound requests and injects credentials. Agents authenticate with access tokens via `Proxy-Authorization` headers.
 - **[Web Dashboard](apps/web)**: Next.js app for managing agents, secrets, and permissions. Provides the API the gateway uses to resolve which credentials to inject for each request.
-- **Secret Store**: AES-256-GCM encrypted credential storage. Secrets are decrypted only at request time, matched by host and path patterns, and injected by the gateway as headers.
+- **Secret Store**: AES-256-GCM encrypted credential storage. Secrets are decrypted only at request time, matched by host and path patterns, and injected by the gateway as headers or URL query parameters.
 
 ## Quick Start
 

--- a/apps/gateway/Cargo.lock
+++ b/apps/gateway/Cargo.lock
@@ -2344,6 +2344,7 @@ dependencies = [
  "base64",
  "clap",
  "dashmap",
+ "form_urlencoded",
  "futures-util",
  "hex",
  "http-body 1.0.1",

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -98,6 +98,9 @@ optional = true
 [dependencies.percent-encoding]
 version = "2"
 
+[dependencies.form_urlencoded]
+version = "1"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -718,27 +718,48 @@ fn build_injections(
 
         "generic" => {
             let config = injection_config.and_then(|v| v.as_object());
+
+            // Check for header injection
             let header_name = config
                 .and_then(|c| c.get("headerName"))
                 .and_then(|v| v.as_str());
 
-            let Some(header_name) = header_name else {
-                return vec![];
-            };
-
-            let value_format = config
-                .and_then(|c| c.get("valueFormat"))
+            // Check for parameter injection
+            let param_name = config
+                .and_then(|c| c.get("paramName"))
                 .and_then(|v| v.as_str());
 
-            let value = match value_format {
-                Some(fmt) => fmt.replace("{value}", decrypted_value),
-                None => decrypted_value.to_string(),
-            };
+            if let Some(header_name) = header_name {
+                let value_format = config
+                    .and_then(|c| c.get("valueFormat"))
+                    .and_then(|v| v.as_str());
 
-            vec![Injection::SetHeader {
-                name: header_name.to_string(),
-                value,
-            }]
+                let value = match value_format {
+                    Some(fmt) => fmt.replace("{value}", decrypted_value),
+                    None => decrypted_value.to_string(),
+                };
+
+                vec![Injection::SetHeader {
+                    name: header_name.to_string(),
+                    value,
+                }]
+            } else if let Some(param_name) = param_name {
+                let param_format = config
+                    .and_then(|c| c.get("paramFormat"))
+                    .and_then(|v| v.as_str());
+
+                let value = match param_format {
+                    Some(fmt) => fmt.replace("{value}", decrypted_value),
+                    None => decrypted_value.to_string(),
+                };
+
+                vec![Injection::SetParam {
+                    name: param_name.to_string(),
+                    value,
+                }]
+            } else {
+                vec![]
+            }
         }
 
         _ => vec![],
@@ -960,5 +981,47 @@ mod tests {
     fn build_injections_unknown_type() {
         let injections = build_injections("unknown", "value", None);
         assert!(injections.is_empty());
+    }
+
+    // ── build_injections: paramName ─────────────────────────────────────
+
+    #[test]
+    fn build_injections_generic_param_name() {
+        let config = serde_json::json!({ "paramName": "api_key" });
+        let injections = build_injections("generic", "my-secret", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetParam {
+                name: "api_key".to_string(),
+                value: "my-secret".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_generic_param_name_with_format() {
+        let config = serde_json::json!({ "paramName": "token", "paramFormat": "Bearer-{value}" });
+        let injections = build_injections("generic", "my-secret", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetParam {
+                name: "token".to_string(),
+                value: "Bearer-my-secret".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_generic_header_takes_precedence_over_param() {
+        // If both headerName and paramName are present, headerName wins
+        let config = serde_json::json!({
+            "headerName": "Authorization",
+            "paramName": "api_key"
+        });
+        let injections = build_injections("generic", "my-secret", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert!(matches!(injections[0], Injection::SetHeader { .. }));
     }
 }

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -729,6 +729,12 @@ fn build_injections(
                 .and_then(|c| c.get("paramName"))
                 .and_then(|v| v.as_str());
 
+            if header_name.is_some() && param_name.is_some() {
+                tracing::warn!(
+                    "generic secret has both headerName and paramName; using headerName"
+                );
+            }
+
             if let Some(header_name) = header_name {
                 let value_format = config
                     .and_then(|c| c.get("valueFormat"))

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -105,7 +105,7 @@ pub(crate) async fn forward_request(
 > {
     let start = std::time::Instant::now();
     let method = req.method().clone();
-    let path = req
+    let mut path = req
         .uri()
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
@@ -166,9 +166,10 @@ pub(crate) async fn forward_request(
         None
     };
 
-    // Apply injection rules matching this request path
-    let injection_count = inject::apply_injections(&mut headers, &path, &rules.injection_rules);
+    // Apply injection rules matching this request path (may mutate path for SetParam)
+    let injection_count = inject::apply_injections(&mut headers, &mut path, &rules.injection_rules);
 
+    let url = format!("{scheme}://{host}{path}");
     // ── ManualApproval: prepare body, store, wait for decision ─────
     let forward_body = if let PolicyDecision::ManualApproval { rule_id } = &decision {
         info!(method = %method, url = %url, rule_id = %rule_id, "MANUAL APPROVAL required");

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -105,7 +105,7 @@ pub(crate) async fn forward_request(
 > {
     let start = std::time::Instant::now();
     let method = req.method().clone();
-    let mut path = req
+    let path = req
         .uri()
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
@@ -166,10 +166,12 @@ pub(crate) async fn forward_request(
         None
     };
 
-    // Apply injection rules matching this request path (may mutate path for SetParam)
-    let injection_count = inject::apply_injections(&mut headers, &mut path, &rules.injection_rules);
-
-    let url = format!("{scheme}://{host}{path}");
+    // Apply injection rules — upstream_path may gain query-param secrets;
+    // the original `path`/`url` stays clean for logging and approval metadata.
+    let mut upstream_path = path.clone();
+    let injection_count =
+        inject::apply_injections(&mut headers, &mut upstream_path, &rules.injection_rules);
+    let upstream_url = format!("{scheme}://{host}{upstream_path}");
     // ── ManualApproval: prepare body, store, wait for decision ─────
     let forward_body = if let PolicyDecision::ManualApproval { rule_id } = &decision {
         info!(method = %method, url = %url, rule_id = %rule_id, "MANUAL APPROVAL required");
@@ -296,7 +298,7 @@ pub(crate) async fn forward_request(
     };
 
     // ── Shared: forward to upstream and stream response back ──────
-    let mut upstream = http_client.request(method.clone(), &url);
+    let mut upstream = http_client.request(method.clone(), &upstream_url);
     for (name, value) in headers.iter() {
         upstream = upstream.header(name.clone(), value.clone());
     }
@@ -305,7 +307,7 @@ pub(crate) async fn forward_request(
     let upstream_resp = upstream
         .send()
         .await
-        .with_context(|| format!("forwarding to {url}"))?;
+        .with_context(|| format!("forwarding to {upstream_url}"))?;
 
     let status = upstream_resp.status();
     let resp_headers = upstream_resp.headers().clone();

--- a/apps/gateway/src/inject.rs
+++ b/apps/gateway/src/inject.rs
@@ -132,31 +132,53 @@ pub(crate) fn apply_injections(
 }
 
 /// Add or replace a URL query parameter in a path+query string.
+///
+/// Only the injected parameter is encoded via `form_urlencoded`; existing
+/// query segments are preserved byte-for-byte so their on-the-wire encoding
+/// is never altered (important for signature-based auth like AWS SigV4).
 fn apply_set_param(request_path: &mut String, name: &str, value: &str) {
-    let (path_part, query_part) = match request_path.split_once('?') {
-        Some((p, q)) => (p.to_string(), Some(q.to_string())),
-        None => (request_path.clone(), None),
+    let encoded_pair = form_urlencoded::Serializer::new(String::new())
+        .append_pair(name, value)
+        .finish();
+    let encoded_name = &encoded_pair[..encoded_pair.find('=').unwrap()];
+
+    let Some(qmark) = request_path.find('?') else {
+        request_path.push('?');
+        request_path.push_str(&encoded_pair);
+        return;
     };
 
-    let mut params: Vec<(String, String)> = query_part
-        .as_deref()
-        .map(|q| {
-            form_urlencoded::parse(q.as_bytes())
-                .map(|(k, v)| (k.into_owned(), v.into_owned()))
-                .collect()
-        })
-        .unwrap_or_default();
+    let query_start = qmark + 1;
+    let query = request_path[query_start..].to_string();
 
-    if let Some(existing) = params.iter_mut().find(|(k, _)| k == name) {
-        existing.1 = value.to_string();
-    } else {
-        params.push((name.to_string(), value.to_string()));
+    if query.is_empty() {
+        request_path.push_str(&encoded_pair);
+        return;
     }
 
-    let new_query = form_urlencoded::Serializer::new(String::new())
-        .extend_pairs(&params)
-        .finish();
-    *request_path = format!("{path_part}?{new_query}");
+    let mut result = String::with_capacity(query_start + query.len() + encoded_pair.len());
+    result.push_str(&request_path[..query_start]);
+
+    let mut replaced = false;
+    for (i, segment) in query.split('&').enumerate() {
+        if i > 0 {
+            result.push('&');
+        }
+        let seg_name = segment.split_once('=').map_or(segment, |(n, _)| n);
+        if seg_name == encoded_name && !replaced {
+            result.push_str(&encoded_pair);
+            replaced = true;
+        } else {
+            result.push_str(segment);
+        }
+    }
+
+    if !replaced {
+        result.push('&');
+        result.push_str(&encoded_pair);
+    }
+
+    *request_path = result;
 }
 
 /// Check if a request path matches a rule's path pattern.

--- a/apps/gateway/src/inject.rs
+++ b/apps/gateway/src/inject.rs
@@ -34,6 +34,11 @@ pub(crate) enum Injection {
     RemoveHeader {
         name: String,
     },
+    /// Add or replace a URL query parameter.
+    SetParam {
+        name: String,
+        value: String,
+    },
 }
 
 /// A rule matching a path pattern with header injection instructions.
@@ -67,11 +72,12 @@ pub(crate) fn extract_agent_token<T>(req: &Request<T>) -> Option<String> {
 
 // ── Injection application ───────────────────────────────────────────────
 
-/// Apply injection rules to the request headers.
+/// Apply injection rules to the request headers and URL path.
+/// `request_path` may be mutated when `SetParam` injections add query parameters.
 /// Returns the number of injection actions applied.
 pub(crate) fn apply_injections(
     headers: &mut hyper::HeaderMap,
-    request_path: &str,
+    request_path: &mut String,
     rules: &[InjectionRule],
 ) -> usize {
     let mut count = 0;
@@ -114,11 +120,43 @@ pub(crate) fn apply_injections(
                         }
                     }
                 }
+                Injection::SetParam { name, value } => {
+                    apply_set_param(request_path, name, value);
+                    count += 1;
+                }
             }
         }
     }
 
     count
+}
+
+/// Add or replace a URL query parameter in a path+query string.
+fn apply_set_param(request_path: &mut String, name: &str, value: &str) {
+    let (path_part, query_part) = match request_path.split_once('?') {
+        Some((p, q)) => (p.to_string(), Some(q.to_string())),
+        None => (request_path.clone(), None),
+    };
+
+    let mut params: Vec<(String, String)> = query_part
+        .as_deref()
+        .map(|q| {
+            form_urlencoded::parse(q.as_bytes())
+                .map(|(k, v)| (k.into_owned(), v.into_owned()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let Some(existing) = params.iter_mut().find(|(k, _)| k == name) {
+        existing.1 = value.to_string();
+    } else {
+        params.push((name.to_string(), value.to_string()));
+    }
+
+    let new_query = form_urlencoded::Serializer::new(String::new())
+        .extend_pairs(&params)
+        .finish();
+    *request_path = format!("{path_part}?{new_query}");
 }
 
 /// Check if a request path matches a rule's path pattern.
@@ -309,7 +347,7 @@ mod tests {
 
         let rules = vec![make_rule("*", vec![set_header("x-api-key", "sk-ant-123")])];
 
-        let count = apply_injections(&mut headers, "/v1/messages", &rules);
+        let count = apply_injections(&mut headers, &mut "/v1/messages".to_string(), &rules);
         assert_eq!(count, 1);
         assert_eq!(headers.get("x-api-key").unwrap(), "sk-ant-123");
         // Original header preserved
@@ -329,7 +367,7 @@ mod tests {
             vec![set_header("authorization", "Bearer new-token")],
         )];
 
-        let count = apply_injections(&mut headers, "/", &rules);
+        let count = apply_injections(&mut headers, &mut "/".to_string(), &rules);
         assert_eq!(count, 1);
         assert_eq!(headers.get("authorization").unwrap(), "Bearer new-token");
     }
@@ -350,7 +388,7 @@ mod tests {
             }],
         )];
 
-        let count = apply_injections(&mut headers, "/", &rules);
+        let count = apply_injections(&mut headers, &mut "/".to_string(), &rules);
         assert_eq!(count, 1);
         assert_eq!(headers.get("authorization").unwrap(), "Bearer real-token");
     }
@@ -368,7 +406,7 @@ mod tests {
             }],
         )];
 
-        let count = apply_injections(&mut headers, "/", &rules);
+        let count = apply_injections(&mut headers, &mut "/".to_string(), &rules);
         assert_eq!(count, 0);
         assert!(headers.get("authorization").is_none());
         // x-api-key untouched
@@ -383,7 +421,7 @@ mod tests {
 
         let rules = vec![make_rule("*", vec![remove_header("authorization")])];
 
-        let count = apply_injections(&mut headers, "/", &rules);
+        let count = apply_injections(&mut headers, &mut "/".to_string(), &rules);
         assert_eq!(count, 1);
         assert!(headers.get("authorization").is_none());
         // Other headers preserved
@@ -397,7 +435,7 @@ mod tests {
 
         let rules = vec![make_rule("*", vec![remove_header("x-not-present")])];
 
-        let count = apply_injections(&mut headers, "/", &rules);
+        let count = apply_injections(&mut headers, &mut "/".to_string(), &rules);
         assert_eq!(count, 0);
     }
 
@@ -414,7 +452,7 @@ mod tests {
             ],
         )];
 
-        let count = apply_injections(&mut headers, "/v1/messages", &rules);
+        let count = apply_injections(&mut headers, &mut "/v1/messages".to_string(), &rules);
         assert_eq!(count, 2);
         assert_eq!(headers.get("x-api-key").unwrap(), "sk-ant-123");
         assert!(headers.get("authorization").is_none());
@@ -429,7 +467,7 @@ mod tests {
             vec![set_header("x-api-key", "sk-ant-123")],
         )];
 
-        let count = apply_injections(&mut headers, "/v2/messages", &rules);
+        let count = apply_injections(&mut headers, &mut "/v2/messages".to_string(), &rules);
         assert_eq!(count, 0);
         assert!(headers.get("x-api-key").is_none());
     }
@@ -444,7 +482,7 @@ mod tests {
         ];
 
         // Only the /v1 rule should match
-        let count = apply_injections(&mut headers, "/v1/messages", &rules);
+        let count = apply_injections(&mut headers, &mut "/v1/messages".to_string(), &rules);
         assert_eq!(count, 1);
         assert_eq!(headers.get("x-api-key").unwrap(), "key-v1");
     }
@@ -454,7 +492,7 @@ mod tests {
         let mut headers = hyper::HeaderMap::new();
         headers.insert("accept", HeaderValue::from_static("*/*"));
 
-        let count = apply_injections(&mut headers, "/anything", &[]);
+        let count = apply_injections(&mut headers, &mut "/anything".to_string(), &[]);
         assert_eq!(count, 0);
     }
 
@@ -508,5 +546,85 @@ mod tests {
     #[test]
     fn vault_cred_empty_password_returns_empty() {
         assert!(vault_credential_to_rules("api.openai.com", &cred(Some(""))).is_empty());
+    }
+
+    // ── SetParam ───────────────────────────────────────────────────────
+
+    fn set_param(name: &str, value: &str) -> Injection {
+        Injection::SetParam {
+            name: name.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn inject_set_param_no_existing_query() {
+        let mut headers = hyper::HeaderMap::new();
+        let mut path = "/v1/search".to_string();
+
+        let rules = vec![make_rule("*", vec![set_param("api_key", "sk-123")])];
+
+        let count = apply_injections(&mut headers, &mut path, &rules);
+        assert_eq!(count, 1);
+        assert_eq!(path, "/v1/search?api_key=sk-123");
+    }
+
+    #[test]
+    fn inject_set_param_with_existing_query() {
+        let mut headers = hyper::HeaderMap::new();
+        let mut path = "/v1/search?q=hello".to_string();
+
+        let rules = vec![make_rule("*", vec![set_param("api_key", "sk-123")])];
+
+        let count = apply_injections(&mut headers, &mut path, &rules);
+        assert_eq!(count, 1);
+        assert!(path.contains("q=hello"));
+        assert!(path.contains("api_key=sk-123"));
+        assert!(path.starts_with("/v1/search?"));
+    }
+
+    #[test]
+    fn inject_set_param_replaces_existing() {
+        let mut headers = hyper::HeaderMap::new();
+        let mut path = "/v1/search?api_key=old-key&q=hello".to_string();
+
+        let rules = vec![make_rule("*", vec![set_param("api_key", "new-key")])];
+
+        let count = apply_injections(&mut headers, &mut path, &rules);
+        assert_eq!(count, 1);
+        assert!(path.contains("api_key=new-key"));
+        assert!(!path.contains("old-key"));
+        assert!(path.contains("q=hello"));
+    }
+
+    #[test]
+    fn inject_set_param_path_mismatch_skips() {
+        let mut headers = hyper::HeaderMap::new();
+        let mut path = "/v2/search".to_string();
+
+        let rules = vec![make_rule("/v1/*", vec![set_param("api_key", "sk-123")])];
+
+        let count = apply_injections(&mut headers, &mut path, &rules);
+        assert_eq!(count, 0);
+        assert_eq!(path, "/v2/search");
+    }
+
+    #[test]
+    fn inject_set_param_combined_with_header() {
+        let mut headers = hyper::HeaderMap::new();
+        let mut path = "/v1/search".to_string();
+
+        let rules = vec![make_rule(
+            "*",
+            vec![
+                set_header("x-custom", "value"),
+                set_param("api_key", "sk-123"),
+            ],
+        )];
+
+        let count = apply_injections(&mut headers, &mut path, &rules);
+        assert_eq!(count, 2);
+        assert_eq!(headers.get("x-custom").unwrap(), "value");
+        assert_eq!(path, "/v1/search?api_key=sk-123");
     }
 }

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx
@@ -19,14 +19,12 @@ import {
   AlertDialogTrigger,
 } from "@onecli/ui/components/alert-dialog";
 import { deleteSecret } from "@/lib/actions/secrets";
+import {
+  type InjectionConfig,
+  isHeaderInjection,
+  isParamInjection,
+} from "@/lib/validations/secret";
 import { SecretDialog } from "./secret-dialog";
-
-interface InjectionConfig {
-  headerName?: string;
-  valueFormat?: string;
-  paramName?: string;
-  paramFormat?: string;
-}
 
 interface SecretCardProps {
   secret: {
@@ -90,22 +88,26 @@ export const SecretCard = ({ secret, onUpdate }: SecretCardProps) => {
                   </code>
                 </span>
               )}
-              {secret.type === "generic" && config?.headerName && (
-                <span className="text-muted-foreground">
-                  Header:{" "}
-                  <code className="bg-muted rounded px-1 py-0.5 font-mono">
-                    {config.headerName}
-                  </code>
-                </span>
-              )}
-              {secret.type === "generic" && config?.paramName && (
-                <span className="text-muted-foreground">
-                  Parameter:{" "}
-                  <code className="bg-muted rounded px-1 py-0.5 font-mono">
-                    {config.paramName}
-                  </code>
-                </span>
-              )}
+              {secret.type === "generic" &&
+                config &&
+                isHeaderInjection(config) && (
+                  <span className="text-muted-foreground">
+                    Header:{" "}
+                    <code className="bg-muted rounded px-1 py-0.5 font-mono">
+                      {config.headerName}
+                    </code>
+                  </span>
+                )}
+              {secret.type === "generic" &&
+                config &&
+                isParamInjection(config) && (
+                  <span className="text-muted-foreground">
+                    Parameter:{" "}
+                    <code className="bg-muted rounded px-1 py-0.5 font-mono">
+                      {config.paramName}
+                    </code>
+                  </span>
+                )}
             </div>
 
             <p className="text-muted-foreground text-xs">

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx
@@ -22,8 +22,10 @@ import { deleteSecret } from "@/lib/actions/secrets";
 import { SecretDialog } from "./secret-dialog";
 
 interface InjectionConfig {
-  headerName: string;
-  valueFormat: string;
+  headerName?: string;
+  valueFormat?: string;
+  paramName?: string;
+  paramFormat?: string;
 }
 
 interface SecretCardProps {
@@ -93,6 +95,14 @@ export const SecretCard = ({ secret, onUpdate }: SecretCardProps) => {
                   Header:{" "}
                   <code className="bg-muted rounded px-1 py-0.5 font-mono">
                     {config.headerName}
+                  </code>
+                </span>
+              )}
+              {secret.type === "generic" && config?.paramName && (
+                <span className="text-muted-foreground">
+                  Parameter:{" "}
+                  <code className="bg-muted rounded px-1 py-0.5 font-mono">
+                    {config.paramName}
                   </code>
                 </span>
               )}

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -24,7 +24,9 @@ import {
 import { Badge } from "@onecli/ui/components/badge";
 import { createSecret, updateSecret } from "@/lib/actions/secrets";
 import {
+  type InjectionConfig,
   detectAnthropicAuthMode,
+  isHeaderInjection,
   isParamInjection,
   looksLikeAnthropicKey,
 } from "@/lib/validations/secret";
@@ -59,13 +61,6 @@ const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
     nameDefault: "",
   },
 ];
-
-interface InjectionConfig {
-  headerName?: string;
-  valueFormat?: string;
-  paramName?: string;
-  paramFormat?: string;
-}
 
 export interface SecretItem {
   id: string;
@@ -140,18 +135,31 @@ export const SecretDialog = ({
     if (open) {
       if (secret) {
         const config = secret.injectionConfig as InjectionConfig | null;
-        const isParam = isParamInjection(config);
         setStep("form");
         setType(secret.type as SecretType);
         setName(secret.name);
         setValue("");
         setHostPattern(secret.hostPattern);
         setPathPattern(secret.pathPattern ?? "");
-        setInjectionTarget(isParam ? "param" : "header");
-        setHeaderName(config?.headerName ?? "Authorization");
-        setValueFormat(config?.valueFormat ?? "Bearer {value}");
-        setParamName(config?.paramName ?? "");
-        setParamFormat(config?.paramFormat ?? "");
+        if (isParamInjection(config)) {
+          setInjectionTarget("param");
+          setParamName(config.paramName);
+          setParamFormat(config.paramFormat ?? "");
+          setHeaderName("Authorization");
+          setValueFormat("Bearer {value}");
+        } else if (isHeaderInjection(config)) {
+          setInjectionTarget("header");
+          setHeaderName(config.headerName);
+          setValueFormat(config.valueFormat ?? "Bearer {value}");
+          setParamName("");
+          setParamFormat("");
+        } else {
+          setInjectionTarget("header");
+          setHeaderName("Authorization");
+          setValueFormat("Bearer {value}");
+          setParamName("");
+          setParamFormat("");
+        }
       } else if (prefill) {
         const isParam = !!prefill.paramName;
         setStep("form");
@@ -429,10 +437,16 @@ export const SecretDialog = ({
                       {type === "generic" && (
                         <>
                           <div className="space-y-2">
-                            <Label>Inject as</Label>
-                            <div className="flex gap-2">
+                            <Label id="inject-as-label">Inject as</Label>
+                            <div
+                              className="flex gap-2"
+                              role="radiogroup"
+                              aria-labelledby="inject-as-label"
+                            >
                               <Button
                                 type="button"
+                                role="radio"
+                                aria-checked={injectionTarget === "header"}
                                 variant={
                                   injectionTarget === "header"
                                     ? "default"
@@ -445,6 +459,8 @@ export const SecretDialog = ({
                               </Button>
                               <Button
                                 type="button"
+                                role="radio"
+                                aria-checked={injectionTarget === "param"}
                                 variant={
                                   injectionTarget === "param"
                                     ? "default"

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@onecli/ui/components/badge";
 import { createSecret, updateSecret } from "@/lib/actions/secrets";
 import {
   detectAnthropicAuthMode,
+  isParamInjection,
   looksLikeAnthropicKey,
 } from "@/lib/validations/secret";
 
@@ -51,7 +52,8 @@ const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
   {
     value: "generic",
     label: "Generic Secret",
-    description: "Inject a custom header into requests matching any host",
+    description:
+      "Inject a custom header or URL parameter into matching requests",
     icon: <Key className="size-5" />,
     hostDefault: "",
     nameDefault: "",
@@ -59,8 +61,10 @@ const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
 ];
 
 interface InjectionConfig {
-  headerName: string;
-  valueFormat: string;
+  headerName?: string;
+  valueFormat?: string;
+  paramName?: string;
+  paramFormat?: string;
 }
 
 export interface SecretItem {
@@ -79,6 +83,8 @@ export interface SecretPrefill {
   pathPattern?: string;
   headerName?: string;
   valueFormat?: string;
+  paramName?: string;
+  paramFormat?: string;
 }
 
 interface SecretDialogProps {
@@ -109,8 +115,13 @@ export const SecretDialog = ({
   const [value, setValue] = useState("");
   const [hostPattern, setHostPattern] = useState("api.anthropic.com");
   const [pathPattern, setPathPattern] = useState("");
+  const [injectionTarget, setInjectionTarget] = useState<"header" | "param">(
+    "header",
+  );
   const [headerName, setHeaderName] = useState("Authorization");
   const [valueFormat, setValueFormat] = useState("Bearer {value}");
+  const [paramName, setParamName] = useState("");
+  const [paramFormat, setParamFormat] = useState("");
 
   // Inline validation for host pattern
   const hostPatternError = (() => {
@@ -129,23 +140,31 @@ export const SecretDialog = ({
     if (open) {
       if (secret) {
         const config = secret.injectionConfig as InjectionConfig | null;
+        const isParam = isParamInjection(config);
         setStep("form");
         setType(secret.type as SecretType);
         setName(secret.name);
         setValue("");
         setHostPattern(secret.hostPattern);
         setPathPattern(secret.pathPattern ?? "");
+        setInjectionTarget(isParam ? "param" : "header");
         setHeaderName(config?.headerName ?? "Authorization");
         setValueFormat(config?.valueFormat ?? "Bearer {value}");
+        setParamName(config?.paramName ?? "");
+        setParamFormat(config?.paramFormat ?? "");
       } else if (prefill) {
+        const isParam = !!prefill.paramName;
         setStep("form");
         setType(prefill.type);
         setName(prefill.name);
         setValue("");
         setHostPattern(prefill.hostPattern);
         setPathPattern(prefill.pathPattern ?? "");
+        setInjectionTarget(isParam ? "param" : "header");
         setHeaderName(prefill.headerName ?? "Authorization");
         setValueFormat(prefill.valueFormat ?? "Bearer {value}");
+        setParamName(prefill.paramName ?? "");
+        setParamFormat(prefill.paramFormat ?? "");
         setTimeout(() => valueInputRef.current?.focus(), 100);
       } else {
         setStep("type");
@@ -154,8 +173,11 @@ export const SecretDialog = ({
         setValue("");
         setHostPattern("api.anthropic.com");
         setPathPattern("");
+        setInjectionTarget("header");
         setHeaderName("Authorization");
         setValueFormat("Bearer {value}");
+        setParamName("");
+        setParamFormat("");
       }
     }
   }, [open, secret, prefill]);
@@ -168,30 +190,37 @@ export const SecretDialog = ({
     setStep("form");
   };
 
+  const hasInjectionTarget =
+    type !== "generic" ||
+    (injectionTarget === "header" ? headerName.trim() : paramName.trim());
+
   const isValid = isEdit
-    ? hostPattern.trim() &&
-      !hostPatternError &&
-      (type !== "generic" || headerName.trim())
+    ? hostPattern.trim() && !hostPatternError && hasInjectionTarget
     : name.trim() &&
       value.trim() &&
       hostPattern.trim() &&
       !hostPatternError &&
-      (type !== "generic" || headerName.trim());
+      hasInjectionTarget;
 
   const handleSave = async () => {
     if (!isValid) return;
     setSaving(true);
     try {
+      const buildInjectionConfig = () => {
+        if (type !== "generic") return undefined;
+        if (injectionTarget === "param") {
+          return { paramName, paramFormat: paramFormat || "{value}" };
+        }
+        return { headerName, valueFormat: valueFormat || "{value}" };
+      };
+
       if (isEdit) {
         await updateSecret(secret.id, {
           name: name !== secret.name ? name : undefined,
           value: value.trim() || undefined,
           hostPattern,
           pathPattern: pathPattern || null,
-          injectionConfig:
-            type === "generic"
-              ? { headerName, valueFormat: valueFormat || "{value}" }
-              : undefined,
+          injectionConfig: buildInjectionConfig() ?? undefined,
         });
         toast.success("Secret updated");
       } else {
@@ -201,10 +230,7 @@ export const SecretDialog = ({
           value,
           hostPattern,
           pathPattern: pathPattern || undefined,
-          injectionConfig:
-            type === "generic"
-              ? { headerName, valueFormat: valueFormat || "{value}" }
-              : null,
+          injectionConfig: buildInjectionConfig() ?? null,
         });
         toast.success("Secret created");
       }
@@ -248,7 +274,7 @@ export const SecretDialog = ({
                   ? "Update the secret\u2019s configuration. Leave the value field empty to keep the current value."
                   : type === "anthropic"
                     ? "Your key will be encrypted and injected into requests to api.anthropic.com."
-                    : "Configure a custom secret to inject as a header into matching requests."}
+                    : "Configure a custom secret to inject as a header or URL parameter into matching requests."}
               </DialogDescription>
             </DialogHeader>
 
@@ -403,34 +429,112 @@ export const SecretDialog = ({
                       {type === "generic" && (
                         <>
                           <div className="space-y-2">
-                            <Label htmlFor="secret-header">Header name</Label>
-                            <Input
-                              id="secret-header"
-                              placeholder="e.g. Authorization"
-                              value={headerName}
-                              onChange={(e) => setHeaderName(e.target.value)}
-                            />
+                            <Label>Inject as</Label>
+                            <div className="flex gap-2">
+                              <Button
+                                type="button"
+                                variant={
+                                  injectionTarget === "header"
+                                    ? "default"
+                                    : "outline"
+                                }
+                                size="sm"
+                                onClick={() => setInjectionTarget("header")}
+                              >
+                                Header
+                              </Button>
+                              <Button
+                                type="button"
+                                variant={
+                                  injectionTarget === "param"
+                                    ? "default"
+                                    : "outline"
+                                }
+                                size="sm"
+                                onClick={() => setInjectionTarget("param")}
+                              >
+                                URL Parameter
+                              </Button>
+                            </div>
                           </div>
 
-                          <div className="space-y-2">
-                            <Label htmlFor="secret-format">
-                              Value format{" "}
-                              <span className="text-muted-foreground font-normal">
-                                (optional)
-                              </span>
-                            </Label>
-                            <Input
-                              id="secret-format"
-                              placeholder="e.g. Bearer {value}"
-                              value={valueFormat}
-                              onChange={(e) => setValueFormat(e.target.value)}
-                            />
-                            <p className="text-muted-foreground text-xs">
-                              Use <code className="text-xs">{"{value}"}</code>{" "}
-                              as a placeholder for the secret. Defaults to the
-                              raw value.
-                            </p>
-                          </div>
+                          {injectionTarget === "header" ? (
+                            <>
+                              <div className="space-y-2">
+                                <Label htmlFor="secret-header">
+                                  Header name
+                                </Label>
+                                <Input
+                                  id="secret-header"
+                                  placeholder="e.g. Authorization"
+                                  value={headerName}
+                                  onChange={(e) =>
+                                    setHeaderName(e.target.value)
+                                  }
+                                />
+                              </div>
+
+                              <div className="space-y-2">
+                                <Label htmlFor="secret-format">
+                                  Value format{" "}
+                                  <span className="text-muted-foreground font-normal">
+                                    (optional)
+                                  </span>
+                                </Label>
+                                <Input
+                                  id="secret-format"
+                                  placeholder="e.g. Bearer {value}"
+                                  value={valueFormat}
+                                  onChange={(e) =>
+                                    setValueFormat(e.target.value)
+                                  }
+                                />
+                                <p className="text-muted-foreground text-xs">
+                                  Use{" "}
+                                  <code className="text-xs">{"{value}"}</code>{" "}
+                                  as a placeholder for the secret. Defaults to
+                                  the raw value.
+                                </p>
+                              </div>
+                            </>
+                          ) : (
+                            <>
+                              <div className="space-y-2">
+                                <Label htmlFor="secret-param">
+                                  Parameter name
+                                </Label>
+                                <Input
+                                  id="secret-param"
+                                  placeholder="e.g. api_key"
+                                  value={paramName}
+                                  onChange={(e) => setParamName(e.target.value)}
+                                />
+                              </div>
+
+                              <div className="space-y-2">
+                                <Label htmlFor="secret-param-format">
+                                  Value format{" "}
+                                  <span className="text-muted-foreground font-normal">
+                                    (optional)
+                                  </span>
+                                </Label>
+                                <Input
+                                  id="secret-param-format"
+                                  placeholder="e.g. {value}"
+                                  value={paramFormat}
+                                  onChange={(e) =>
+                                    setParamFormat(e.target.value)
+                                  }
+                                />
+                                <p className="text-muted-foreground text-xs">
+                                  Use{" "}
+                                  <code className="text-xs">{"{value}"}</code>{" "}
+                                  as a placeholder for the secret. Defaults to
+                                  the raw value.
+                                </p>
+                              </div>
+                            </>
+                          )}
                         </>
                       )}
                     </div>

--- a/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
@@ -68,6 +68,8 @@ export const SecretsContent = () => {
         name: searchParams.get("name") ?? `${host} Secret`,
         headerName: searchParams.get("header") ?? undefined,
         valueFormat: searchParams.get("format") ?? undefined,
+        paramName: searchParams.get("param") ?? undefined,
+        paramFormat: searchParams.get("paramFormat") ?? undefined,
       });
       setCreateOpen(true);
       router.replace(window.location.pathname, { scroll: false });

--- a/apps/web/src/lib/services/secret-service.ts
+++ b/apps/web/src/lib/services/secret-service.ts
@@ -4,6 +4,8 @@ import { ServiceError } from "@/lib/services/errors";
 import { DEMO_SECRET_NAME, DEMO_SECRET_VALUE } from "@/lib/constants";
 import {
   detectAnthropicAuthMode,
+  isHeaderInjection,
+  isParamInjection,
   type CreateSecretInput,
   type UpdateSecretInput,
 } from "@/lib/validations/secret";
@@ -65,10 +67,13 @@ export const createSecret = async (
     throw new ServiceError("BAD_REQUEST", "Host pattern is required");
 
   if (input.type === "generic") {
-    if (!input.injectionConfig?.headerName?.trim()) {
+    const config = input.injectionConfig;
+    const hasHeader = isHeaderInjection(config) && config.headerName.trim();
+    const hasParam = isParamInjection(config) && config.paramName.trim();
+    if (!hasHeader && !hasParam) {
       throw new ServiceError(
         "BAD_REQUEST",
-        "Header name is required for generic secrets",
+        "Header name or parameter name is required for generic secrets",
       );
     }
   }
@@ -78,10 +83,18 @@ export const createSecret = async (
   const pathPattern = input.pathPattern?.trim() || null;
   const injectionConfig =
     input.type === "generic" && input.injectionConfig
-      ? ({
-          headerName: input.injectionConfig.headerName.trim(),
-          valueFormat: input.injectionConfig.valueFormat?.trim() || "{value}",
-        } as Prisma.InputJsonValue)
+      ? isParamInjection(input.injectionConfig)
+        ? ({
+            paramName: input.injectionConfig.paramName.trim(),
+            paramFormat: input.injectionConfig.paramFormat?.trim() || "{value}",
+          } as Prisma.InputJsonValue)
+        : isHeaderInjection(input.injectionConfig)
+          ? ({
+              headerName: input.injectionConfig.headerName.trim(),
+              valueFormat:
+                input.injectionConfig.valueFormat?.trim() || "{value}",
+            } as Prisma.InputJsonValue)
+          : Prisma.JsonNull
       : Prisma.JsonNull;
 
   const metadata =
@@ -172,12 +185,21 @@ export const updateSecret = async (
   }
 
   if (input.injectionConfig !== undefined && secret.type === "generic") {
-    data.injectionConfig = input.injectionConfig
-      ? ({
-          headerName: input.injectionConfig.headerName.trim(),
-          valueFormat: input.injectionConfig.valueFormat?.trim() || "{value}",
-        } as Prisma.InputJsonValue)
-      : Prisma.JsonNull;
+    if (!input.injectionConfig) {
+      data.injectionConfig = Prisma.JsonNull;
+    } else if (isParamInjection(input.injectionConfig)) {
+      data.injectionConfig = {
+        paramName: input.injectionConfig.paramName.trim(),
+        paramFormat: input.injectionConfig.paramFormat?.trim() || "{value}",
+      } as Prisma.InputJsonValue;
+    } else if (isHeaderInjection(input.injectionConfig)) {
+      data.injectionConfig = {
+        headerName: input.injectionConfig.headerName.trim(),
+        valueFormat: input.injectionConfig.valueFormat?.trim() || "{value}",
+      } as Prisma.InputJsonValue;
+    } else {
+      data.injectionConfig = Prisma.JsonNull;
+    }
   }
 
   if (Object.keys(data).length === 0) {

--- a/apps/web/src/lib/validations/secret.ts
+++ b/apps/web/src/lib/validations/secret.ts
@@ -1,14 +1,18 @@
 import { z } from "zod";
 
-const headerInjectionSchema = z.object({
-  headerName: z.string().min(1),
-  valueFormat: z.string().optional(),
-});
+const headerInjectionSchema = z
+  .object({
+    headerName: z.string().min(1),
+    valueFormat: z.string().optional(),
+  })
+  .strict();
 
-const paramInjectionSchema = z.object({
-  paramName: z.string().min(1),
-  paramFormat: z.string().optional(),
-});
+const paramInjectionSchema = z
+  .object({
+    paramName: z.string().min(1),
+    paramFormat: z.string().optional(),
+  })
+  .strict();
 
 const injectionConfigSchema = z
   .union([headerInjectionSchema, paramInjectionSchema])

--- a/apps/web/src/lib/validations/secret.ts
+++ b/apps/web/src/lib/validations/secret.ts
@@ -1,12 +1,37 @@
 import { z } from "zod";
 
+const headerInjectionSchema = z.object({
+  headerName: z.string().min(1),
+  valueFormat: z.string().optional(),
+});
+
+const paramInjectionSchema = z.object({
+  paramName: z.string().min(1),
+  paramFormat: z.string().optional(),
+});
+
 const injectionConfigSchema = z
-  .object({
-    headerName: z.string().min(1),
-    valueFormat: z.string().optional(),
-  })
+  .union([headerInjectionSchema, paramInjectionSchema])
   .nullable()
   .optional();
+
+export type HeaderInjectionConfig = z.infer<typeof headerInjectionSchema>;
+export type ParamInjectionConfig = z.infer<typeof paramInjectionSchema>;
+export type InjectionConfig = HeaderInjectionConfig | ParamInjectionConfig;
+
+export const isHeaderInjection = (
+  config: unknown,
+): config is HeaderInjectionConfig =>
+  config !== null &&
+  typeof config === "object" &&
+  "headerName" in (config as Record<string, unknown>);
+
+export const isParamInjection = (
+  config: unknown,
+): config is ParamInjectionConfig =>
+  config !== null &&
+  typeof config === "object" &&
+  "paramName" in (config as Record<string, unknown>);
 
 /** Validates a host pattern is a hostname, not a URL or path. */
 const hostPatternSchema = z


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Extends other secrets to act on url query parameters rather than HTTP headers

## What is the current behavior?

Fixes #191

## What is the new behavior?

Update the create service endpoint and update the UI accordingly

<img width="1922" height="1154" alt="onecli" src="https://github.com/user-attachments/assets/8b4bbe92-3090-48dd-946d-57e28f6f7a17" />

## Additional context

Add any other context or screenshots.
