### PR TITLE
fix: stop auto-creating httpbin demo secret for new accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,19 @@ DATABASE_URL=postgresql://onecli:onecli@localhost:5432/onecli
 # Generate with: openssl rand -hex 32
 NEXTAUTH_SECRET=
 
-# Gateway auth mode — "local" skips JWT validation (single-user dev), "oauth" validates NextAuth cookies.
+# Gateway auth mode — "local" skips JWT validation (single-user dev), "oauth" validates OIDC access tokens.
 AUTH_MODE=local
 
-# Google OAuth (for login — works in both auth modes)
+# OIDC login provider (Keycloak, Okta, Auth0, etc.)
+# Set all three + NEXTAUTH_SECRET to enable multi-user OAuth login.
+# Redirect URI to register with your provider: {APP_URL}/api/auth/callback/oidc
+OAUTH_ISSUER=
+OAUTH_AUDIENCE=
+OAUTH_CLIENT_ID=
+OAUTH_CLIENT_SECRET=
+
+# Google OAuth — used for Google Workspace app connections (Gmail, Calendar, etc.)
+# NOT used for login. Set these only if you use Google Workspace integrations.
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,24 @@
+name: Kagenti Project Automation
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  add:
+    name: Add item to Kagenti Project
+
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+
+    # Pinned to @main intentionally: org-internal workflows propagate updates automatically.
+    uses: kagenti/.github/.github/workflows/add-to-project.yml@main
+    secrets: inherit
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@ packages/typescript-config/
 
 - `DATABASE_URL`: PostgreSQL connection string
 - `NEXT_PUBLIC_COGNITO_*`: AWS Cognito config (injected at build time in CI)
-- `STRIPE_SECRET_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`: Third-party credentials
+- `OAUTH_ISSUER`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`: OIDC login provider
+- `STRIPE_SECRET_KEY`: Stripe credentials
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`: Google Workspace app connections
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -125,13 +125,16 @@ Dashboard at **http://localhost:10254**, gateway at **http://localhost:10255**.
 
 All environment variables are optional for local development:
 
-| Variable                | Description                       | Default            |
-| ----------------------- | --------------------------------- | ------------------ |
-| `DATABASE_URL`          | PostgreSQL connection string      | See `.env.example` |
-| `NEXTAUTH_SECRET`       | Enables Google OAuth (multi-user) | Single-user mode   |
-| `GOOGLE_CLIENT_ID`      | Google OAuth client ID            | —                  |
-| `GOOGLE_CLIENT_SECRET`  | Google OAuth client secret        | —                  |
-| `SECRET_ENCRYPTION_KEY` | AES-256-GCM encryption key        | Auto-generated     |
+| Variable                | Description                                | Default            |
+| ----------------------- | ------------------------------------------ | ------------------ |
+| `DATABASE_URL`          | PostgreSQL connection string               | See `.env.example` |
+| `NEXTAUTH_SECRET`       | Enables OIDC login (multi-user)            | Single-user mode   |
+| `OAUTH_ISSUER`          | OIDC provider issuer URL                   | —                  |
+| `OAUTH_CLIENT_ID`       | OIDC client ID                             | —                  |
+| `OAUTH_CLIENT_SECRET`   | OIDC client secret                         | —                  |
+| `GOOGLE_CLIENT_ID`      | Google Workspace app connections client ID | —                  |
+| `GOOGLE_CLIENT_SECRET`  | Google Workspace app connections secret    | —                  |
+| `SECRET_ENCRYPTION_KEY` | AES-256-GCM encryption key                 | Auto-generated     |
 
 ## Contributing
 

--- a/apps/gateway/src/auth.rs
+++ b/apps/gateway/src/auth.rs
@@ -1,8 +1,11 @@
-//! Gateway authentication for browser requests.
+//! Gateway authentication for browser and API requests.
 //!
 //! Supports two modes controlled by the `AUTH_MODE` env var:
 //! - `local`: bypasses JWT validation, looks up the "local-admin" user directly.
-//! - `oauth` (default): validates a NextAuth session cookie JWT (HS256).
+//! - `oauth` (default): accepts three auth methods (tried in order):
+//!   1. API key: `Authorization: Bearer oc_...`
+//!   2. OIDC access token: `Authorization: Bearer <jwt>` (validated via JWKS)
+//!   3. NextAuth session cookie: `authjs.session-token` (HS256 via NEXTAUTH_SECRET)
 
 use std::sync::OnceLock;
 
@@ -18,12 +21,13 @@ use tracing::warn;
 
 use crate::db;
 use crate::gateway::GatewayState;
+use crate::jwks::JwksManager;
 
 // ── AuthError ────────────────────────────────────────────────────────────
 
 /// Authentication error — always returns 401 Unauthorized.
 #[derive(Debug)]
-pub(crate) struct AuthError(String);
+pub(crate) struct AuthError(pub(crate) String);
 
 impl std::fmt::Display for AuthError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -37,7 +41,7 @@ impl IntoResponse for AuthError {
     }
 }
 
