### PR TITLE
feat: make app and gateway ports configurable for multi-user hosts

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,13 +29,13 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "${ONECLI_BIND_HOST:-127.0.0.1}:10254:10254"
-      - "${ONECLI_BIND_HOST:-127.0.0.1}:10255:10255"
+      - "${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}:10254"
+      - "${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_GATEWAY_PORT:-10255}:10255"
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-onecli}:${POSTGRES_PASSWORD:-onecli}@postgres:5432/${POSTGRES_DB:-onecli}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-}
-      NEXT_PUBLIC_APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:10254
-      APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:10254
+      NEXT_PUBLIC_APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}
+      APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}
     volumes:
       - app-data:/app/data
     env_file:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,8 +14,13 @@
 #   export POSTGRES_PORT=5433
 #   curl -fsSL https://onecli.sh/install | sh
 #
+# Custom app/gateway ports (e.g. for multi-user hosts):
+#   export ONECLI_APP_PORT=11254
+#   export ONECLI_GATEWAY_PORT=11255
+#   curl -fsSL https://onecli.sh/install | sh
+#
 # This script checks for Docker, downloads the docker-compose.yml,
-# and starts OneCLI (app + PostgreSQL) on ports 10254 and 10255.
+# and starts OneCLI (app + PostgreSQL) on ports 10254 and 10255 by default.
 
 INSTALL_DIR="$HOME/.onecli"
 COMPOSE_FILE="$INSTALL_DIR/docker-compose.yml"
@@ -170,10 +175,10 @@ main() {
 
   echo ""
   echo "  OneCLI is running!"
-  echo "  ONECLI_URL:  http://$ONECLI_BIND_HOST:10254"
+  echo "  ONECLI_URL:  http://$ONECLI_BIND_HOST:${ONECLI_APP_PORT:-10254}"
   echo ""
-  echo "  Dashboard:  http://$ONECLI_BIND_HOST:10254"
-  echo "  Gateway:    http://$ONECLI_BIND_HOST:10255"
+  echo "  Dashboard:  http://$ONECLI_BIND_HOST:${ONECLI_APP_PORT:-10254}"
+  echo "  Gateway:    http://$ONECLI_BIND_HOST:${ONECLI_GATEWAY_PORT:-10255}"
   echo ""
   echo "  Compose file: $COMPOSE_FILE"
   echo ""


### PR DESCRIPTION
The host-side ports `10254` and `10255` are hardcoded in `docker/docker-compose.yml`, so two users on the same machine can't both run OneCLI — the second container fails to bind. Postgres already has `POSTGRES_PORT` for this; app and gateway didn't.

Adds `ONECLI_APP_PORT` (default `10254`) and `ONECLI_GATEWAY_PORT` (default `10255`), matching the existing `${ONECLI_BIND_HOST:-127.0.0.1}` / `${POSTGRES_PORT:-5432}` convention. Container-internal ports are unchanged — only the host side varies.