### PR TITLE
chore: sync gateway telemetry, secrets UI, and trial budget schema

### DIFF
--- a/apps/gateway/src/cloud/hooks.rs
+++ b/apps/gateway/src/cloud/hooks.rs
@@ -1,0 +1,6 @@
+//! Cloud hooks stub — replaced by onecli-cloud overlay.
+//!
+//! This file exists so `cargo fmt` can resolve the `#[path = "cloud/hooks.rs"]`
+//! module declaration. The real implementation lives in the cloud repo.
+
+pub(crate) use super::hooks::*;

--- a/apps/gateway/src/cloud/trial.rs
+++ b/apps/gateway/src/cloud/trial.rs
@@ -1,0 +1,4 @@
+//! Cloud trial stub — replaced by onecli-cloud overlay.
+//!
+//! This file exists so `cargo fmt` can resolve the `#[path = "cloud/trial.rs"]`
+//! module declaration. The real implementation lives in the cloud repo.

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -44,6 +44,12 @@ pub(crate) struct ConnectResponse {
     /// a more helpful error ("grant access") instead of "connect the app".
     #[serde(default)]
     pub access_restricted: bool,
+    /// True when credentials were injected from a platform-provisioned secret (trial mode).
+    #[serde(default)]
+    pub is_trial: bool,
+    /// True when the trial budget is exhausted — requests should be blocked.
+    #[serde(default)]
+    pub budget_blocked: bool,
 }
 
 /// Result of per-request app connection resolution.