-// ── JWT claims ───────────────────────────────────────────────────────────
+// ── NextAuth cookie claims ──────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
 struct SessionClaims {
@@ -60,7 +64,13 @@ fn nextauth_secret() -> Option<&'static str> {
 
 // ── Extractor ────────────────────────────────────────────────────────────
 
-/// Authenticated user extracted from browser session cookies.
+/// Authenticated user extracted from the request.
+///
+/// Authentication methods (tried in order):
+/// 1. API key: `Authorization: Bearer oc_...` (OneCLI API key)
+/// 2. OIDC access token: `Authorization: Bearer <jwt>` (validated via JWKS)
+/// 3. NextAuth session cookie: `authjs.session-token` (HS256 via NEXTAUTH_SECRET)
+/// 4. Local mode: bypasses auth, returns the "local-admin" user
 ///
 /// Add as an Axum handler parameter to require authentication:
 /// ```ignore
@@ -78,18 +88,18 @@ impl FromRequestParts<GatewayState> for AuthUser {
         parts: &mut Parts,
         state: &GatewayState,
     ) -> Result<Self, Self::Rejection> {
+        let pool = &state.policy_engine.pool;
+
         // Try API key auth first (Authorization: Bearer oc_...)
-        if let Some(api_key_user) =
-            validate_api_key(&state.policy_engine.pool, &parts.headers).await
-        {
+        if let Some(api_key_user) = validate_api_key(pool, &parts.headers).await {
             return Ok(api_key_user);
         }
 
-        // Fall back to session auth (cookies / JWT)
-        let user_id = validate_request(&state.policy_engine.pool, &parts.headers).await?;
+        // Fall back to session auth (OIDC JWT, NextAuth cookie, or local mode)
+        let user_id = validate_request(pool, &parts.headers, state.jwks.as_ref()).await?;
 
         // Resolve account from membership
-        let account_id = db::find_account_id_by_user(&state.policy_engine.pool, &user_id)
+        let account_id = db::find_account_id_by_user(pool, &user_id)
             .await
             .map_err(|e| {
                 warn!(error = %e, "auth: failed to resolve account");
@@ -134,12 +144,15 @@ async fn validate_api_key(pool: &PgPool, headers: &HeaderMap) -> Option<AuthUser
 
 // ── Session auth ─────────────────────────────────────────────────────────
 
-/// Validate an incoming browser request and return the internal user ID.
-/// The caller resolves the account ID from the user's membership.
-async fn validate_request(pool: &PgPool, headers: &HeaderMap) -> Result<String, AuthError> {
+/// Validate an incoming request and return the internal user ID.
+async fn validate_request(
+    pool: &PgPool,
+    headers: &HeaderMap,
+    jwks: Option<&JwksManager>,
+) -> Result<String, AuthError> {
     match auth_mode() {
         "local" => validate_local(pool).await,
-        _ => validate_oauth(pool, headers).await,
+        _ => validate_oauth(pool, headers, jwks).await,
     }
 }
 
@@ -162,14 +175,57 @@ async fn validate_local(pool: &PgPool) -> Result<String, AuthError> {
 
 // ── OAuth mode ───────────────────────────────────────────────────────────
 
-async fn validate_oauth(pool: &PgPool, headers: &HeaderMap) -> Result<String, AuthError> {
-    // 1. Extract session token from cookies
+/// Authenticate via OIDC access token (Bearer header) or NextAuth session cookie.
+///
+/// Tries the Bearer token first (via JWKS validation), then falls back to
+/// the NextAuth session cookie (HS256 with NEXTAUTH_SECRET).
+async fn validate_oauth(
+    pool: &PgPool,
+    headers: &HeaderMap,
+    jwks: Option<&JwksManager>,
+) -> Result<String, AuthError> {
+    // 1. Try OIDC access token from Authorization header
+    if let Some(sub) = try_bearer_jwt(headers, jwks).await {
+        return lookup_user(pool, &sub).await;
+    }
+
+    // 2. Fall back to NextAuth session cookie
+    validate_nextauth_cookie(pool, headers).await
+}
+
+/// Try to validate a non-`oc_` Bearer token as an OIDC access token.
+/// Returns the `sub` claim on success, `None` if no valid token found.
+async fn try_bearer_jwt(headers: &HeaderMap, jwks: Option<&JwksManager>) -> Option<String> {
+    let jwks = jwks?;
+
+    let auth_header = headers.get(hyper::header::AUTHORIZATION)?.to_str().ok()?;
+
+    let token = auth_header
+        .strip_prefix("Bearer ")
+        .or_else(|| auth_header.strip_prefix("bearer "))?;
+
+    // Skip oc_ tokens — those are API keys handled elsewhere
+    if token.starts_with("oc_") {
+        return None;
+    }
+
+    match jwks.validate(token).await {
+        Ok(claims) => Some(claims.sub),
+        Err(e) => {
+            warn!(error = %e, "OIDC bearer auth: JWT validation failed");
+            None
+        }
+    }
+}
+
+/// Validate a NextAuth session cookie (HS256 JWT signed with NEXTAUTH_SECRET).
+async fn validate_nextauth_cookie(pool: &PgPool, headers: &HeaderMap) -> Result<String, AuthError> {
     let cookie_header = headers
         .get(hyper::header::COOKIE)
         .and_then(|v| v.to_str().ok())
         .ok_or_else(|| {
             warn!("oauth auth: no cookie header");
-            AuthError("missing cookie".to_string())
+            AuthError("missing authentication".to_string())
         })?;
 
     let token = parse_cookie(cookie_header, "authjs.session-token").ok_or_else(|| {
@@ -177,13 +233,11 @@ async fn validate_oauth(pool: &PgPool, headers: &HeaderMap) -> Result<String, Au
         AuthError("missing session token".to_string())
     })?;
 
-    // 2. Read NEXTAUTH_SECRET
     let secret = nextauth_secret().ok_or_else(|| {
         warn!("oauth auth: NEXTAUTH_SECRET not set");
         AuthError("server misconfigured".to_string())
     })?;
 
-    // 3. Decode JWT (HS256)
     let mut validation = Validation::new(Algorithm::HS256);
     validation.required_spec_claims.clear();
     validation.validate_exp = false;
@@ -194,28 +248,30 @@ async fn validate_oauth(pool: &PgPool, headers: &HeaderMap) -> Result<String, Au
         &validation,
     )
     .map_err(|e| {
-        warn!(error = %e, "oauth auth: JWT decode failed");
+        warn!(error = %e, "oauth auth: NextAuth JWT decode failed");
         AuthError("invalid session token".to_string())
     })?;
 
-    let sub = &token_data.claims.sub;
+    lookup_user(pool, &token_data.claims.sub).await
+}
 
-    // 4. Look up user by external auth ID
-    let user = db::find_user_by_external_auth_id(pool, sub)
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Look up an internal user ID from an external auth ID (OIDC `sub` or NextAuth subject).
+async fn lookup_user(pool: &PgPool, external_auth_id: &str) -> Result<String, AuthError> {
+    let user = db::find_user_by_external_auth_id(pool, external_auth_id)
         .await
         .map_err(|e| {
             warn!(error = %e, "oauth auth: db error");
             AuthError("internal error".to_string())
         })?
         .ok_or_else(|| {
-            warn!(sub = %sub, "oauth auth: user not found");
+            warn!(sub = %external_auth_id, "oauth auth: user not found");
             AuthError("user not found".to_string())
         })?;
 
     Ok(user.id)
 }
-
-// ── Helpers ──────────────────────────────────────────────────────────────
 
 /// Parse a specific cookie value from a Cookie header string.
 fn parse_cookie<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -40,6 +40,7 @@ use crate::ca::CertificateAuthority;
 use crate::cache::CacheStore;
 use crate::connect::{self, AppConnectionResult, ConnectError, PolicyEngine};
 use crate::inject;
+use crate::jwks::JwksManager;
 use crate::vault;
 
 // ── GatewayState ───────────────────────────────────────────────────────
@@ -74,6 +75,9 @@ pub(crate) struct GatewayState {
     pub vault_service: Arc<vault::VaultService>,
     /// Manual approval store for held requests.
     pub approval_store: Arc<dyn ApprovalStore>,
+    /// OIDC JWKS manager for OAuth access token validation.
+    /// `None` in local auth mode (no OIDC provider configured).
+    pub jwks: Option<JwksManager>,
 }
 
 // ── GatewayServer ───────────────────────────────────────────────────────
@@ -137,6 +141,7 @@ impl GatewayServer {
         vault_service: Arc<vault::VaultService>,
         cache: Arc<dyn CacheStore>,
         approval_store: Arc<dyn ApprovalStore>,
+        jwks: Option<JwksManager>,
     ) -> Self {
         let global_skip = std::env::var("GATEWAY_DANGER_ACCEPT_INVALID_CERTS").is_ok();
         let skip_verify_hosts = Arc::new(parse_skip_verify_hosts());
@@ -156,6 +161,7 @@ impl GatewayServer {
             cache,
             vault_service,
             approval_store,
+            jwks,
         };
 
         Self { state, port }

--- a/apps/gateway/src/jwks.rs
+++ b/apps/gateway/src/jwks.rs
@@ -1,0 +1,269 @@
+//! OIDC JWKS manager for OAuth resource server authentication.
+//!
+//! Fetches the provider's signing keys via OIDC discovery and caches them
+//! in memory. Keys are refreshed when an unknown `kid` is encountered
+//! (key rotation) or after `JWKS_MAX_AGE` (proactive refresh).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, TokenData, Validation};
+use serde::Deserialize;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+use crate::auth::AuthError;
+
+/// Minimum interval between JWKS refresh attempts (prevents thundering herd).
+const JWKS_REFRESH_COOLDOWN: Duration = Duration::from_secs(30);
+
+/// Maximum age before proactive refresh (even if all kids match).
+#[allow(dead_code)]
+const JWKS_MAX_AGE: Duration = Duration::from_secs(3600);
+
+// ── OIDC / JWKS response types ─────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct OidcDiscovery {
+    issuer: String,
+    jwks_uri: String,
+}
+
+#[derive(Deserialize)]
+struct JwksResponse {
+    keys: Vec<JwkKey>,
+}
+
+#[derive(Deserialize)]
+struct JwkKey {
+    kid: Option<String>,
+    kty: String,
+    #[serde(rename = "use")]
+    use_: Option<String>,
+    n: Option<String>,
+    e: Option<String>,
+}
+
+// ── Cached key store ────────────────────────────────────────────────────
+
+struct CachedKeys {
+    keys: HashMap<String, DecodingKey>,
+    fetched_at: Instant,
+}
+
+// ── JWT claims ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AccessTokenClaims {
+    pub sub: String,
+}
+
+// ── JwksManager ─────────────────────────────────────────────────────────
+
+/// Manages OIDC JWKS keys for JWT access token validation.
+///
+/// On creation, performs OIDC discovery to find the `jwks_uri`, then
+/// fetches and caches the signing keys. Keys are automatically refreshed
+/// when an unknown `kid` is encountered.
+#[derive(Clone)]
+pub(crate) struct JwksManager {
+    issuer: String,
+    audience: String,
+    jwks_uri: String,
+    cache: Arc<RwLock<CachedKeys>>,
+    http_client: reqwest::Client,
+}
+
+/// Accepted RSA signature algorithms for access token validation.
+const ACCEPTED_ALGORITHMS: &[Algorithm] = &[Algorithm::RS256, Algorithm::RS384, Algorithm::RS512];
+
+impl JwksManager {
+    /// Create a new JWKS manager.
+    ///
+    /// When `jwks_url_override` is provided, uses it directly to fetch keys
+    /// (skipping OIDC discovery). Otherwise performs standard OIDC discovery
+    /// via `{issuer_url}/.well-known/openid-configuration`.
+    pub async fn new(
+        issuer_url: &str,
+        audience: String,
+        jwks_url_override: Option<String>,
+    ) -> Result<Self> {
+        let http_client = reqwest::Client::new();
+        let base = issuer_url.trim_end_matches('/');
+
+        let (issuer, jwks_uri) = if let Some(url) = jwks_url_override {
+            info!(jwks_uri = %url, "using OAUTH_JWKS_URL override, skipping OIDC discovery");
+            (base.to_string(), url)
+        } else {
+            let discovery_url = format!("{base}/.well-known/openid-configuration");
+            let discovery: OidcDiscovery = http_client
+                .get(&discovery_url)
+                .send()
+                .await
+                .context("fetching OIDC discovery document")?
+                .json()
+                .await
+                .context("parsing OIDC discovery document")?;
+
+            info!(
+                issuer = %discovery.issuer,
+                jwks_uri = %discovery.jwks_uri,
+                "OIDC discovery loaded"
+            );
+            (discovery.issuer, discovery.jwks_uri)
+        };
+
+        let keys = fetch_jwks(&http_client, &jwks_uri).await?;
+        info!(key_count = keys.len(), "JWKS loaded");
+
+        Ok(Self {
+            issuer,
+            audience,
+            jwks_uri,
+            cache: Arc::new(RwLock::new(CachedKeys {
+                keys,
+                fetched_at: Instant::now(),
+            })),
+            http_client,
+        })
+    }
+
+    /// Validate a JWT access token and return its claims.
+    ///
+    /// If the token's `kid` is not in the cache, triggers a JWKS refresh
+    /// (with cooldown) and retries. Validates signature, expiration, and issuer.
+    pub async fn validate(&self, token: &str) -> Result<AccessTokenClaims, AuthError> {
+        let header = decode_header(token).map_err(|e| {
+            warn!(error = %e, "JWT header decode failed");
+            AuthError("invalid token".to_string())
+        })?;
+
+        let kid = header.kid.as_deref();
+
+        // Try with cached keys
+        {
+            let cache = self.cache.read().await;
+            if let Some(claims) = self.try_decode(token, kid, &cache.keys)? {
+                return Ok(claims);
+            }
+        }
+
+        // Key not found — refresh JWKS (with cooldown) and retry
+        self.maybe_refresh().await;
+
+        let cache = self.cache.read().await;
+        self.try_decode(token, kid, &cache.keys)?.ok_or_else(|| {
+            warn!(kid = ?kid, "JWT kid not found in JWKS after refresh");
+            AuthError("invalid token".to_string())
+        })
+    }
+
+    /// Try to decode the token using the cached keys.
+    /// Returns `Ok(Some(claims))` if decoded, `Ok(None)` if no matching key, `Err` on validation failure.
+    fn try_decode(
+        &self,
+        token: &str,
+        kid: Option<&str>,
+        keys: &HashMap<String, DecodingKey>,
+    ) -> Result<Option<AccessTokenClaims>, AuthError> {
+        let key = if let Some(kid) = kid {
+            keys.get(kid)
+        } else if keys.len() == 1 {
+            // No kid in JWT header — use the only available key
+            keys.values().next()
+        } else {
+            None
+        };
+
+        let key = match key {
+            Some(k) => k,
+            None => return Ok(None),
+        };
+
+        let mut validation = Validation::default();
+        validation.algorithms = ACCEPTED_ALGORITHMS.to_vec();
+        validation.set_issuer(&[&self.issuer]);
+        validation.set_audience(&[&self.audience]);
+
+        let token_data: TokenData<AccessTokenClaims> =
+            decode(token, key, &validation).map_err(|e| {
+                warn!(error = %e, "JWT validation failed");
+                AuthError("invalid token".to_string())
+            })?;
+
+        Ok(Some(token_data.claims))
+    }
+
+    /// Refresh JWKS if the cooldown period has elapsed.
+    async fn maybe_refresh(&self) {
+        {
+            let cache = self.cache.read().await;
+            if cache.fetched_at.elapsed() < JWKS_REFRESH_COOLDOWN {
+                return;
+            }
+        }
+
+        match fetch_jwks(&self.http_client, &self.jwks_uri).await {
+            Ok(keys) => {
+                info!(key_count = keys.len(), "JWKS refreshed");
+                let mut cache = self.cache.write().await;
+                cache.keys = keys;
+                cache.fetched_at = Instant::now();
+            }
+            Err(e) => {
+                warn!(error = %e, "JWKS refresh failed, using cached keys");
+            }
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Fetch and parse JWKS from the given URI, returning a kid → DecodingKey map.
+async fn fetch_jwks(
+    client: &reqwest::Client,
+    jwks_uri: &str,
+) -> Result<HashMap<String, DecodingKey>> {
+    let jwks: JwksResponse = client
+        .get(jwks_uri)
+        .send()
+        .await
+        .context("fetching JWKS")?
+        .json()
+        .await
+        .context("parsing JWKS")?;
+
+    let mut keys = HashMap::new();
+
+    for jwk in jwks.keys {
+        if jwk.kty != "RSA" {
+            continue;
+        }
+        if jwk.use_.as_deref().is_some_and(|u| u != "sig") {
+            continue;
+        }
+
+        let kid = match jwk.kid {
+            Some(kid) => kid,
+            None => continue,
+        };
+
+        let (n, e) = match (jwk.n, jwk.e) {
+            (Some(n), Some(e)) => (n, e),
+            _ => continue,
+        };
+
+        match DecodingKey::from_rsa_components(&n, &e) {
+            Ok(key) => {
+                keys.insert(kid, key);
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to parse JWKS RSA key");
+            }
+        }
+    }
+
+    Ok(keys)
+}

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -34,6 +34,7 @@ mod crypto;
 mod db;
 mod gateway;
 mod inject;
+mod jwks;
 mod policy;
 mod vault;
 
@@ -152,6 +153,21 @@ async fn main() -> Result<()> {
     // OSS: in-memory DashMap + tokio channels. Cloud: Redis + BLPOP.
     let approval_store = approval::create_store().await?;
 
+    // Initialize OIDC JWKS manager for OAuth access token validation.
+    // Optional: enabled when OAUTH_ISSUER is set. The gateway also accepts
+    // NextAuth session cookies (HS256 via NEXTAUTH_SECRET) as a fallback,
+    // so JWKS is not required for browser-based auth to work.
+    let jwks = match std::env::var("OAUTH_ISSUER") {
+        Ok(issuer) => {
+            let audience = std::env::var("OAUTH_AUDIENCE")
+                .context("OAUTH_AUDIENCE must be set when OAUTH_ISSUER is set")?;
+            let jwks_url = std::env::var("OAUTH_JWKS_URL").ok();
+            let manager = jwks::JwksManager::new(&issuer, audience, jwks_url).await?;
+            Some(manager)
+        }
+        Err(_) => None,
+    };
+
     info!(port = cli.port, "gateway ready");
 
     // Start the gateway server (blocks forever)
@@ -162,6 +178,7 @@ async fn main() -> Result<()> {
         vault_service,
         cache,
         approval_store,
+        jwks,
     );
     server.run().await
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@onecli/ui": "workspace:*",
     "aws-amplify": "^6.16.2",
     "input-otp": "^1.4.2",
+    "jose": "^6.2.2",
     "lucide-react": "^0.562.0",
     "next": "16.1.0",
     "next-auth": "5.0.0-beta.30",

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -34,7 +34,7 @@ export default function DashboardLayout({
 
   const initSession = useCallback(async () => {
     try {
-      const res = await fetch("/api/auth/session");
+      const res = await fetch("/api/auth/sync");
       if (!res.ok) {
         signOutRef.current();
         return;

--- a/apps/web/src/app/api/auth/sync/route.ts
+++ b/apps/web/src/app/api/auth/sync/route.ts
@@ -4,7 +4,6 @@ import { getServerSession } from "@/lib/auth/server";
 import { verifyAndResolveIdentity } from "@/lib/validate-jwt";
 import { logger } from "@/lib/logger";
 import { DEFAULT_AGENT_NAME } from "@/lib/constants";
-import { seedDemoSecret } from "@/lib/services/secret-service";
 import { generateApiKey } from "@/lib/services/api-key-service";
 import { generateAccessToken } from "@/lib/services/agent-service";
 import { getSessionAttributes, onUserCreated } from "@/lib/auth/session-hooks";
@@ -16,7 +15,7 @@ import { getSessionAttributes, onUserCreated } from "@/lib/auth/session-hooks";
  * 1. Reads the auth session (cookie/token) or validates a JWT Bearer token
  * 2. Upserts the user in the database
  * 3. Ensures the user has an Account + AccountMember + ApiKey
- * 4. Seeds defaults (agent, demo secret) into the account
+ * 4. Seeds the default agent into the account
  * 5. Returns the user profile
  *
  * Called by the login page after auth, by the dashboard layout on mount,
@@ -77,10 +76,7 @@ export const GET = async (request: NextRequest) => {
     // Ensure the user has an Account. Create one if this is their first login.
     let membership = await db.accountMember.findFirst({
       where: { userId: user.id },
-      select: {
-        accountId: true,
-        account: { select: { demoSeeded: true } },
-      },
+      select: { accountId: true },
     });
 
     if (!membership) {
@@ -90,7 +86,7 @@ export const GET = async (request: NextRequest) => {
           createdByUserId: user.id,
           createdByUserEmail: user.email,
         },
-        select: { id: true, demoSeeded: true },
+        select: { id: true },
       });
 
       await db.accountMember.create({
@@ -112,47 +108,27 @@ export const GET = async (request: NextRequest) => {
         },
       });
 
-      membership = {
-        accountId: account.id,
-        account: { demoSeeded: account.demoSeeded },
-      };
+      membership = { accountId: account.id };
 
       onUserCreated({ email: user.email, name: user.name }, extra);
     }
 
     const accountId = membership.accountId;
-    const demoSeeded = membership.account.demoSeeded;
 
     // Seed defaults into the account — idempotent, skips anything that already exists
-    const ops = [];
-
     const hasDefaultAgent = await db.agent.findFirst({
       where: { accountId, isDefault: true },
       select: { id: true },
     });
 
     if (!hasDefaultAgent) {
-      ops.push(
-        db.agent.create({
-          data: {
-            name: DEFAULT_AGENT_NAME,
-            accessToken: generateAccessToken(),
-            isDefault: true,
-            accountId,
-          },
-        }),
-      );
-    }
-
-    if (ops.length > 0) {
-      await db.$transaction(ops);
-    }
-
-    if (!demoSeeded) {
-      await seedDemoSecret(accountId);
-      await db.account.update({
-        where: { id: accountId },
-        data: { demoSeeded: true },
+      await db.agent.create({
+        data: {
+          name: DEFAULT_AGENT_NAME,
+          accessToken: generateAccessToken(),
+          isDefault: true,
+          accountId,
+        },
       });
     }
 

--- a/apps/web/src/app/api/auth/sync/route.ts
+++ b/apps/web/src/app/api/auth/sync/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { db } from "@onecli/db";
 import { getServerSession } from "@/lib/auth/server";
+import { verifyAndResolveIdentity } from "@/lib/validate-jwt";
 import { logger } from "@/lib/logger";
 import { DEFAULT_AGENT_NAME } from "@/lib/constants";
 import { seedDemoSecret } from "@/lib/services/secret-service";
@@ -9,40 +10,60 @@ import { generateAccessToken } from "@/lib/services/agent-service";
 import { getSessionAttributes, onUserCreated } from "@/lib/auth/session-hooks";
 
 /**
- * GET /api/auth/session
+ * GET /api/auth/sync
  *
  * Single endpoint that handles the full auth → DB sync flow:
- * 1. Reads the auth session (cookie/token)
+ * 1. Reads the auth session (cookie/token) or validates a JWT Bearer token
  * 2. Upserts the user in the database
  * 3. Ensures the user has an Account + AccountMember + ApiKey
  * 4. Seeds defaults (agent, demo secret) into the account
  * 5. Returns the user profile
  *
- * Called by the login page after auth and by the dashboard layout on mount.
- * Returns 401 if no valid session exists.
+ * Called by the login page after auth, by the dashboard layout on mount,
+ * or by API clients with a JWT access token to provision their account.
+ * Returns 401 if no valid session or token exists.
  */
 export const GET = async (request: NextRequest) => {
   try {
+    // Try session auth first, then JWT Bearer token
     const session = await getServerSession();
-    if (!session || !session.email) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+    let authId: string;
+    let email: string;
+    let name: string | null | undefined;
+
+    if (session?.email) {
+      authId = session.id;
+      email = session.email;
+      name = session.name;
+    } else {
+      const identity = await verifyAndResolveIdentity(request);
+      if (!identity) {
+        return NextResponse.json(
+          { error: "Not authenticated" },
+          { status: 401 },
+        );
+      }
+      authId = identity.sub;
+      email = identity.email;
+      name = identity.name;
     }
 
     const extra = getSessionAttributes(request);
 
     // Upsert user by email — creates on first login, updates on subsequent.
     const user = await db.user.upsert({
-      where: { email: session.email },
+      where: { email },
       create: {
-        externalAuthId: session.id,
-        email: session.email,
-        name: session.name,
+        externalAuthId: authId,
+        email,
+        name: name ?? null,
         lastLoginAt: new Date(),
         ...extra,
       },
       update: {
-        externalAuthId: session.id,
-        name: session.name,
+        externalAuthId: authId,
+        name: name ?? null,
         lastLoginAt: new Date(),
         ...extra,
       },
@@ -141,10 +162,7 @@ export const GET = async (request: NextRequest) => {
       name: user.name,
     });
   } catch (err) {
-    logger.error(
-      { err, route: "GET /api/auth/session" },
-      "session sync failed",
-    );
+    logger.error({ err, route: "GET /api/auth/sync" }, "session sync failed");
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 },

--- a/apps/web/src/app/setup-error/page.tsx
+++ b/apps/web/src/app/setup-error/page.tsx
@@ -11,9 +11,10 @@ const errors: Record<string, { title: string; description: React.ReactNode }> =
       title: "OAuth not configured",
       description: (
         <p>
-          <Code>NEXTAUTH_SECRET</Code> is set but <Code>GOOGLE_CLIENT_ID</Code>{" "}
-          and <Code>GOOGLE_CLIENT_SECRET</Code> are missing. Either provide all
-          three or remove <Code>NEXTAUTH_SECRET</Code> to use local mode.
+          <Code>NEXTAUTH_SECRET</Code> is set but <Code>OAUTH_ISSUER</Code>,{" "}
+          <Code>OAUTH_CLIENT_ID</Code>, and <Code>OAUTH_CLIENT_SECRET</Code> are
+          missing. Either provide all four or remove{" "}
+          <Code>NEXTAUTH_SECRET</Code> to use local mode.
         </p>
       ),
     },

--- a/apps/web/src/lib/api-auth.ts
+++ b/apps/web/src/lib/api-auth.ts
@@ -1,5 +1,6 @@
 import { db } from "@onecli/db";
 import { validateApiKey } from "@/lib/validate-api-key";
+import { validateJwt } from "@/lib/validate-jwt";
 import { getServerSession } from "@/lib/auth/server";
 
 export interface AuthContext {
@@ -9,7 +10,7 @@ export interface AuthContext {
 
 /**
  * Resolve the authenticated user + account from an API request.
- * Tries API key first (`Authorization: Bearer oc_...`), then falls back to session.
+ * Tries API key first, then OAuth JWT, then falls back to session.
  */
 export const resolveApiAuth = async (
   request: Request,
@@ -17,6 +18,10 @@ export const resolveApiAuth = async (
   // API key auth — returns userId + accountId directly
   const apiKeyAuth = await validateApiKey(request);
   if (apiKeyAuth) return apiKeyAuth;
+
+  // OAuth JWT auth — validate OIDC access token
+  const jwtAuth = await validateJwt(request);
+  if (jwtAuth) return jwtAuth;
 
   // Session auth — resolve from membership
   const session = await getServerSession();

--- a/apps/web/src/lib/auth/auth-provider.tsx
+++ b/apps/web/src/lib/auth/auth-provider.tsx
@@ -45,7 +45,7 @@ const OAuthInner = ({ children }: { children: ReactNode }) => {
   }, [session]);
 
   const signIn = useCallback(async () => {
-    await nextAuthSignIn("google");
+    await nextAuthSignIn("oidc");
   }, []);
 
   const signOut = useCallback(async () => {

--- a/apps/web/src/lib/auth/login-content.tsx
+++ b/apps/web/src/lib/auth/login-content.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { LogIn } from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
 import { useAuth } from "@/providers/auth-provider";
 
@@ -16,7 +17,7 @@ export const LoginContent = () => {
 
     const syncUser = async () => {
       try {
-        const res = await fetch("/api/auth/session");
+        const res = await fetch("/api/auth/sync");
         if (res.ok) {
           router.replace("/overview");
         } else {
@@ -77,15 +78,15 @@ export const LoginContent = () => {
             <Button
               size="lg"
               variant="outline"
-              className="w-full gap-2 text-base bg-white text-black hover:bg-gray-100 dark:bg-white dark:text-black dark:hover:bg-gray-100"
+              className="w-full gap-2 text-base"
               loading={signingIn}
               onClick={() => {
                 setSigningIn(true);
                 signIn();
               }}
             >
-              <GoogleIcon />
-              {signingIn ? "Redirecting..." : "Continue with Google"}
+              <LogIn className="h-4 w-4" />
+              {signingIn ? "Redirecting..." : "Sign in"}
             </Button>
             <p className="text-muted-foreground mt-4 text-center text-xs whitespace-nowrap">
               By continuing, you acknowledge OneCLI&apos;s{" "}
@@ -103,28 +104,3 @@ export const LoginContent = () => {
     </div>
   );
 };
-
-const GoogleIcon = () => (
-  <svg
-    className="h-4 w-4"
-    viewBox="-3 0 262 262"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M255.878 133.451c0-10.734-.871-18.567-2.756-26.69H130.55v48.448h71.947c-1.45 12.04-9.283 30.172-26.69 42.356l-.244 1.622 38.755 30.023 2.685.268c24.659-22.774 38.875-56.282 38.875-96.027"
-      fill="#4285F4"
-    />
-    <path
-      d="M130.55 261.1c35.248 0 64.839-11.605 86.453-31.622l-41.196-31.913c-11.024 7.688-25.82 13.055-45.257 13.055-34.523 0-63.824-22.773-74.269-54.25l-1.531.13-40.298 31.187-.527 1.465C35.393 231.798 79.49 261.1 130.55 261.1"
-      fill="#34A853"
-    />
-    <path
-      d="M56.281 156.37c-2.756-8.123-4.351-16.827-4.351-25.82 0-8.994 1.595-17.697 4.206-25.82l-.073-1.73L15.26 71.312l-1.335.635C5.077 89.644 0 109.517 0 130.55s5.077 40.905 13.925 58.602l42.356-32.782"
-      fill="#FBBC05"
-    />
-    <path
-      d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0 79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251"
-      fill="#EB4335"
-    />
-  </svg>
-);

--- a/apps/web/src/lib/auth/nextauth-config.ts
+++ b/apps/web/src/lib/auth/nextauth-config.ts
@@ -1,8 +1,13 @@
 import NextAuth, { type DefaultSession } from "next-auth";
-import Google from "next-auth/providers/google";
+import type { Provider } from "next-auth/providers";
 import {
-  GOOGLE_CLIENT_ID,
-  GOOGLE_CLIENT_SECRET,
+  OAUTH_ISSUER,
+  OAUTH_JWKS_URL,
+  OAUTH_AUTHORIZATION_URL,
+  OAUTH_TOKEN_URL,
+  OAUTH_USERINFO_URL,
+  OAUTH_CLIENT_ID,
+  OAUTH_CLIENT_SECRET,
   NEXTAUTH_SECRET,
 } from "@/lib/env";
 
@@ -14,15 +19,23 @@ declare module "next-auth" {
   }
 }
 
+const oidcProvider: Provider = {
+  id: "oidc",
+  name: "SSO",
+  type: "oidc",
+  issuer: OAUTH_ISSUER,
+  clientId: OAUTH_CLIENT_ID,
+  clientSecret: OAUTH_CLIENT_SECRET,
+  ...(OAUTH_AUTHORIZATION_URL
+    ? { authorization: OAUTH_AUTHORIZATION_URL }
+    : {}),
+  ...(OAUTH_TOKEN_URL ? { token: OAUTH_TOKEN_URL } : {}),
+  ...(OAUTH_USERINFO_URL ? { userinfo: OAUTH_USERINFO_URL } : {}),
+  ...(OAUTH_JWKS_URL ? { jwks_endpoint: OAUTH_JWKS_URL } : {}),
+};
+
 export const { auth, handlers } = NextAuth({
-  providers: GOOGLE_CLIENT_ID
-    ? [
-        Google({
-          clientId: GOOGLE_CLIENT_ID,
-          clientSecret: GOOGLE_CLIENT_SECRET,
-        }),
-      ]
-    : [],
+  providers: OAUTH_CLIENT_ID ? [oidcProvider] : [],
   session: { strategy: "jwt" },
   secret: NEXTAUTH_SECRET,
   pages: {

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -52,6 +52,25 @@ export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID ?? "";
 
 export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET ?? "";
 
+// ── OIDC Login Provider ────────────────────────────────────────────────
+
+export const OAUTH_ISSUER = process.env.OAUTH_ISSUER ?? "";
+
+export const OAUTH_JWKS_URL = process.env.OAUTH_JWKS_URL ?? "";
+
+export const OAUTH_AUDIENCE = process.env.OAUTH_AUDIENCE ?? "";
+
+export const OAUTH_AUTHORIZATION_URL =
+  process.env.OAUTH_AUTHORIZATION_URL ?? "";
+
+export const OAUTH_TOKEN_URL = process.env.OAUTH_TOKEN_URL ?? "";
+
+export const OAUTH_USERINFO_URL = process.env.OAUTH_USERINFO_URL ?? "";
+
+export const OAUTH_CLIENT_ID = process.env.OAUTH_CLIENT_ID ?? "";
+
+export const OAUTH_CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET ?? "";
+
 // ── Cloud: Cognito ──────────────────────────────────────────────────────
 
 export const COGNITO_CLIENT_ID =

--- a/apps/web/src/lib/runtime-config.ts
+++ b/apps/web/src/lib/runtime-config.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import { EDITION, GOOGLE_CLIENT_ID, NEXTAUTH_SECRET } from "@/lib/env";
+import { EDITION, OAUTH_CLIENT_ID, NEXTAUTH_SECRET } from "@/lib/env";
 
 interface RuntimeConfig {
   authMode: "cloud" | "oauth" | "local";
@@ -33,7 +33,7 @@ export const getRuntimeConfig = (): RuntimeConfig => {
     // are client-rendered behind auth anyway, the fallback value is fine.
     cached = {
       authMode: NEXTAUTH_SECRET ? "oauth" : "local",
-      oauthConfigured: !!GOOGLE_CLIENT_ID,
+      oauthConfigured: !!OAUTH_CLIENT_ID,
     };
     return cached;
   }

--- a/apps/web/src/lib/validate-jwt.ts
+++ b/apps/web/src/lib/validate-jwt.ts
@@ -1,0 +1,164 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { db } from "@onecli/db";
+import { OAUTH_ISSUER, OAUTH_AUDIENCE, OAUTH_JWKS_URL } from "@/lib/env";
+import { logger } from "@/lib/logger";
+
+export interface JwtAuth {
+  userId: string;
+  accountId: string;
+}
+
+const log = logger.child({ module: "validate-jwt" });
+
+// Module-level singletons — persist across requests in the Node.js process.
+let cachedJwksUri: string | null = null;
+let cachedGetKey: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+const resolveJwksUri = async (): Promise<string | null> => {
+  if (cachedJwksUri) return cachedJwksUri;
+
+  if (OAUTH_JWKS_URL) {
+    cachedJwksUri = OAUTH_JWKS_URL;
+    return cachedJwksUri;
+  }
+
+  try {
+    const res = await fetch(`${OAUTH_ISSUER}/.well-known/openid-configuration`);
+    const doc = (await res.json()) as { jwks_uri?: string };
+    if (!doc.jwks_uri) {
+      log.warn("OIDC discovery response missing jwks_uri");
+      return null;
+    }
+    cachedJwksUri = doc.jwks_uri;
+    return cachedJwksUri;
+  } catch (err) {
+    log.warn({ err }, "OIDC discovery failed");
+    return null;
+  }
+};
+
+const getKeyFunction = async (): Promise<ReturnType<
+  typeof createRemoteJWKSet
+> | null> => {
+  if (cachedGetKey) return cachedGetKey;
+
+  const jwksUri = await resolveJwksUri();
+  if (!jwksUri) return null;
+
+  cachedGetKey = createRemoteJWKSet(new URL(jwksUri));
+  return cachedGetKey;
+};
+
+const extractBearerToken = (request: Request): string | null => {
+  const header = request.headers.get("authorization");
+  if (!header) return null;
+  const token = header.startsWith("Bearer ") ? header.slice(7).trim() : null;
+  if (!token || token.startsWith("oc_")) return null;
+  return token;
+};
+
+const lookupUser = async (externalAuthId: string): Promise<JwtAuth | null> => {
+  const user = await db.user.findUnique({
+    where: { externalAuthId },
+    select: {
+      id: true,
+      memberships: { select: { accountId: true }, take: 1 },
+    },
+  });
+
+  if (!user || user.memberships.length === 0) {
+    log.warn({ sub: externalAuthId }, "JWT auth: user or account not found");
+    return null;
+  }
+
+  return { userId: user.id, accountId: user.memberships[0]!.accountId };
+};
+
+/**
+ * Validate an OAuth access token (JWT) from a request's `Authorization: Bearer ...` header.
+ * Verifies signature via JWKS, checks issuer + audience + expiration, then resolves the user.
+ * Returns null (and logs a warning) on any failure, allowing fallthrough to session auth.
+ */
+export const validateJwt = async (
+  request: Request,
+): Promise<JwtAuth | null> => {
+  if (!OAUTH_ISSUER) return null;
+
+  const token = extractBearerToken(request);
+  if (!token) return null;
+
+  const getKey = await getKeyFunction();
+  if (!getKey) return null;
+
+  try {
+    const { payload } = await jwtVerify(token, getKey, {
+      issuer: OAUTH_ISSUER,
+      audience: OAUTH_AUDIENCE || undefined,
+      algorithms: ["RS256", "RS384", "RS512"],
+    });
+
+    const sub = payload.sub;
+    if (!sub) {
+      log.warn("JWT missing sub claim");
+      return null;
+    }
+
+    return await lookupUser(sub);
+  } catch (err) {
+    log.warn({ err }, "JWT validation failed");
+    return null;
+  }
+};
+
+// ── Identity resolution (JWT verify + email/name from claims) ──────────
+
+export interface ResolvedIdentity {
+  sub: string;
+  email: string;
+  name?: string;
+}
+
+/**
+ * Verify a JWT access token and resolve the user's identity (sub + email + name)
+ * from the token claims, without performing a database lookup.
+ *
+ * Returns null if the JWT is invalid or the email claim is missing.
+ */
+export const verifyAndResolveIdentity = async (
+  request: Request,
+): Promise<ResolvedIdentity | null> => {
+  if (!OAUTH_ISSUER) return null;
+
+  const token = extractBearerToken(request);
+  if (!token) return null;
+
+  const getKey = await getKeyFunction();
+  if (!getKey) return null;
+
+  try {
+    const { payload } = await jwtVerify(token, getKey, {
+      issuer: OAUTH_ISSUER,
+      audience: OAUTH_AUDIENCE || undefined,
+      algorithms: ["RS256", "RS384", "RS512"],
+    });
+
+    const sub = payload.sub;
+    if (!sub) {
+      log.warn("JWT missing sub claim");
+      return null;
+    }
+
+    const email = typeof payload.email === "string" ? payload.email : undefined;
+    if (!email) {
+      log.warn({ sub }, "JWT missing email claim");
+      return null;
+    }
+
+    const name = typeof payload.name === "string" ? payload.name : undefined;
+
+    return { sub, email, name };
+  } catch (err) {
+    log.warn({ err }, "JWT verification failed");
+    return null;
+  }
+};

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import {
   IS_CLOUD,
-  GOOGLE_CLIENT_ID,
+  OAUTH_CLIENT_ID,
   NEXTAUTH_SECRET,
   SECRET_ENCRYPTION_KEY,
 } from "@/lib/env";
@@ -15,8 +15,8 @@ type SetupErrorCode = "oauth-misconfigured" | "missing-encryption-key";
 const getSetupError = (): SetupErrorCode | null => {
   if (IS_CLOUD) return null;
 
-  // NEXTAUTH_SECRET is set but Google OAuth creds are missing
-  if (NEXTAUTH_SECRET && !GOOGLE_CLIENT_ID) {
+  // NEXTAUTH_SECRET is set but OIDC provider creds are missing
+  if (NEXTAUTH_SECRET && !OAUTH_CLIENT_ID) {
     return "oauth-misconfigured";
   }
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,7 +37,7 @@ else
 fi
 export AUTH_MODE
 OAUTH_CONFIGURED="false"
-if [ "$AUTH_MODE" = "cloud" ] || [ -n "$GOOGLE_CLIENT_ID" ]; then
+if [ "$AUTH_MODE" = "cloud" ] || [ -n "$OAUTH_CLIENT_ID" ]; then
   OAUTH_CONFIGURED="true"
 fi
 printf '{"authMode":"%s","oauthConfigured":%s}\n' "$AUTH_MODE" "$OAUTH_CONFIGURED" > /app/data/runtime-config.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      jose:
+        specifier: ^6.2.2
+        version: 6.2.2
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.4)
@@ -3427,8 +3430,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.2.0:
-    resolution: {integrity: sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==}
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -4474,7 +4477,7 @@ snapshots:
   '@auth/core@0.41.0':
     dependencies:
       '@panva/hkdf': 1.2.1
-      jose: 6.2.0
+      jose: 6.2.2
       oauth4webapi: 3.8.5
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
@@ -8532,7 +8535,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@6.2.0: {}
+  jose@6.2.2: {}
 
   joycon@3.1.1: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,14 @@
     "STRIPE_BIZ_PRICE_ID",
     "GOOGLE_CLIENT_ID",
     "GOOGLE_CLIENT_SECRET",
+    "OAUTH_ISSUER",
+    "OAUTH_JWKS_URL",
+    "OAUTH_AUTHORIZATION_URL",
+    "OAUTH_TOKEN_URL",
+    "OAUTH_USERINFO_URL",
+    "OAUTH_CLIENT_ID",
+    "OAUTH_CLIENT_SECRET",
+    "OAUTH_AUDIENCE",
     "OAUTH_STATE_SECRET",
     "NEXT_PUBLIC_APP_URL",
     "SECRET_ENCRYPTION_KEY",
@@ -57,7 +65,10 @@
         "REDIS_PORT",
         "REDIS_PASSWORD",
         "REDIS_TLS",
-        "COGNITO_USER_POOL_ID"
+        "COGNITO_USER_POOL_ID",
+        "AUTH_MODE",
+        "OAUTH_ISSUER",
+        "OAUTH_AUDIENCE"
       ]
     },
     "@onecli/gateway#check": {


### PR DESCRIPTION
## Summary
- New accounts no longer receive an out-of-the-box demo secret pointing at `httpbin.org`
- Removes the `seedDemoSecret` call and `demoSeeded` field reads from `/api/auth/sync`
- The on-demand "Create demo secret" button in the Get Started dialog still works

## Test plan
- [ ] Sign up a new account and confirm no demo secret is created
- [ ] Open the Get Started dialog → "Try the gateway" and verify the "Create demo secret" button still seeds the secret manually
- [ ] Existing accounts with the demo secret are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)