### PR TITLE
ci: add SBOM crypto audit to block unapproved crypto dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,24 @@ jobs:
             --exit-code; EXIT_CODE=$?
           docker rm -f shadow-db
           exit $EXIT_CODE
+
+  security:
+    name: SBOM Crypto Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/gateway -> target
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Audit crypto dependencies
+        run: ./scripts/sbom-crypto-audit.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,16 +115,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Check for changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            deps:
+              - 'apps/gateway/Cargo.lock'
+              - 'pnpm-lock.yaml'
+              - 'scripts/sbom-crypto-audit.sh'
+              - '.github/workflows/ci.yml'
+
       - name: Setup Rust
+        if: steps.changes.outputs.deps == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust
+        if: steps.changes.outputs.deps == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/gateway -> target
 
       - name: Setup Node.js
+        if: steps.changes.outputs.deps == 'true'
         uses: ./.github/actions/setup-node
 
       - name: Audit crypto dependencies
+        if: steps.changes.outputs.deps == 'true'
         run: ./scripts/sbom-crypto-audit.sh

--- a/scripts/sbom-crypto-audit.sh
+++ b/scripts/sbom-crypto-audit.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+################################################################################
+# SBOM Crypto Audit — verify no unapproved crypto libraries in dependency tree.
+#
+# Approved crypto components:
+#   Rust:  ring, rustls, rcgen (cert gen), jsonwebtoken
+#   Rust (transitive, approved): sha2, hmac, cipher, crypto-common, sha1, sha3,
+#          ed25519-dalek, clatter (via Bitwarden Agent Access SDK / sqlx)
+#   JS:    node:crypto (built-in) — no third-party crypto packages
+#
+# Unapproved (would fail this check):
+#   Rust:  openssl, openssl-sys, boringssl
+#   JS:    crypto-js, sjcl, node-forge, tweetnacl, libsodium, bcrypt, argon2, scrypt
+#
+# Usage: ./scripts/sbom-crypto-audit.sh
+################################################################################
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ERRORS=0
+
+echo "=== SBOM Crypto Audit ==="
+echo ""
+
+# ── Rust crate audit ──────────────────────────────────────────────────
+echo "--- Rust: checking for unapproved crypto crates ---"
+
+BLOCKED_RUST_CRATES="openssl|openssl-sys|boringssl|boring|boring-sys"
+
+cd "$PROJECT_ROOT/apps/gateway"
+RUST_HITS=$(cargo tree -f '{p}' 2>/dev/null | grep -iE "^($BLOCKED_RUST_CRATES) " || true)
+
+if [ -n "$RUST_HITS" ]; then
+  echo "FAIL: Unapproved Rust crypto crates found:"
+  echo "$RUST_HITS"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "PASS: No unapproved Rust crypto crates"
+fi
+
+echo ""
+
+# ── JS package audit ─────────────────────────────────────────────────
+echo "--- JS: checking for unapproved crypto packages ---"
+
+BLOCKED_JS_PACKAGES="crypto-js|sjcl|node-forge|tweetnacl|libsodium|libsodium-wrappers|sodium-native|bcrypt|bcryptjs|argon2|scrypt|scrypt-js"
+
+cd "$PROJECT_ROOT"
+JS_HITS=$(pnpm list --depth=Infinity 2>/dev/null | grep -iE "$BLOCKED_JS_PACKAGES" || true)
+
+if [ -n "$JS_HITS" ]; then
+  echo "FAIL: Unapproved JS crypto packages found:"
+  echo "$JS_HITS"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "PASS: No unapproved JS crypto packages"
+fi
+
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo "--- Approved crypto inventory ---"
+echo "  Rust: ring (AES-256-GCM), rustls (TLS), rcgen (cert gen), jsonwebtoken (JWT)"
+echo "  Rust (transitive): sha2, hmac, cipher, ed25519-dalek (via Bitwarden SDK / sqlx)"
+echo "  JS:   node:crypto built-in (AES-256-GCM)"
+echo ""
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "AUDIT FAILED: $ERRORS unapproved crypto component(s) detected"
+  exit 1
+else
+  echo "AUDIT PASSED: all crypto components are on the approved list"
+fi
+
+################################################################################
+# Changelog:
+# 2026-03-24  Initial creation — crypto dependency audit for SBOM compliance
+################################################################################

