### PR TITLE
refactor: service layer cleanup

### DIFF
--- a/apps/web/src/lib/services/app-config-service.ts
+++ b/apps/web/src/lib/services/app-config-service.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { db, Prisma } from "@onecli/db";
 import { cryptoService } from "@/lib/crypto";
 import { logger } from "@/lib/logger";

--- a/apps/web/src/lib/services/organization-service.ts
+++ b/apps/web/src/lib/services/organization-service.ts
@@ -89,6 +89,14 @@ export const bootstrapOrganization = async (
   return { project, organization: org };
 };
 
+export const validateOrgName = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.length > 255) {
+    throw new Error("Organization name must be 1-255 characters");
+  }
+  return trimmed;
+};
+
 /**
  * Ensure a project has an API key for the given user and a default agent.
  * Idempotent — skips creation if they already exist.


### PR DESCRIPTION
## Summary

- Add `validateOrgName` to `organization-service.ts` — shared validation for org name (1-255 chars, trimmed)
- Remove `"use server"` directive from `app-config-service.ts` — service files are internal and should not be exposed as server actions; they're called by action files that handle auth + audit

## Changes

Two files modified, no behavior change.