@@ -145,7 +151,7 @@ impl PolicyEngine {
         agent: &db::AgentRow,
         hostname: &str,
     ) -> Result<ConnectResponse, ConnectError> {
-        let injection_rules = self.resolve_secret_injections(agent, hostname).await?;
+        let (injection_rules, is_trial) = self.resolve_secret_injections(agent, hostname).await?;
         let app_connections = self.resolve_app_connections(agent, hostname).await?;
         let policy_rules = self.resolve_policy_rules(agent, hostname).await?;
         let has_rules =
@@ -157,6 +163,14 @@ impl PolicyEngine {
             && agent.secret_mode == SECRET_MODE_SELECTIVE
             && self.has_project_credentials(agent, hostname).await;
 
+        let budget_blocked = if is_trial {
+            db::is_trial_budget_blocked(&self.pool, &agent.project_id)
+                .await
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
         Ok(ConnectResponse {
             intercept: has_rules || access_restricted,
             injection_rules,
@@ -167,15 +181,18 @@ impl PolicyEngine {
             agent_name: Some(agent.name.clone()),
             agent_identifier: agent.identifier.clone(),
             access_restricted,
+            is_trial,
+            budget_blocked,
         })
     }
 
     /// Build injection rules from secrets matching this host.
+    /// Returns `(rules, has_platform_secret)`.
     async fn resolve_secret_injections(
         &self,
         agent: &db::AgentRow,
         hostname: &str,
-    ) -> Result<Vec<InjectionRule>, ConnectError> {
+    ) -> Result<(Vec<InjectionRule>, bool), ConnectError> {
         let secrets = if agent.secret_mode == SECRET_MODE_SELECTIVE {
             db::find_secrets_by_agent(&self.pool, &agent.id).await
         } else {
@@ -187,6 +204,8 @@ impl PolicyEngine {
             .into_iter()
             .filter(|s| host_matches(hostname, &s.host_pattern))
             .collect();
+
+        let has_platform = matching.iter().any(|s| s.is_platform);
 
         let mut rules = Vec::with_capacity(matching.len());
         for secret in &matching {
@@ -208,7 +227,7 @@ impl PolicyEngine {
             });
         }
 
-        Ok(rules)
+        Ok((rules, has_platform))
     }
 
     /// Fetch app connections matching providers for this host (deferred resolution).
@@ -865,6 +884,8 @@ mod tests {
             agent_name: None,
             agent_identifier: None,
             access_restricted: false,
+            is_trial: false,
+            budget_blocked: false,
         };
 
         store
@@ -906,6 +927,8 @@ mod tests {
             agent_name: Some("Test".to_string()),
             agent_identifier: None,
             access_restricted: false,
+            is_trial: false,
+            budget_blocked: false,
         };
 
         // Pre-populate cache with the key format that resolve() uses
@@ -939,6 +962,8 @@ mod tests {
             agent_name: Some("Selective Agent".to_string()),
             agent_identifier: None,
             access_restricted: true,
+            is_trial: false,
+            budget_blocked: false,
         };
 
         store

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -38,6 +38,7 @@ pub(crate) struct SecretRow {
     pub host_pattern: String,
     pub path_pattern: Option<String>,
     pub injection_config: Option<serde_json::Value>,
+    pub is_platform: bool,
 }
 
 /// A policy rule row from the `policy_rules` table.
@@ -146,7 +147,7 @@ pub(crate) async fn find_secrets_by_project(
     project_id: &str,
 ) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT type, encrypted_value, host_pattern, path_pattern, injection_config FROM secrets WHERE project_id = $1"#,
+        r#"SELECT type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform FROM secrets WHERE project_id = $1"#,
     )
     .bind(project_id)
     .fetch_all(pool)
@@ -157,7 +158,7 @@ pub(crate) async fn find_secrets_by_project(
 /// Find secrets assigned to a specific agent (selective mode).
 pub(crate) async fn find_secrets_by_agent(pool: &PgPool, agent_id: &str) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT s.type, s.encrypted_value, s.host_pattern, s.path_pattern, s.injection_config
+        r#"SELECT s.type, s.encrypted_value, s.host_pattern, s.path_pattern, s.injection_config, s.is_platform
            FROM secrets s
            INNER JOIN agent_secrets as_ ON s.id = as_.secret_id
            WHERE as_.agent_id = $1"#,
@@ -330,6 +331,23 @@ pub(crate) async fn update_vault_connection_data(
     .await
     .context("updating vault_connection connection_data")?;
     Ok(())
+}
+
+/// Check if the trial budget for the project's owner is exhausted.
+pub(crate) async fn is_trial_budget_blocked(pool: &PgPool, project_id: &str) -> Result<bool> {
+    let row: Option<(String,)> = sqlx::query_as(
+        r#"SELECT tb.status
+           FROM trial_budgets tb
+           INNER JOIN organization_members om ON om.user_id = tb.user_id
+           INNER JOIN projects p ON p.organization_id = om.organization_id
+           WHERE p.id = $1 AND tb.status = 'exhausted'
+           LIMIT 1"#,
+    )
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await
+    .context("checking trial budget status")?;
+    Ok(row.is_some())
 }
 
 /// Delete a vault connection for a project + provider pair.

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -14,9 +14,18 @@
 //! - [`response`]: pre-built gateway error responses
 
 pub(crate) mod forward;
+#[cfg(not(feature = "cloud"))]
+mod hooks;
+#[cfg(feature = "cloud")]
+#[path = "cloud/hooks.rs"]
+mod hooks;
 mod mitm;
 mod response;
 mod tunnel;
+
+#[cfg(feature = "cloud")]
+#[path = "cloud/trial.rs"]
+mod trial;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -655,6 +664,8 @@ async fn handle_http_proxy(
         policy_rules: resolved.policy_rules,
         access_restricted: resolved.access_restricted,
         intercept_token: None,
+        is_trial: resolved.is_trial,
+        budget_blocked: resolved.budget_blocked,
     };
 
     let mut resp = forward::forward_request(

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use futures_util::{StreamExt, TryStreamExt};
-use http_body_util::{Either, Full, StreamBody};
+use http_body_util::{Either, Full};
 use hyper::body::{Bytes, Frame, Incoming};
 use hyper::header::HeaderName;
 use hyper::{Request, Response, StatusCode};
@@ -21,6 +21,7 @@ use crate::cache::CacheStore;
 use crate::inject;
 use crate::policy::{self, PolicyDecision};
 
+use super::hooks;
 use super::mitm::ResolvedRules;
 use super::response;
 use super::ProxyContext;
@@ -95,14 +96,7 @@ pub(crate) async fn forward_request(
     cache: &dyn CacheStore,
     proxy_ctx: &ProxyContext,
     approval_store: &Arc<dyn ApprovalStore>,
-) -> Result<
-    Response<
-        Either<
-            Full<Bytes>,
-            StreamBody<impl futures_util::Stream<Item = Result<Frame<Bytes>, reqwest::Error>>>,
-        >,
-    >,
-> {
+) -> Result<Response<hooks::ForwardResponseBody>> {
     let start = std::time::Instant::now();
     let method = req.method().clone();
     let path = req
@@ -195,12 +189,19 @@ pub(crate) async fn forward_request(
         None
     };
 
+    hooks::prepare_request(rules, host, &path, &mut headers);
+
     // Apply injection rules — upstream_path may gain query-param secrets;
     // the original `path`/`url` stays clean for logging and approval metadata.
     let mut upstream_path = path.clone();
     let injection_count =
         inject::apply_injections(&mut headers, &mut upstream_path, &rules.injection_rules);
     let upstream_url = format!("{scheme}://{host}{upstream_path}");
+
+    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx) {
+        return Ok(resp);
+    }
+
     // ── ManualApproval: prepare body, store, wait for decision ─────
     let forward_body = if let PolicyDecision::ManualApproval { rule_id } = &decision {
         info!(method = %method, url = %url, rule_id = %rule_id, "MANUAL APPROVAL required");
@@ -326,7 +327,7 @@ pub(crate) async fn forward_request(
         reqwest::Body::wrap(body)
     };
 
-    // ── Shared: forward to upstream and stream response back ──────
+    // ── Forward to upstream ──────────────────────────────────────────
     let mut upstream = http_client.request(method.clone(), &upstream_url);
     for (name, value) in headers.iter() {
         upstream = upstream.header(name.clone(), value.clone());
@@ -340,46 +341,6 @@ pub(crate) async fn forward_request(
 
     let status = upstream_resp.status();
     let resp_headers = upstream_resp.headers().clone();
-
-    // Track credential-injected requests (Postgres + PostHog + Redis)
-    if injection_count > 0 {
-        if let (Some(aid), Some(gid)) = (
-            proxy_ctx.project_id.as_deref(),
-            proxy_ctx.agent_id.as_deref(),
-        ) {
-            let hostname = super::strip_port(host);
-            let (provider, _) = crate::apps::provider_for_host_and_path(hostname, &path)
-                .unwrap_or((hostname, hostname));
-
-            let ts = time::OffsetDateTime::now_utc()
-                .format(&time::format_description::well_known::Iso8601::DEFAULT)
-                .unwrap_or_default();
-
-            // Strip query params to avoid logging sensitive data (API keys, tokens)
-            let telemetry_path = match path.find('?') {
-                Some(i) => &path[..i],
-                None => &path,
-            };
-
-            crate::telemetry::on_request(crate::telemetry::RequestEvent {
-                project_id: aid.to_string(),
-                agent_id: gid.to_string(),
-                agent_name: proxy_ctx
-                    .agent_name
-                    .as_deref()
-                    .unwrap_or("unknown")
-                    .to_string(),
-                method: method.to_string(),
-                host: host.to_string(),
-                path: telemetry_path.to_string(),
-                provider: provider.to_string(),
-                status: status.as_u16(),
-                latency_ms: start.elapsed().as_millis() as u32,
-                injection_count: injection_count as u16,
-                timestamp: ts,
-            });
-        }
-    }
 
     // If no credentials were injected and upstream returned 401/403,
     // guide the agent to connect/configure credentials in OneCLI.
@@ -489,10 +450,50 @@ pub(crate) async fn forward_request(
         "MITM"
     );
 
-    // Stream response body to client (no buffering — critical for SSE)
-    let resp_stream = upstream_resp.bytes_stream().map_ok(Frame::data);
-    let body = StreamBody::new(resp_stream);
+    // Track all authenticated proxied requests and stream response body.
+    // Hooks handle telemetry emission and optional response stream wrapping.
+    let body_stream: hooks::BodyStream = if let (Some(aid), Some(gid)) = (
+        proxy_ctx.project_id.as_deref(),
+        proxy_ctx.agent_id.as_deref(),
+    ) {
+        let hostname = super::strip_port(host);
+        let (provider, _) = crate::apps::provider_for_host_and_path(hostname, &path)
+            .unwrap_or((hostname, hostname));
 
+        let ts = time::OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Iso8601::DEFAULT)
+            .unwrap_or_default();
+
+        let telemetry_path = match path.find('?') {
+            Some(i) => &path[..i],
+            None => &path,
+        };
+
+        let meta = hooks::RequestMeta {
+            project_id: aid.to_string(),
+            agent_id: gid.to_string(),
+            agent_name: proxy_ctx
+                .agent_name
+                .as_deref()
+                .unwrap_or("unknown")
+                .to_string(),
+            method: method.to_string(),
+            host: host.to_string(),
+            path: telemetry_path.to_string(),
+            provider: provider.to_string(),
+            status: status.as_u16(),
+            latency_ms: start.elapsed().as_millis() as u32,
+            injection_count: injection_count as u16,
+            timestamp: ts,
+            injected: injection_count > 0,
+        };
+
+        hooks::track_and_wrap(meta, rules, &resp_headers, upstream_resp.bytes_stream())
+    } else {
+        Box::pin(upstream_resp.bytes_stream().map_ok(Frame::data))
+    };
+
+    let body = http_body_util::StreamBody::new(body_stream);
     let mut response = Response::new(Either::Right(body));
     *response.status_mut() = status;
 

--- a/apps/gateway/src/gateway/hooks.rs
+++ b/apps/gateway/src/gateway/hooks.rs
@@ -1,0 +1,78 @@
+//! Forward hooks — extension points for the request forwarding pipeline.
+//!
+//! OSS version: all hooks are no-ops. The cloud build swaps this module
+//! via `#[path = "cloud/hooks.rs"]` to add trial budget enforcement and
+//! Anthropic token tracking.
+
+use std::pin::Pin;
+
+use futures_util::TryStreamExt;
+use http_body_util::{Either, Full, StreamBody};
+use hyper::body::{Bytes, Frame};
+use hyper::Response;
+
+use super::mitm::ResolvedRules;
+use super::ProxyContext;
+
+// ── Shared types ────────────────────────────────────────────────────────
+
+pub(crate) type BodyStream =
+    Pin<Box<dyn futures_util::Stream<Item = Result<Frame<Bytes>, reqwest::Error>> + Send>>;
+
+pub(crate) type ForwardResponseBody = Either<Full<Bytes>, StreamBody<BodyStream>>;
+
+/// Common telemetry fields for a proxied request, passed from forward to hooks.
+pub(crate) struct RequestMeta {
+    pub project_id: String,
+    pub agent_id: String,
+    pub agent_name: String,
+    pub method: String,
+    pub host: String,
+    pub path: String,
+    pub provider: String,
+    pub status: u16,
+    pub latency_ms: u32,
+    pub injection_count: u16,
+    pub timestamp: String,
+    pub injected: bool,
+}
+
+// ── Hooks ───────────────────────────────────────────────────────────────
+
+pub(crate) fn prepare_request(
+    _rules: &ResolvedRules,
+    _host: &str,
+    _path: &str,
+    _headers: &mut hyper::HeaderMap,
+) {
+}
+
+pub(crate) fn pre_forward(
+    _rules: &ResolvedRules,
+    _proxy_ctx: &ProxyContext,
+) -> Option<Response<ForwardResponseBody>> {
+    None
+}
+
+pub(crate) fn track_and_wrap(
+    meta: RequestMeta,
+    _rules: &ResolvedRules,
+    _resp_headers: &hyper::HeaderMap,
+    stream: impl futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+) -> BodyStream {
+    crate::telemetry::on_request(crate::telemetry::RequestEvent {
+        project_id: meta.project_id,
+        agent_id: meta.agent_id,
+        agent_name: meta.agent_name,
+        method: meta.method,
+        host: meta.host,
+        path: meta.path,
+        provider: meta.provider,
+        status: meta.status,
+        latency_ms: meta.latency_ms,
+        injection_count: meta.injection_count,
+        timestamp: meta.timestamp,
+        injected: meta.injected,
+    });
+    Box::pin(stream.map_ok(Frame::data))
+}

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -147,6 +147,12 @@ pub(crate) struct ResolvedRules {
     /// Ready-to-use interception data when the resolved connection has a
     /// cached token that should be served instead of forwarding.
     pub intercept_token: Option<InterceptToken>,
+    /// True when credentials come from a platform-provisioned secret (trial mode).
+    #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+    pub is_trial: bool,
+    /// True when the trial budget is exhausted — requests should be blocked.
+    #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+    pub budget_blocked: bool,
 }
 
 /// Result of per-request rule resolution including app connection disambiguation.
@@ -265,6 +271,8 @@ async fn resolve_rules(
             policy_rules: resp.policy_rules,
             access_restricted: resp.access_restricted,
             intercept_token,
+            is_trial: resp.is_trial,
+            budget_blocked: resp.budget_blocked,
         },
         app_connections: resp.app_connections,
     })

--- a/apps/gateway/src/telemetry.rs
+++ b/apps/gateway/src/telemetry.rs
@@ -14,10 +14,10 @@ use tracing::{info, warn};
 
 use crate::cache::CacheStore;
 use crate::telemetry_core::{
-    collect_batch, insert_batch, CHANNEL_CAPACITY, FLUSH_BATCH_SIZE, SENDER,
+    collect_batch, extract_columns, CHANNEL_CAPACITY, FLUSH_BATCH_SIZE, SENDER,
 };
 
-// Re-export shared types for consumer code (forward.rs)
+// Re-export shared types for consumer code
 pub(crate) use crate::telemetry_core::{on_request, RequestEvent};
 
 /// Initialize the telemetry background flush task.
@@ -27,6 +27,33 @@ pub(crate) fn init(pool: PgPool, _cache: Arc<dyn CacheStore>) {
     SENDER.set(tx).ok();
     tokio::spawn(flush_loop(rx, pool));
     info!("telemetry initialized (postgres)");
+}
+
+async fn insert_batch(pool: &PgPool, events: &[RequestEvent]) -> Result<(), sqlx::Error> {
+    let injected: Vec<&RequestEvent> = events.iter().filter(|e| e.injected).collect();
+    if injected.is_empty() {
+        return Ok(());
+    }
+    let c = extract_columns(&injected);
+
+    sqlx::query(
+        "INSERT INTO request_logs (id, project_id, agent_id, method, host, path, provider, status, latency_ms, injection_count)
+         SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[], $8::int4[], $9::int4[], $10::int4[])",
+    )
+    .bind(&c.ids)
+    .bind(&c.project_ids)
+    .bind(&c.agent_ids)
+    .bind(&c.methods)
+    .bind(&c.hosts)
+    .bind(&c.paths)
+    .bind(&c.providers)
+    .bind(&c.statuses)
+    .bind(&c.latencies)
+    .bind(&c.injections)
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 async fn flush_loop(mut rx: mpsc::Receiver<RequestEvent>, pool: PgPool) {

--- a/apps/gateway/src/telemetry_core.rs
+++ b/apps/gateway/src/telemetry_core.rs
@@ -6,7 +6,6 @@
 
 use std::sync::OnceLock;
 
-use sqlx::PgPool;
 use tokio::sync::mpsc;
 
 pub(crate) const FLUSH_INTERVAL_SECS: u64 = 5;
@@ -28,6 +27,20 @@ pub(crate) struct RequestEvent {
     pub injection_count: u16,
     #[allow(dead_code)] // read by cloud telemetry (PostHog), unused in OSS
     pub timestamp: String,
+    pub injected: bool,
+    #[cfg(feature = "cloud")]
+    pub model: Option<String>,
+    #[cfg(feature = "cloud")]
+    pub input_tokens: Option<i32>,
+    #[cfg(feature = "cloud")]
+    pub output_tokens: Option<i32>,
+    #[cfg(feature = "cloud")]
+    pub cache_creation_input_tokens: Option<i32>,
+    #[cfg(feature = "cloud")]
+    pub cache_read_input_tokens: Option<i32>,
+    #[cfg(feature = "cloud")]
+    #[allow(dead_code)] // read by cloud telemetry (token counters), unused in OSS
+    pub is_trial: bool,
 }
 
 pub(crate) static SENDER: OnceLock<mpsc::Sender<RequestEvent>> = OnceLock::new();
@@ -70,41 +83,80 @@ pub(crate) async fn collect_batch(
     }
 }
 
-/// Batch INSERT events into the `request_logs` table using UNNEST.
-pub(crate) async fn insert_batch(
-    pool: &PgPool,
-    events: &[RequestEvent],
-) -> Result<(), sqlx::Error> {
-    let ids: Vec<String> = events
-        .iter()
-        .map(|_| uuid::Uuid::new_v4().to_string())
-        .collect();
-    let project_ids: Vec<String> = events.iter().map(|e| e.project_id.clone()).collect();
-    let agent_ids: Vec<String> = events.iter().map(|e| e.agent_id.clone()).collect();
-    let methods: Vec<String> = events.iter().map(|e| e.method.clone()).collect();
-    let hosts: Vec<String> = events.iter().map(|e| e.host.clone()).collect();
-    let paths: Vec<String> = events.iter().map(|e| e.path.clone()).collect();
-    let providers: Vec<String> = events.iter().map(|e| e.provider.clone()).collect();
-    let statuses: Vec<i32> = events.iter().map(|e| e.status as i32).collect();
-    let latencies: Vec<i32> = events.iter().map(|e| e.latency_ms as i32).collect();
-    let injections: Vec<i32> = events.iter().map(|e| e.injection_count as i32).collect();
+/// Pre-extracted column vectors for batch INSERT into `request_logs`.
+/// Accepts `&[&RequestEvent]` so callers can filter before extracting.
+pub(crate) struct BatchColumns {
+    pub ids: Vec<String>,
+    pub project_ids: Vec<String>,
+    pub agent_ids: Vec<String>,
+    pub methods: Vec<String>,
+    pub hosts: Vec<String>,
+    pub paths: Vec<String>,
+    pub providers: Vec<String>,
+    pub statuses: Vec<i32>,
+    pub latencies: Vec<i32>,
+    pub injections: Vec<i32>,
+}
 
-    sqlx::query(
-        "INSERT INTO request_logs (id, project_id, agent_id, method, host, path, provider, status, latency_ms, injection_count)
-         SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[], $8::int4[], $9::int4[], $10::int4[])",
-    )
-    .bind(&ids)
-    .bind(&project_ids)
-    .bind(&agent_ids)
-    .bind(&methods)
-    .bind(&hosts)
-    .bind(&paths)
-    .bind(&providers)
-    .bind(&statuses)
-    .bind(&latencies)
-    .bind(&injections)
-    .execute(pool)
-    .await?;
+pub(crate) fn extract_columns(events: &[&RequestEvent]) -> BatchColumns {
+    BatchColumns {
+        ids: events
+            .iter()
+            .map(|_| uuid::Uuid::new_v4().to_string())
+            .collect(),
+        project_ids: events.iter().map(|e| e.project_id.clone()).collect(),
+        agent_ids: events.iter().map(|e| e.agent_id.clone()).collect(),
+        methods: events.iter().map(|e| e.method.clone()).collect(),
+        hosts: events.iter().map(|e| e.host.clone()).collect(),
+        paths: events.iter().map(|e| e.path.clone()).collect(),
+        providers: events.iter().map(|e| e.provider.clone()).collect(),
+        statuses: events.iter().map(|e| e.status as i32).collect(),
+        latencies: events.iter().map(|e| e.latency_ms as i32).collect(),
+        injections: events.iter().map(|e| e.injection_count as i32).collect(),
+    }
+}
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_event() -> RequestEvent {
+        RequestEvent {
+            project_id: "p1".into(),
+            agent_id: "a1".into(),
+            agent_name: "test".into(),
+            method: "POST".into(),
+            host: "api.anthropic.com".into(),
+            path: "/v1/messages".into(),
+            provider: "anthropic".into(),
+            status: 200,
+            latency_ms: 100,
+            injection_count: 1,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            injected: true,
+            #[cfg(feature = "cloud")]
+            model: None,
+            #[cfg(feature = "cloud")]
+            input_tokens: None,
+            #[cfg(feature = "cloud")]
+            output_tokens: None,
+            #[cfg(feature = "cloud")]
+            cache_creation_input_tokens: None,
+            #[cfg(feature = "cloud")]
+            cache_read_input_tokens: None,
+            #[cfg(feature = "cloud")]
+            is_trial: false,
+        }
+    }
+
+    #[test]
+    fn on_request_truncates_long_paths() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        SENDER.set(tx).ok();
+        let mut ev = base_event();
+        ev.path = "x".repeat(MAX_PATH_LEN + 100);
+        on_request(ev);
+        let received = rx.try_recv().unwrap();
+        assert_eq!(received.path.len(), MAX_PATH_LEN);
+    }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@aws-amplify/adapter-nextjs": "^1.7.2",
     "@aws-sdk/client-kms": "^3.1014.0",
+    "@aws-sdk/client-secrets-manager": "^3.1014.0",
     "@onecli/db": "workspace:*",
     "@onecli/ui": "workspace:*",
     "aws-amplify": "^6.16.2",

--- a/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
@@ -36,6 +36,7 @@ interface ConnectedItem {
     hostPattern: string;
     pathPattern: string | null;
     injectionConfig: unknown;
+    isPlatform: boolean;
     createdAt: Date;
   };
 }

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx
@@ -35,6 +35,7 @@ interface SecretCardProps {
     hostPattern: string;
     pathPattern: string | null;
     injectionConfig: unknown;
+    isPlatform: boolean;
     createdAt: Date;
   };
   onUpdate: () => void;
@@ -71,6 +72,11 @@ export const SecretCard = ({ secret, onUpdate }: SecretCardProps) => {
               <Badge variant="secondary" className="text-xs">
                 {secret.typeLabel}
               </Badge>
+              {secret.isPlatform && (
+                <Badge variant="outline" className="text-xs text-brand">
+                  Trial
+                </Badge>
+              )}
             </div>
 
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -71,6 +71,7 @@ export interface SecretItem {
   hostPattern: string;
   pathPattern: string | null;
   injectionConfig: unknown;
+  isPlatform: boolean;
 }
 
 export interface SecretPrefill {
@@ -210,13 +211,16 @@ export const SecretDialog = ({
     type !== "generic" ||
     (injectionTarget === "header" ? headerName.trim() : paramName.trim());
 
-  const isValid = isEdit
-    ? hostPattern.trim() && !hostPatternError && hasInjectionTarget
-    : isNameValid &&
-      value.trim() &&
-      hostPattern.trim() &&
-      !hostPatternError &&
-      hasInjectionTarget;
+  const isPlatformEdit = isEdit && secret?.isPlatform;
+  const isValid = isPlatformEdit
+    ? !!value.trim()
+    : isEdit
+      ? hostPattern.trim() && !hostPatternError && hasInjectionTarget
+      : isNameValid &&
+        value.trim() &&
+        hostPattern.trim() &&
+        !hostPatternError &&
+        hasInjectionTarget;
 
   const handleSave = async () => {
     if (!isValid) return;
@@ -231,13 +235,18 @@ export const SecretDialog = ({
       };
 
       if (isEdit) {
-        await updateSecret(secret.id, {
-          name: name !== secret.name ? name : undefined,
-          value: value.trim() || undefined,
-          hostPattern,
-          pathPattern: pathPattern || null,
-          injectionConfig: buildInjectionConfig() ?? undefined,
-        });
+        await updateSecret(
+          secret.id,
+          secret.isPlatform
+            ? { value: value.trim() }
+            : {
+                name: name !== secret.name ? name : undefined,
+                value: value.trim() || undefined,
+                hostPattern,
+                pathPattern: pathPattern || null,
+                injectionConfig: buildInjectionConfig() ?? undefined,
+              },
+        );
         toast.success("Secret updated");
       } else {
         await createSecret({
@@ -286,11 +295,13 @@ export const SecretDialog = ({
                 </DialogTitle>
               </div>
               <DialogDescription>
-                {isEdit
-                  ? "Update the secret\u2019s configuration. Leave the value field empty to keep the current value."
-                  : type === "anthropic"
-                    ? "Your key will be encrypted and injected into requests to api.anthropic.com."
-                    : "Configure a custom secret to inject as a header or URL parameter into matching requests."}
+                {isPlatformEdit
+                  ? "Replace the trial key with your own Anthropic key to continue using Claude."
+                  : isEdit
+                    ? "Update the secret\u2019s configuration. Leave the value field empty to keep the current value."
+                    : type === "anthropic"
+                      ? "Your key will be encrypted and injected into requests to api.anthropic.com."
+                      : "Configure a custom secret to inject as a header or URL parameter into matching requests."}
               </DialogDescription>
               {type === "generic" && !isEdit && !prefill && (
                 <div className="flex items-center gap-2 pt-1">
@@ -329,30 +340,36 @@ export const SecretDialog = ({
             </DialogHeader>
 
             <div className="min-h-0 space-y-4 overflow-y-auto py-2">
-              <div className="space-y-2">
-                <Label htmlFor="secret-name">Name</Label>
-                <Input
-                  id="secret-name"
-                  placeholder={
-                    type === "anthropic"
-                      ? "e.g. Anthropic Production Key"
-                      : "e.g. GitHub Token"
-                  }
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  onBlur={() => setNameTouched(true)}
-                  autoFocus
-                  className={cn(showNameError && "border-destructive")}
-                />
-                {showNameError && (
-                  <p className="text-destructive text-xs">{nameError}</p>
-                )}
-              </div>
+              {!isPlatformEdit && (
+                <div className="space-y-2">
+                  <Label htmlFor="secret-name">Name</Label>
+                  <Input
+                    id="secret-name"
+                    placeholder={
+                      type === "anthropic"
+                        ? "e.g. Anthropic Production Key"
+                        : "e.g. GitHub Token"
+                    }
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    onBlur={() => setNameTouched(true)}
+                    autoFocus
+                    className={cn(showNameError && "border-destructive")}
+                  />
+                  {showNameError && (
+                    <p className="text-destructive text-xs">{nameError}</p>
+                  )}
+                </div>
+              )}
 
               <div className="space-y-2">
                 <Label htmlFor="secret-value">
-                  {isEdit ? "New value" : "Secret value"}{" "}
-                  {isEdit && (
+                  {isPlatformEdit
+                    ? "Your API key"
+                    : isEdit
+                      ? "New value"
+                      : "Secret value"}{" "}
+                  {isEdit && !isPlatformEdit && (
                     <span className="text-muted-foreground font-normal">
                       (leave empty to keep current)
                     </span>
@@ -530,111 +547,116 @@ export const SecretDialog = ({
                 </div>
               )}
 
-              <Accordion
-                type="single"
-                collapsible
-                className="border-none"
-                defaultValue={undefined}
-              >
-                <AccordionItem value="advanced" className="border-t border-b-0">
-                  <AccordionTrigger className="py-3 hover:no-underline">
-                    <span className="text-muted-foreground flex items-center gap-2 text-xs font-normal">
-                      <Settings2 className="size-3.5" />
-                      Advanced settings
-                    </span>
-                  </AccordionTrigger>
-                  <AccordionContent className="pb-0">
-                    <div className="space-y-4">
-                      {(type === "anthropic" ||
-                        (type === "generic" && !!prefill)) && (
+              {isPlatformEdit ? null : (
+                <Accordion
+                  type="single"
+                  collapsible
+                  className="border-none"
+                  defaultValue={undefined}
+                >
+                  <AccordionItem
+                    value="advanced"
+                    className="border-t border-b-0"
+                  >
+                    <AccordionTrigger className="py-3 hover:no-underline">
+                      <span className="text-muted-foreground flex items-center gap-2 text-xs font-normal">
+                        <Settings2 className="size-3.5" />
+                        Advanced settings
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="pb-0">
+                      <div className="space-y-4">
+                        {(type === "anthropic" ||
+                          (type === "generic" && !!prefill)) && (
+                          <div className="space-y-2">
+                            <Label htmlFor="secret-host">Host pattern</Label>
+                            <Input
+                              id="secret-host"
+                              placeholder="e.g. api.example.com or *.example.com"
+                              value={hostPattern}
+                              onChange={(e) => setHostPattern(e.target.value)}
+                              disabled={!!prefill}
+                            />
+                            {hostPatternError ? (
+                              <p className="text-xs text-red-500">
+                                {hostPatternError}
+                              </p>
+                            ) : (
+                              <p className="text-muted-foreground text-xs">
+                                The host this secret applies to. Use{" "}
+                                <code className="text-xs">*.example.com</code>{" "}
+                                for wildcard subdomains.
+                              </p>
+                            )}
+                          </div>
+                        )}
+
                         <div className="space-y-2">
-                          <Label htmlFor="secret-host">Host pattern</Label>
-                          <Input
-                            id="secret-host"
-                            placeholder="e.g. api.example.com or *.example.com"
-                            value={hostPattern}
-                            onChange={(e) => setHostPattern(e.target.value)}
-                            disabled={!!prefill}
-                          />
-                          {hostPatternError ? (
-                            <p className="text-xs text-red-500">
-                              {hostPatternError}
-                            </p>
-                          ) : (
-                            <p className="text-muted-foreground text-xs">
-                              The host this secret applies to. Use{" "}
-                              <code className="text-xs">*.example.com</code> for
-                              wildcard subdomains.
-                            </p>
-                          )}
-                        </div>
-                      )}
-
-                      <div className="space-y-2">
-                        <Label htmlFor="secret-path">
-                          Path pattern{" "}
-                          <span className="text-muted-foreground font-normal">
-                            (optional)
-                          </span>
-                        </Label>
-                        <Input
-                          id="secret-path"
-                          placeholder="e.g. /v1/*"
-                          value={pathPattern}
-                          onChange={(e) => setPathPattern(e.target.value)}
-                        />
-                      </div>
-
-                      {type === "generic" && (
-                        <div
-                          key={`format-${injectionTarget}`}
-                          className="animate-in fade-in duration-150 space-y-2"
-                        >
-                          <Label
-                            htmlFor={
-                              injectionTarget === "header"
-                                ? "secret-format"
-                                : "secret-param-format"
-                            }
-                          >
-                            Value format{" "}
+                          <Label htmlFor="secret-path">
+                            Path pattern{" "}
                             <span className="text-muted-foreground font-normal">
                               (optional)
                             </span>
                           </Label>
                           <Input
-                            id={
-                              injectionTarget === "header"
-                                ? "secret-format"
-                                : "secret-param-format"
-                            }
-                            placeholder={
-                              injectionTarget === "header"
-                                ? "e.g. Bearer {value}"
-                                : "e.g. {value}"
-                            }
-                            value={
-                              injectionTarget === "header"
-                                ? valueFormat
-                                : paramFormat
-                            }
-                            onChange={(e) =>
-                              injectionTarget === "header"
-                                ? setValueFormat(e.target.value)
-                                : setParamFormat(e.target.value)
-                            }
+                            id="secret-path"
+                            placeholder="e.g. /v1/*"
+                            value={pathPattern}
+                            onChange={(e) => setPathPattern(e.target.value)}
                           />
-                          <p className="text-muted-foreground text-xs">
-                            Use <code className="text-xs">{"{value}"}</code> as
-                            a placeholder for the secret. Defaults to the raw
-                            value.
-                          </p>
                         </div>
-                      )}
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
+
+                        {type === "generic" && (
+                          <div
+                            key={`format-${injectionTarget}`}
+                            className="animate-in fade-in duration-150 space-y-2"
+                          >
+                            <Label
+                              htmlFor={
+                                injectionTarget === "header"
+                                  ? "secret-format"
+                                  : "secret-param-format"
+                              }
+                            >
+                              Value format{" "}
+                              <span className="text-muted-foreground font-normal">
+                                (optional)
+                              </span>
+                            </Label>
+                            <Input
+                              id={
+                                injectionTarget === "header"
+                                  ? "secret-format"
+                                  : "secret-param-format"
+                              }
+                              placeholder={
+                                injectionTarget === "header"
+                                  ? "e.g. Bearer {value}"
+                                  : "e.g. {value}"
+                              }
+                              value={
+                                injectionTarget === "header"
+                                  ? valueFormat
+                                  : paramFormat
+                              }
+                              onChange={(e) =>
+                                injectionTarget === "header"
+                                  ? setValueFormat(e.target.value)
+                                  : setParamFormat(e.target.value)
+                              }
+                            />
+                            <p className="text-muted-foreground text-xs">
+                              Use <code className="text-xs">{"{value}"}</code>{" "}
+                              as a placeholder for the secret. Defaults to the
+                              raw value.
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              )}
             </div>
 
             <DialogFooter>

--- a/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
@@ -18,6 +18,7 @@ interface Secret {
   hostPattern: string;
   pathPattern: string | null;
   injectionConfig: unknown;
+  isPlatform: boolean;
   createdAt: Date;
 }
 

--- a/apps/web/src/lib/services/secret-service.ts
+++ b/apps/web/src/lib/services/secret-service.ts
@@ -34,6 +34,7 @@ export const listSecrets = async (projectId: string) => {
       hostPattern: true,
       pathPattern: true,
       injectionConfig: true,
+      isPlatform: true,
       createdAt: true,
     },
     orderBy: { createdAt: "desc" },
@@ -146,10 +147,25 @@ export const updateSecret = async (
 ) => {
   const secret = await db.secret.findFirst({
     where: { id: secretId, projectId },
-    select: { id: true, type: true },
+    select: { id: true, type: true, isPlatform: true },
   });
 
   if (!secret) throw new ServiceError("NOT_FOUND", "Secret not found");
+
+  if (secret.isPlatform) {
+    const hasNonValueFields =
+      input.name !== undefined ||
+      input.hostPattern !== undefined ||
+      input.pathPattern !== undefined ||
+      input.injectionConfig !== undefined;
+    if (hasNonValueFields)
+      throw new ServiceError(
+        "FORBIDDEN",
+        "Only the value can be updated on platform secrets",
+      );
+    if (input.value === undefined)
+      throw new ServiceError("BAD_REQUEST", "Value is required");
+  }
 
   const data: Record<string, unknown> = {};
 
@@ -164,6 +180,10 @@ export const updateSecret = async (
     if (!value)
       throw new ServiceError("BAD_REQUEST", "Secret value is required");
     data.encryptedValue = await cryptoService.encrypt(value);
+
+    if (secret.isPlatform) {
+      data.isPlatform = false;
+    }
 
     // Re-detect auth mode when value changes for Anthropic secrets
     if (secret.type === "anthropic") {

--- a/packages/db/prisma/migrations/20260430110827_add_trial_budget/migration.sql
+++ b/packages/db/prisma/migrations/20260430110827_add_trial_budget/migration.sql
@@ -1,0 +1,30 @@
+-- AlterTable
+ALTER TABLE "request_logs" ADD COLUMN     "cache_creation_input_tokens" INTEGER,
+ADD COLUMN     "cache_read_input_tokens" INTEGER,
+ADD COLUMN     "cost_microcents" INTEGER,
+ADD COLUMN     "input_tokens" INTEGER,
+ADD COLUMN     "model" TEXT,
+ADD COLUMN     "output_tokens" INTEGER;
+
+-- AlterTable
+ALTER TABLE "secrets" ADD COLUMN     "is_platform" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "trial_budgets" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "budget_cents" INTEGER NOT NULL DEFAULT 500,
+    "spent_cents" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "last_synced_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "trial_budgets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "trial_budgets_user_id_key" ON "trial_budgets"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "trial_budgets" ADD CONSTRAINT "trial_budgets_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260430142459_replace_token_columns_with_extra_data/migration.sql
+++ b/packages/db/prisma/migrations/20260430142459_replace_token_columns_with_extra_data/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `cache_creation_input_tokens` on the `request_logs` table. All the data in the column will be lost.
+  - You are about to drop the column `cache_read_input_tokens` on the `request_logs` table. All the data in the column will be lost.
+  - You are about to drop the column `cost_microcents` on the `request_logs` table. All the data in the column will be lost.
+  - You are about to drop the column `input_tokens` on the `request_logs` table. All the data in the column will be lost.
+  - You are about to drop the column `model` on the `request_logs` table. All the data in the column will be lost.
+  - You are about to drop the column `output_tokens` on the `request_logs` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "request_logs" DROP COLUMN "cache_creation_input_tokens",
+DROP COLUMN "cache_read_input_tokens",
+DROP COLUMN "cost_microcents",
+DROP COLUMN "input_tokens",
+DROP COLUMN "model",
+DROP COLUMN "output_tokens",
+ADD COLUMN     "extra_data" JSONB;

--- a/packages/db/prisma/migrations/20260501144937_trial_budget_cascade_delete/migration.sql
+++ b/packages/db/prisma/migrations/20260501144937_trial_budget_cascade_delete/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "trial_budgets" DROP CONSTRAINT "trial_budgets_user_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "trial_budgets" ADD CONSTRAINT "trial_budgets_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -116,6 +116,7 @@ model User {
   onboardingSurveys       OnboardingSurvey[]
   createdAgentSecrets     AgentSecret[]        @relation("AgentSecretCreator")
   updatedAgentSecrets     AgentSecret[]        @relation("AgentSecretUpdater")
+  trialBudget             TrialBudget?
 
   @@map("users")
 }
@@ -171,6 +172,7 @@ model Secret {
   pathPattern     String?  @map("path_pattern") // "/v1/*", null = all paths
   injectionConfig Json?    @map("injection_config") // type-specific config (generic: { headerName, valueFormat })
   metadata        Json? // type-specific metadata (anthropic: { authMode: "api-key" | "oauth" })
+  isPlatform      Boolean  @default(false) @map("is_platform")
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @updatedAt @map("updated_at")
   project         Project  @relation(fields: [projectId], references: [id])
@@ -265,6 +267,7 @@ model RequestLog {
   status         Int
   latencyMs      Int      @map("latency_ms")
   injectionCount Int      @map("injection_count")
+  extraData      Json?    @map("extra_data")
   createdAt      DateTime @default(now()) @map("created_at")
 
   @@index([projectId, createdAt])
@@ -402,4 +405,20 @@ model PlatformDeployment {
 
   @@index([projectId])
   @@map("platform_deployments")
+}
+
+// ── Trial budget ────────────────────────────────────────────────────────
+
+model TrialBudget {
+  id           String   @id @default(uuid())
+  userId       String   @unique @map("user_id")
+  budgetCents  Int      @default(500) @map("budget_cents")
+  spentCents   Int      @default(0) @map("spent_cents")
+  status       String   @default("active") // "active" | "exhausted" | "upgraded"
+  lastSyncedAt DateTime @default(now()) @map("last_synced_at")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("trial_budgets")
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@aws-sdk/client-kms':
         specifier: ^3.1014.0
         version: 3.1014.0
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.1014.0
+        version: 3.1041.0
       '@onecli/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -396,12 +399,20 @@ packages:
     resolution: {integrity: sha512-JllssIZCPxAgYy4gkIM2e/kXxWT0xQzzZd5y9rRStm0bl5MiLAxzX4q9WhGG7glyB++EuhYskiT1N+DzyM5nTw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-secrets-manager@3.1041.0':
+    resolution: {integrity: sha512-dr4AbZ5hIDyecKHWyYy0LhK3h6q/jd6QWem46wyHulJ6IBRPENlpB7iXo7KKFWkgKSweCEqjHVB5W+3WB4JiYw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.973.13':
     resolution: {integrity: sha512-eCFiLyBhJR7c/i8hZOETdzj2wsLFzi2L/w9/jajOgwmGqO8xrUExqkTZqdjROkwU62owqeqSuw4sIzlCv1E/ww==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.973.23':
     resolution: {integrity: sha512-aoJncvD1XvloZ9JLnKqTRL9dBy+Szkryoag9VT+V1TqsuUgIxV9cnBVM/hrDi2vE8bDqLiDR8nirdRcCdtJu0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.11':
@@ -412,12 +423,20 @@ packages:
     resolution: {integrity: sha512-BkAfKq8Bd4shCtec1usNz//urPJF/SZy14qJyxkSaRJQ/Vv1gVh0VZSTmS7aE6aLMELkFV5wHHrS9ZcdG8Kxsg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.13':
     resolution: {integrity: sha512-a864QxQWFkdCZ5wQF0QZNKTbqAc/DFQNeARp4gOyZZdql5RHjj4CppUSfwAzS9cpw2IPY3eeJjWqLZ1QiDB/6w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.23':
     resolution: {integrity: sha512-4XZ3+Gu5DY8/n8zQFHBgcKTF7hWQl42G6CY9xfXVo2d25FM/lYkpmuzhYopYoPL1ITWkJ2OSBQfYEu5JRfHOhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.11':
@@ -428,12 +447,20 @@ packages:
     resolution: {integrity: sha512-PZLSmU0JFpNCDFReidBezsgL5ji9jOBry8CnZdw4Jj6d0K2z3Ftnp44NXgADqYx5BLMu/ZHujfeJReaDoV+IwQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.11':
     resolution: {integrity: sha512-stdy09EpBTmsxGiXe1vB5qtXNww9wact36/uWLlSV0/vWbCOUAY2JjhPXoDVLk8n+E6r0M5HeZseLk+iTtifxg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.23':
     resolution: {integrity: sha512-OmE/pSkbMM3dCj1HdOnZ5kXnKK+R/Yz+kbBugraBecp0pGAs21eEURfQRz+1N2gzIHLVyGIP1MEjk/uSrFsngg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.12':
@@ -444,12 +471,20 @@ packages:
     resolution: {integrity: sha512-9Jwi7aps3AfUicJyF5udYadPypPpCwUZ6BSKr/QjRbVCpRVS1wc+1Q6AEZ/qz8J4JraeRd247pSzyMQSIHVebw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.11':
     resolution: {integrity: sha512-B049fvbv41vf0Fs5bCtbzHpruBDp61sPiFDxUmkAJ/zvgSAturpj2rqzV1rj2clg4mb44Uxp9rgpcODexNFlFA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.21':
     resolution: {integrity: sha512-nRxbeOJ1E1gVA0lNQezuMVndx+ZcuyaW/RB05pUsznN5BxykSlH6KkZ/7Ca/ubJf3i5N3p0gwNO5zgPSCzj+ww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.11':
@@ -460,12 +495,24 @@ packages:
     resolution: {integrity: sha512-APUccADuYPLL0f2htpM8Z4czabSmHOdo4r41W6lKEZdy++cNJ42Radqy6x4TopENzr3hR6WYMyhiuiqtbf/nAA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.11':
     resolution: {integrity: sha512-VR2Ju/QBdOjnWNIYuxRml63eFDLGc6Zl8aDwLi1rzgWo3rLBgtaWhWVBAijhVXzyPdQIOqdL8hvll5ybqumjeQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.23':
     resolution: {integrity: sha512-H5JNqtIwOu/feInmMMWcK0dL5r897ReEn7n2m16Dd0DPD9gA2Hg8Cq4UDzZ/9OzaLh/uqBM6seixz0U6Fi2Eag==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.4':
@@ -476,12 +523,20 @@ packages:
     resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-logger@3.972.4':
     resolution: {integrity: sha512-xFqPvTysuZAHSkdygT+ken/5rzkR7fhOoDPejAJQslZpp0XBepmCJnDOqA57ERtCTBpu8wpjTFI1ETd4S0AXEw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-logger@3.972.8':
     resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-recursion-detection@3.972.4':
@@ -492,12 +547,20 @@ packages:
     resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-user-agent@3.972.13':
     resolution: {integrity: sha512-p1kVYbzBxRmhuOHoL/ANJPCedqUxnVgkEjxPoxt5pQv/yzppHM7aBWciYEE9TZY59M421D3GjLfZIZBoEFboVQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-user-agent@3.972.24':
     resolution: {integrity: sha512-dLTWy6IfAMhNiSEvMr07g/qZ54be6pLqlxVblbF6AzafmmGAzMMj8qMoY9B4+YgT+gY9IcuxZslNh03L6PyMCQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.996.1':
@@ -508,6 +571,14 @@ packages:
     resolution: {integrity: sha512-ptZ1HF4yYHNJX8cgFF+8NdYO69XJKZn7ft0/ynV3c0hCbN+89fAbrLS+fqniU2tW8o9Kfqhj8FUh+IPXb2Qsuw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.4':
     resolution: {integrity: sha512-3GrJYv5eI65oCKveBZP7Q246dVP+tqeys9aKMB0dfX1glUWfppWlxIu52derqdNb9BX9lxYmeiaBcBIqOAYSgQ==}
     engines: {node: '>=20.0.0'}
@@ -516,8 +587,16 @@ packages:
     resolution: {integrity: sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1014.0':
     resolution: {integrity: sha512-gHTHNUoaOGNrSWkl32A7wFsU78jlNTlqMccLu0byUk5CysYYXaxNMIonIVr4YcykC7vgtDS5ABuz83giy6fzJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.997.0':
@@ -536,6 +615,14 @@ packages:
     resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-endpoints@3.982.0':
     resolution: {integrity: sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==}
     engines: {node: '>=20.0.0'}
@@ -548,9 +635,16 @@ packages:
     resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-locate-window@3.965.4':
     resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
 
   '@aws-sdk/util-user-agent-browser@3.972.4':
     resolution: {integrity: sha512-GHb+8XHv6hfLWKQKAKaSOm+vRvogg07s+FWtbR3+eCXXPSFn9XVmiYF4oypAxH7dGIvoxkVG/buHEnzYukyJiA==}
@@ -576,8 +670,21 @@ packages:
       aws-crt:
         optional: true
 
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
   '@aws-sdk/xml-builder@3.972.15':
     resolution: {integrity: sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.6':
@@ -945,6 +1052,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1881,12 +1991,20 @@ packages:
     resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/config-resolver@4.4.9':
     resolution: {integrity: sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.23.12':
     resolution: {integrity: sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.23.6':
@@ -1899,6 +2017,10 @@ packages:
 
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.10':
@@ -1929,6 +2051,10 @@ packages:
     resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-node@4.2.10':
     resolution: {integrity: sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==}
     engines: {node: '>=18.0.0'}
@@ -1937,12 +2063,20 @@ packages:
     resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/invalid-dependency@4.2.10':
     resolution: {integrity: sha512-vy9KPNSFUU0ajFYk0sDZIYiUlAWGEAhRfehIr5ZkdFrRFTAuXEPUd41USuqHU6vvLX4r6Q9X7MKBco5+Il0Org==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/invalid-dependency@4.2.12':
     resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -1972,12 +2106,20 @@ packages:
     resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-endpoint@4.4.20':
     resolution: {integrity: sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-endpoint@4.4.27':
     resolution: {integrity: sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.4.37':
@@ -1988,12 +2130,20 @@ packages:
     resolution: {integrity: sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-serde@4.2.11':
     resolution: {integrity: sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-serde@4.2.15':
     resolution: {integrity: sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.10':
@@ -2004,12 +2154,20 @@ packages:
     resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-config-provider@4.3.10':
     resolution: {integrity: sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-config-provider@4.3.12':
     resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.4.12':
@@ -2020,12 +2178,20 @@ packages:
     resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.10':
     resolution: {integrity: sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.3.10':
@@ -2036,12 +2202,20 @@ packages:
     resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/querystring-builder@4.2.10':
     resolution: {integrity: sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-builder@4.2.12':
     resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-parser@4.2.10':
@@ -2052,12 +2226,20 @@ packages:
     resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/service-error-classification@4.2.10':
     resolution: {integrity: sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/service-error-classification@4.2.12':
     resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/shared-ini-file-loader@4.4.5':
@@ -2068,6 +2250,10 @@ packages:
     resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.3.10':
     resolution: {integrity: sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==}
     engines: {node: '>=18.0.0'}
@@ -2076,8 +2262,16 @@ packages:
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.0':
     resolution: {integrity: sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.7':
@@ -2100,12 +2294,20 @@ packages:
     resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/url-parser@4.2.10':
     resolution: {integrity: sha512-uypjF7fCDsRk26u3qHmFI/ePL7bxxB9vKkE+2WKEciHhz+4QtbzWiHRVNRJwU3cKhrYDYQE3b0MRFtqfLYdA4A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.12':
     resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@3.0.0':
@@ -2168,6 +2370,10 @@ packages:
     resolution: {integrity: sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-defaults-mode-node@4.2.39':
     resolution: {integrity: sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==}
     engines: {node: '>=18.0.0'}
@@ -2176,12 +2382,20 @@ packages:
     resolution: {integrity: sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-endpoints@3.3.1':
     resolution: {integrity: sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-endpoints@3.3.3':
     resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@2.0.0':
@@ -2204,6 +2418,10 @@ packages:
     resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-retry@4.2.10':
     resolution: {integrity: sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==}
     engines: {node: '>=18.0.0'}
@@ -2212,12 +2430,20 @@ packages:
     resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-retry@4.3.8':
+    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-stream@4.5.15':
     resolution: {integrity: sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.20':
     resolution: {integrity: sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.1':
@@ -3144,6 +3370,9 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
   fast-xml-parser@5.3.6:
     resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
     hasBin: true
@@ -3154,6 +3383,10 @@ packages:
 
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastq@1.20.1:
@@ -3864,6 +4097,10 @@ packages:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -4353,6 +4590,9 @@ packages:
   strnum@2.2.1:
     resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
 
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4737,7 +4977,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -4745,7 +4985,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -4938,6 +5178,50 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-secrets-manager@3.1041.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/core@3.973.13':
     dependencies:
       '@aws-sdk/types': 3.973.2
@@ -4970,6 +5254,23 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.11':
     dependencies:
       '@aws-sdk/core': 3.973.13
@@ -4984,6 +5285,14 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.13':
@@ -5010,6 +5319,19 @@ snapshots:
       '@smithy/smithy-client': 4.12.7
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.20
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.11':
@@ -5050,6 +5372,25 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.972.11':
     dependencies:
       '@aws-sdk/core': 3.973.13
@@ -5072,6 +5413,19 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5110,6 +5464,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.39':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.972.11':
     dependencies:
       '@aws-sdk/core': 3.973.13
@@ -5126,6 +5497,15 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.11':
@@ -5154,6 +5534,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.972.11':
     dependencies:
       '@aws-sdk/core': 3.973.13
@@ -5178,6 +5571,25 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-host-header@3.972.4':
     dependencies:
       '@aws-sdk/types': 3.973.2
@@ -5192,6 +5604,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-logger@3.972.4':
     dependencies:
       '@aws-sdk/types': 3.973.2
@@ -5202,6 +5620,14 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.4':
@@ -5218,6 +5644,23 @@ snapshots:
       '@aws/lambda-invoke-store': 0.2.3
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.13':
@@ -5239,6 +5682,17 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-retry': 4.2.12
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.8
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.996.1':
@@ -5327,6 +5781,58 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.6':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.4':
     dependencies:
       '@aws-sdk/types': 3.973.2
@@ -5343,6 +5849,15 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1014.0':
     dependencies:
       '@aws-sdk/core': 3.973.23
@@ -5351,6 +5866,18 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5382,6 +5909,15 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
   '@aws-sdk/util-endpoints@3.982.0':
     dependencies:
       '@aws-sdk/types': 3.973.2
@@ -5406,8 +5942,23 @@ snapshots:
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
   '@aws-sdk/util-locate-window@3.965.4':
     dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.972.4':
@@ -5441,10 +5992,26 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.15':
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.6':
@@ -5799,6 +6366,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.0':
     optional: true
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6777,6 +7346,15 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
   '@smithy/config-resolver@4.4.9':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
@@ -6795,6 +7373,19 @@ snapshots:
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.20
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
       '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
@@ -6826,6 +7417,14 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.10':
@@ -6874,6 +7473,14 @@ snapshots:
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
   '@smithy/hash-node@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -6888,6 +7495,13 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@smithy/invalid-dependency@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -6896,6 +7510,11 @@ snapshots:
   '@smithy/invalid-dependency@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -6932,6 +7551,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/middleware-endpoint@4.4.20':
     dependencies:
       '@smithy/core': 3.23.6
@@ -6952,6 +7577,17 @@ snapshots:
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.37':
@@ -6978,6 +7614,19 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
   '@smithy/middleware-serde@4.2.11':
     dependencies:
       '@smithy/protocol-http': 5.3.10
@@ -6991,6 +7640,13 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/middleware-stack@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -6999,6 +7655,11 @@ snapshots:
   '@smithy/middleware-stack@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.10':
@@ -7013,6 +7674,13 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.12':
@@ -7031,6 +7699,13 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -7041,6 +7716,11 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/protocol-http@5.3.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -7049,6 +7729,11 @@ snapshots:
   '@smithy/protocol-http@5.3.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.10':
@@ -7063,6 +7748,12 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
   '@smithy/querystring-parser@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -7073,6 +7764,11 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/service-error-classification@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -7080,6 +7776,10 @@ snapshots:
   '@smithy/service-error-classification@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
 
   '@smithy/shared-ini-file-loader@4.4.5':
     dependencies:
@@ -7089,6 +7789,11 @@ snapshots:
   '@smithy/shared-ini-file-loader@4.4.7':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.10':
@@ -7113,6 +7818,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.0':
     dependencies:
       '@smithy/core': 3.23.6
@@ -7121,6 +7837,16 @@ snapshots:
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
       '@smithy/util-stream': 4.5.15
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.12.7':
@@ -7149,6 +7875,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/url-parser@4.2.10':
     dependencies:
       '@smithy/querystring-parser': 4.2.10
@@ -7159,6 +7889,12 @@ snapshots:
     dependencies:
       '@smithy/querystring-parser': 4.2.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-base64@3.0.0':
@@ -7237,6 +7973,13 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-defaults-mode-node@4.2.39':
     dependencies:
       '@smithy/config-resolver': 4.4.9
@@ -7257,6 +8000,16 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-endpoints@3.3.1':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
@@ -7267,6 +8020,12 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@2.0.0':
@@ -7291,6 +8050,11 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-retry@4.2.10':
     dependencies:
       '@smithy/service-error-classification': 4.2.10
@@ -7301,6 +8065,12 @@ snapshots:
     dependencies:
       '@smithy/service-error-classification': 4.2.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.15':
@@ -7319,6 +8089,17 @@ snapshots:
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/node-http-handler': 4.5.0
       '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -8379,6 +9160,10 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.0
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
   fast-xml-parser@5.3.6:
     dependencies:
       strnum: 2.1.2
@@ -8393,6 +9178,13 @@ snapshots:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
       strnum: 2.2.1
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastq@1.20.1:
     dependencies:
@@ -9065,6 +9857,8 @@ snapshots:
 
   path-expression-matcher@1.2.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -9639,6 +10433,8 @@ snapshots:
   strnum@2.1.2: {}
 
   strnum@2.2.1: {}
+
+  strnum@2.2.3: {}
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -41,7 +41,9 @@
     "REDIS_HOST",
     "REDIS_PORT",
     "REDIS_USERNAME",
-    "REDIS_PASSWORD"
+    "REDIS_PASSWORD",
+    "CRON_SECRET_NAME",
+    "ANTHROPIC_SECRET_NAME"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- **Gateway**: Add hook-based request interception system, telemetry core improvements, forwarding refactor with streaming body support
- **Web**: Update secrets dialog with new form structure, add isPlatform support to connected-tab and secrets-content components
- **Database**: Add trial_budget table and migration, replace token columns with extra_data JSON field, add cascade delete for trial budgets
- **Config**: Update turbo.json pipeline tasks and web package.json dependencies

## Test plan

- [ ] Verify `cargo build` succeeds without `--features cloud`
- [ ] Verify `pnpm check` passes (lint + types + format)
- [ ] Verify secrets page renders correctly with new isPlatform field
- [ ] Verify database migrations apply cleanly on fresh PostgreSQL