--- a/scripts/sbom-crypto-audit.sh
+++ b/scripts/sbom-crypto-audit.sh
@@ -73,8 +73,3 @@ if [ "$ERRORS" -gt 0 ]; then
 else
   echo "AUDIT PASSED: all crypto components are on the approved list"
 fi
-
-################################################################################
-# Changelog:
-# 2026-03-24  Initial creation — crypto dependency audit for SBOM compliance
-################################################################################


### PR DESCRIPTION
Refs #235.

> First-time contributor note: CI is currently `BLOCKED` because this PR modifies `.github/workflows/ci.yml`. GitHub doesn't run workflow changes from forked PRs without maintainer approval (sensible default). Happy to demonstrate the new job running green on a self-PR within my fork if that helps before approval.

## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES.

Process note: CONTRIBUTING.md asks contributors to open an issue first for new features. Issue #235 is now open with the proposal and open questions. This PR can be reviewed as the concrete draft, or closed and re-scoped from the discussion in #235 — whichever maintainers prefer.

## What kind of change does this PR introduce?

CI / security tooling. New CI job + shell script. No application code is modified.

## What is the current behavior?

No automated check on the project's crypto dependency tree. A future PR could pull in `openssl-sys`, `crypto-js`, `node-forge`, `bcrypt`, etc. — directly or transitively — and silently expand the trusted code base of a credential vault. The current safety net is manual review.

Related issue: #235.

## What is the new behavior?

A new `SBOM Crypto Audit` job runs on every PR:

1. Walks the Rust dep tree (`cargo tree`); fails on any blocked crate (`openssl`, `openssl-sys`, `boringssl`, `boring`, `boring-sys`).
2. Walks the JS dep tree (`pnpm list --depth=Infinity`); fails on any blocked package (`crypto-js`, `sjcl`, `node-forge`, `tweetnacl`, `libsodium*`, `bcrypt*`, `argon2`, `scrypt*`).
3. On success, prints the approved-crypto inventory.

**Verification on current `main`:** script passes without any code changes — confirming the existing dep tree is already on the approved list. This PR adds a guard, not a fix.

```
=== SBOM Crypto Audit ===
--- Rust: checking for unapproved crypto crates ---
PASS: No unapproved Rust crypto crates
--- JS: checking for unapproved crypto packages ---
PASS: No unapproved JS crypto packages
AUDIT PASSED: all crypto components are on the approved list
```

## Additional context

**Why this matters for a credential vault**

- Locks the answer to "what crypto is in our trusted base?" into CI.
- Catches supply-chain regressions: a dep upgrade pulling in `openssl-sys` via a new Postgres/HTTP client becomes a CI failure, not a silent expansion.
- Surfaces the trusted set explicitly for security reviewers and downstream packagers.

**Scope / limitations**

- Approve/block lists live in the script — easy to amend.
- Open to discussion on `bcrypt` / `argon2` being blocked: currently blocked because `node:crypto` covers what the project needs, but if user-password hashing is added later those would need to be approved.
- Job adds ~30s to CI after cache warms up.
- New job (not folded into `lint`) because `lint` lacks the Rust toolchain. Happy to relocate if preferred.

**Local CI checks per CONTRIBUTING.md**

`bun run build` and `bun run check` are not relevant to this change (no application code, no types). The script itself was run against this branch on top of `main`; output above.

**Follow-up PRs (independent, opening only after this one's direction is settled)**

- `docs: AES-256-GCM wire format` — documents the at-rest encryption format
- `test(gateway): Node.js cross-validation fixture` — adds a fixed test vector to catch wire-format drift between the TS encrypter and Rust decrypter