### PR TITLE
feat: add OpenAI secret type, WebSocket proxy, and SecretInput rewrite

### DIFF
--- a/apps/gateway/Cargo.lock
+++ b/apps/gateway/Cargo.lock
@@ -2371,6 +2371,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 tokio = { version = "1", features = ["full"] }
 
 # HTTP
-hyper = { version = "1", features = ["http1", "server"] }
+hyper = { version = "1", features = ["http1", "server", "client"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body = "1"
 http-body-util = "0.1"
@@ -25,6 +25,9 @@ tower-http = { version = "0.6", features = ["cors"] }
 tokio-rustls = "0.26"
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2"
+
+# WebSocket upstream TLS root certificates
+webpki-roots = "0.26"
 
 # Certificate generation
 rcgen = "0.13"

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -806,6 +806,11 @@ fn build_injections(
             }
         }
 
+        "openai" => vec![Injection::SetHeader {
+            name: "authorization".to_string(),
+            value: format!("Bearer {decrypted_value}"),
+        }],
+
         "generic" => {
             let config = injection_config.and_then(|v| v.as_object());
 

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -22,6 +22,7 @@ mod hooks;
 mod mitm;
 mod response;
 mod tunnel;
+mod websocket;
 
 #[cfg(feature = "cloud")]
 #[path = "cloud/trial.rs"]

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -72,7 +72,7 @@ pub(super) async fn mitm(
         .title_case_headers(true)
         .serve_connection(
             io,
-            service_fn(move |req| {
+            service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
                 let host = host_owned.clone();
                 let client = http_client.clone();
                 let cache = Arc::clone(&cache);
@@ -81,6 +81,7 @@ pub(super) async fn mitm(
                 let engine = Arc::clone(&policy_engine);
                 let vault_rules = Arc::clone(&vault_injection_rules);
                 async move {
+                    let is_ws = super::websocket::is_websocket_upgrade(&req);
                     let connection_id = connect::extract_connection_id(req.headers());
 
                     // Re-resolve rules from cache on each request so that
@@ -100,16 +101,39 @@ pub(super) async fn mitm(
                             rules,
                             app_connections,
                         }) => {
-                            match forward::forward_request(
-                                req, &host, "https", client, &rules, &*cache, &ctx, &approvals,
-                            )
-                            .await
-                            {
-                                Ok(mut resp) => {
-                                    connect::inject_connections_header(&mut resp, &app_connections);
-                                    Ok(resp)
+                            if is_ws {
+                                match super::websocket::handle_websocket(
+                                    req, &host, &rules, &*cache, &ctx,
+                                )
+                                .await
+                                {
+                                    Ok(mut resp) => {
+                                        connect::inject_connections_header(
+                                            &mut resp,
+                                            &app_connections,
+                                        );
+                                        Ok(resp)
+                                    }
+                                    Err(e) => {
+                                        warn!(host = %host, error = %e, "WebSocket handler failed");
+                                        Ok(response::resolution_failed())
+                                    }
                                 }
-                                Err(e) => Err(e),
+                            } else {
+                                match forward::forward_request(
+                                    req, &host, "https", client, &rules, &*cache, &ctx, &approvals,
+                                )
+                                .await
+                                {
+                                    Ok(mut resp) => {
+                                        connect::inject_connections_header(
+                                            &mut resp,
+                                            &app_connections,
+                                        );
+                                        Ok(resp)
+                                    }
+                                    Err(e) => Err(e),
+                                }
                             }
                         }
                         Ok(ResolveResult::Ambiguous(connections)) => {
@@ -127,6 +151,7 @@ pub(super) async fn mitm(
                 }
             }),
         )
+        .with_upgrades()
         .await
         .context("serving MITM connection")
 }

--- a/apps/gateway/src/gateway/websocket.rs
+++ b/apps/gateway/src/gateway/websocket.rs
@@ -1,0 +1,419 @@
+//! WebSocket proxy: detect upgrade requests, inject credentials into the
+//! handshake, connect to the upstream server, and pipe frames bidirectionally.
+//!
+//! This module runs alongside [`super::forward`] inside the MITM HTTP/1.1
+//! service. When a WebSocket upgrade is detected, the request is routed here
+//! instead of the normal reqwest-based forwarding path.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use http_body_util::{Either, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::client::conn::http1;
+use hyper::header::{HeaderName, HeaderValue};
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use tracing::{info, warn};
+
+use crate::cache::CacheStore;
+use crate::inject;
+use crate::policy::{self, PolicyDecision};
+
+use super::hooks;
+use super::mitm::ResolvedRules;
+use super::response;
+use super::ProxyContext;
+
+const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+
+const WEBSOCKET_HANDSHAKE_HEADERS: &[&str] = &[
+    "upgrade",
+    "connection",
+    "sec-websocket-key",
+    "sec-websocket-version",
+    "sec-websocket-protocol",
+    "sec-websocket-extensions",
+    "origin",
+];
+
+const WEBSOCKET_RESPONSE_HEADERS: &[&str] = &[
+    "upgrade",
+    "connection",
+    "sec-websocket-accept",
+    "sec-websocket-protocol",
+    "sec-websocket-extensions",
+];
+
+pub(super) fn is_websocket_upgrade(req: &Request<Incoming>) -> bool {
+    let has_upgrade = req
+        .headers()
+        .get("upgrade")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
+
+    let has_connection = req
+        .headers()
+        .get("connection")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.to_ascii_lowercase().contains("upgrade"));
+
+    has_upgrade && has_connection
+}
+
+fn is_websocket_forwarded_header(name: &HeaderName) -> bool {
+    let s = name.as_str();
+    if s == "host" || s == "content-length" || s == crate::connect::CONNECTION_ID_HEADER {
+        return false;
+    }
+    if WEBSOCKET_HANDSHAKE_HEADERS.contains(&s) {
+        return true;
+    }
+    const NON_WS_HOP_BY_HOP: &[&str] = &[
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "proxy-connection",
+        "te",
+        "trailers",
+        "transfer-encoding",
+    ];
+    !NON_WS_HOP_BY_HOP.contains(&s)
+}
+
+pub(super) async fn handle_websocket(
+    mut req: Request<Incoming>,
+    host: &str,
+    rules: &ResolvedRules,
+    cache: &dyn CacheStore,
+    proxy_ctx: &ProxyContext,
+) -> Result<Response<Either<Full<Bytes>, http_body_util::StreamBody<hooks::BodyStream>>>> {
+    let start = std::time::Instant::now();
+    let path = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str().to_string())
+        .unwrap_or_else(|| "/".to_string());
+
+    let agent_token = proxy_ctx.agent_token.as_deref().unwrap_or("");
+    let decision = policy::evaluate("GET", &path, &rules.policy_rules, agent_token, cache).await;
+
+    match &decision {
+        PolicyDecision::Blocked => {
+            warn!(host = %host, path = %path, "WebSocket BLOCKED by policy rule");
+            return Ok(response::blocked_by_policy("GET", &path));
+        }
+        PolicyDecision::RateLimited {
+            limit,
+            window,
+            retry_after_secs,
+        } => {
+            warn!(host = %host, path = %path, limit, window, "WebSocket RATE LIMITED");
+            return Ok(response::rate_limited(*limit, window, *retry_after_secs));
+        }
+        PolicyDecision::ManualApproval { .. } => {
+            warn!(host = %host, path = %path, "WebSocket blocked: manual approval not supported for WebSocket");
+            return Ok(response::blocked_by_policy("GET", &path));
+        }
+        PolicyDecision::Allow => {}
+    }
+
+    let client_upgrade = hyper::upgrade::on(&mut req);
+
+    let (parts, _body) = req.into_parts();
+    let mut headers = hyper::HeaderMap::new();
+    for (name, value) in parts.headers.iter() {
+        if is_websocket_forwarded_header(name) {
+            headers.append(name.clone(), value.clone());
+        }
+    }
+
+    let mut upstream_path = path.clone();
+    let injection_count =
+        inject::apply_injections(&mut headers, &mut upstream_path, &rules.injection_rules);
+
+    let hostname = super::strip_port(host);
+    let port = host
+        .split(':')
+        .nth(1)
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(443);
+
+    let upstream_io = connect_upstream_tls(hostname, port)
+        .await
+        .context("WebSocket: connecting to upstream")?;
+
+    let (mut sender, conn) = http1::Builder::new()
+        .handshake(upstream_io)
+        .await
+        .context("WebSocket: upstream HTTP handshake")?;
+
+    tokio::spawn(async move {
+        if let Err(e) = conn.with_upgrades().await {
+            warn!(error = %e, "WebSocket: upstream connection driver error");
+        }
+    });
+
+    let mut upstream_req = Request::builder()
+        .method("GET")
+        .uri(&upstream_path)
+        .body(http_body_util::Empty::<Bytes>::new())
+        .context("building upstream WebSocket request")?;
+
+    let host_header = if port == 443 { hostname } else { host };
+    upstream_req.headers_mut().insert(
+        "host",
+        HeaderValue::from_str(host_header).unwrap_or(HeaderValue::from_static("localhost")),
+    );
+    for (name, value) in headers.iter() {
+        upstream_req
+            .headers_mut()
+            .append(name.clone(), value.clone());
+    }
+
+    let upstream_resp = sender
+        .send_request(upstream_req)
+        .await
+        .context("WebSocket: sending upgrade request to upstream")?;
+
+    if upstream_resp.status() != StatusCode::SWITCHING_PROTOCOLS {
+        warn!(
+            host = %host,
+            status = %upstream_resp.status().as_u16(),
+            "WebSocket: upstream rejected upgrade"
+        );
+        let status = upstream_resp.status();
+        let body = format!(
+            "WebSocket upgrade rejected by upstream ({})",
+            status.as_u16()
+        );
+        let mut resp = Response::new(Either::Left(Full::new(Bytes::from(body))));
+        *resp.status_mut() = status;
+        return Ok(resp);
+    }
+
+    let resp_headers = upstream_resp.headers().clone();
+
+    let upstream_upgraded = hyper::upgrade::on(upstream_resp)
+        .await
+        .context("WebSocket: extracting upstream upgraded IO")?;
+
+    let mut client_resp = Response::new(Either::Left(Full::new(Bytes::new())));
+    *client_resp.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
+
+    for name_str in WEBSOCKET_RESPONSE_HEADERS {
+        if let Ok(name) = HeaderName::from_bytes(name_str.as_bytes()) {
+            if let Some(value) = resp_headers.get(&name) {
+                client_resp.headers_mut().insert(name, value.clone());
+            }
+        }
+    }
+
+    emit_telemetry(proxy_ctx, host, &path, injection_count, start);
+
+    let host_owned = host.to_string();
+    tokio::spawn(async move {
+        match client_upgrade.await {
+            Ok(client_io) => {
+                let mut client = TokioIo::new(client_io);
+                let mut upstream = TokioIo::new(upstream_upgraded);
+
+                match pipe_websocket(&mut client, &mut upstream, WS_IDLE_TIMEOUT).await {
+                    Ok((c2s, s2c)) => {
+                        info!(
+                            host = %host_owned,
+                            client_to_server = c2s,
+                            server_to_client = s2c,
+                            "WebSocket closed"
+                        );
+                    }
+                    Err(e) => {
+                        info!(host = %host_owned, error = %e, "WebSocket pipe ended");
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(host = %host_owned, error = %e, "WebSocket: client upgrade failed");
+            }
+        }
+    });
+
+    Ok(client_resp)
+}
+
+async fn connect_upstream_tls(
+    hostname: &str,
+    port: u16,
+) -> Result<TokioIo<tokio_rustls::client::TlsStream<TcpStream>>> {
+    let tcp = TcpStream::connect((hostname, port))
+        .await
+        .context("TCP connect to upstream")?;
+
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    let mut tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    let connector = TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls::pki_types::ServerName::try_from(hostname.to_string())
+        .context("invalid server name")?;
+
+    let tls_stream = connector
+        .connect(server_name, tcp)
+        .await
+        .context("TLS handshake with upstream")?;
+
+    Ok(TokioIo::new(tls_stream))
+}
+
+async fn pipe_websocket<C, S>(
+    client: &mut C,
+    server: &mut S,
+    timeout: Duration,
+) -> std::io::Result<(u64, u64)>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let (cr, cw) = tokio::io::split(client);
+    let (sr, sw) = tokio::io::split(server);
+
+    let c2s = copy_with_idle_timeout(cr, sw, timeout);
+    let s2c = copy_with_idle_timeout(sr, cw, timeout);
+
+    tokio::try_join!(c2s, s2c)
+}
+
+async fn copy_with_idle_timeout<R, W>(
+    mut reader: R,
+    mut writer: W,
+    timeout: Duration,
+) -> std::io::Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0u8; 8192];
+    let mut total = 0u64;
+
+    loop {
+        let n = match tokio::time::timeout(timeout, reader.read(&mut buf)).await {
+            Ok(Ok(0)) => return Ok(total),
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Ok(total),
+        };
+        writer.write_all(&buf[..n]).await?;
+        total += n as u64;
+    }
+}
+
+fn emit_telemetry(
+    proxy_ctx: &ProxyContext,
+    host: &str,
+    path: &str,
+    injection_count: usize,
+    start: std::time::Instant,
+) {
+    info!(
+        method = "WEBSOCKET",
+        host = %host,
+        path = %path,
+        injections_applied = injection_count,
+        latency_ms = start.elapsed().as_millis() as u32,
+        "WebSocket upgrade"
+    );
+
+    if let (Some(pid), Some(aid)) = (
+        proxy_ctx.project_id.as_deref(),
+        proxy_ctx.agent_id.as_deref(),
+    ) {
+        let hostname = super::strip_port(host);
+        let (provider, _) =
+            crate::apps::provider_for_host_and_path(hostname, path).unwrap_or((hostname, hostname));
+
+        crate::telemetry::on_request(crate::telemetry::RequestEvent {
+            project_id: pid.to_string(),
+            agent_id: aid.to_string(),
+            agent_name: proxy_ctx
+                .agent_name
+                .as_deref()
+                .unwrap_or("unknown")
+                .to_string(),
+            method: "WEBSOCKET".to_string(),
+            host: host.to_string(),
+            path: path.to_string(),
+            provider: provider.to_string(),
+            status: 101,
+            latency_ms: start.elapsed().as_millis() as u32,
+            injection_count: injection_count as u16,
+            timestamp: time::OffsetDateTime::now_utc()
+                .format(&time::format_description::well_known::Iso8601::DEFAULT)
+                .unwrap_or_default(),
+            injected: injection_count > 0,
+            #[cfg(feature = "cloud")]
+            model: None,
+            #[cfg(feature = "cloud")]
+            input_tokens: None,
+            #[cfg(feature = "cloud")]
+            output_tokens: None,
+            #[cfg(feature = "cloud")]
+            cache_creation_input_tokens: None,
+            #[cfg(feature = "cloud")]
+            cache_read_input_tokens: None,
+            #[cfg(feature = "cloud")]
+            is_trial: false,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn websocket_header_preserved() {
+        let name = HeaderName::from_static("sec-websocket-key");
+        assert!(is_websocket_forwarded_header(&name));
+
+        let name = HeaderName::from_static("upgrade");
+        assert!(is_websocket_forwarded_header(&name));
+
+        let name = HeaderName::from_static("connection");
+        assert!(is_websocket_forwarded_header(&name));
+
+        let name = HeaderName::from_static("origin");
+        assert!(is_websocket_forwarded_header(&name));
+    }
+
+    #[test]
+    fn dangerous_headers_stripped() {
+        let name = HeaderName::from_static("proxy-authorization");
+        assert!(!is_websocket_forwarded_header(&name));
+
+        let name = HeaderName::from_static("host");
+        assert!(!is_websocket_forwarded_header(&name));
+
+        let name = HeaderName::from_static("transfer-encoding");
+        assert!(!is_websocket_forwarded_header(&name));
+    }
+
+    #[test]
+    fn regular_headers_forwarded() {
+        let name = HeaderName::from_static("authorization");
+        assert!(is_websocket_forwarded_header(&name));
+
+        let name = HeaderName::from_static("x-custom-header");
+        assert!(is_websocket_forwarded_header(&name));
+
+        let name = HeaderName::from_static("accept");
+        assert!(is_websocket_forwarded_header(&name));
+    }
+}

--- a/apps/web/src/app/(connect)/app-connect/_components/credentials-flow.tsx
+++ b/apps/web/src/app/(connect)/app-connect/_components/credentials-flow.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { Button } from "@onecli/ui/components/button";
 import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
+import { SecretInput } from "@/components/secret-input";
 import { ConnectLayout } from "./connect-layout";
 
 interface FileImportConfig {
@@ -179,25 +180,36 @@ export const CredentialsFlow = ({
                 {field.description}
               </p>
             )}
-            <Input
-              id={`connect-${field.name}`}
-              type={
-                field.secret === true ||
-                (field.secret === undefined && app.connectionType === "api_key")
-                  ? "password"
-                  : "text"
-              }
-              value={values[field.name] ?? ""}
-              onChange={(e) =>
-                setValues((prev) => ({
-                  ...prev,
-                  [field.name]: e.target.value,
-                }))
-              }
-              placeholder={field.placeholder}
-              className="font-mono text-sm"
-              autoFocus={i === 0}
-            />
+            {field.secret === true ||
+            (field.secret === undefined && app.connectionType === "api_key") ? (
+              <SecretInput
+                id={`connect-${field.name}`}
+                value={values[field.name] ?? ""}
+                onChange={(e) =>
+                  setValues((prev) => ({
+                    ...prev,
+                    [field.name]: e.target.value,
+                  }))
+                }
+                placeholder={field.placeholder}
+                autoFocus={i === 0}
+              />
+            ) : (
+              <Input
+                id={`connect-${field.name}`}
+                type="text"
+                value={values[field.name] ?? ""}
+                onChange={(e) =>
+                  setValues((prev) => ({
+                    ...prev,
+                    [field.name]: e.target.value,
+                  }))
+                }
+                placeholder={field.placeholder}
+                className="font-mono text-sm"
+                autoFocus={i === 0}
+              />
+            )}
           </div>
         ))}
         <Button

--- a/apps/web/src/app/(dashboard)/connections/(tabs)/secrets/page.tsx
+++ b/apps/web/src/app/(dashboard)/connections/(tabs)/secrets/page.tsx
@@ -13,8 +13,8 @@ export default async function SecretsRedirectPage({
   const prefix = projectId ? `/p/${projectId}` : "";
   const base = `${prefix}/connections`;
 
-  if (sp.create === "anthropic") {
-    redirect(`${base}/llms?create=anthropic`);
+  if (sp.create === "anthropic" || sp.create === "openai") {
+    redirect(`${base}/llms?create=${sp.create}`);
   }
 
   const qs = new URLSearchParams();

--- a/apps/web/src/app/(dashboard)/connections/_components/app-config-form.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-config-form.tsx
@@ -25,6 +25,7 @@ import { Card } from "@onecli/ui/components/card";
 import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
 import { Switch } from "@onecli/ui/components/switch";
+import { SecretInput } from "@/components/secret-input";
 import {
   saveAppConfig,
   getAppConfigStatus,
@@ -227,23 +228,37 @@ export const AppConfigForm = ({
                     {field.description}
                   </p>
                 )}
-                <Input
-                  id={`config-${field.name}`}
-                  type={field.secret ? "password" : "text"}
-                  value={values[field.name] ?? ""}
-                  onChange={(e) =>
-                    setValues((prev) => ({
-                      ...prev,
-                      [field.name]: e.target.value,
-                    }))
-                  }
-                  placeholder={
-                    field.secret && hasCredentials
-                      ? "Leave empty to keep current"
-                      : field.placeholder
-                  }
-                  className="font-mono text-sm"
-                />
+                {field.secret ? (
+                  <SecretInput
+                    id={`config-${field.name}`}
+                    value={values[field.name] ?? ""}
+                    onChange={(e) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        [field.name]: e.target.value,
+                      }))
+                    }
+                    placeholder={
+                      hasCredentials
+                        ? "Leave empty to keep current"
+                        : field.placeholder
+                    }
+                  />
+                ) : (
+                  <Input
+                    id={`config-${field.name}`}
+                    type="text"
+                    value={values[field.name] ?? ""}
+                    onChange={(e) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        [field.name]: e.target.value,
+                      }))
+                    }
+                    placeholder={field.placeholder}
+                    className="font-mono text-sm"
+                  />
+                )}
               </div>
             ))}
 

--- a/apps/web/src/app/(dashboard)/connections/_components/configure-credentials-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/configure-credentials-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@onecli/ui/components/button";
 import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
+import { SecretInput } from "@/components/secret-input";
 import { saveAppConfig, setAppConfigEnabled } from "@/lib/actions/app-config";
 import type { OAuthConfigField } from "@/lib/apps/types";
 import { IS_CLOUD } from "@/lib/env";
@@ -86,20 +87,35 @@ export const ConfigureCredentialsDialog = ({
                   {field.description}
                 </p>
               )}
-              <Input
-                id={`config-${field.name}`}
-                type={field.secret ? "password" : "text"}
-                value={values[field.name] ?? ""}
-                onChange={(e) =>
-                  setValues((prev) => ({
-                    ...prev,
-                    [field.name]: e.target.value,
-                  }))
-                }
-                placeholder={field.placeholder}
-                className="font-mono text-sm"
-                autoFocus={i === 0}
-              />
+              {field.secret ? (
+                <SecretInput
+                  id={`config-${field.name}`}
+                  value={values[field.name] ?? ""}
+                  onChange={(e) =>
+                    setValues((prev) => ({
+                      ...prev,
+                      [field.name]: e.target.value,
+                    }))
+                  }
+                  placeholder={field.placeholder}
+                  autoFocus={i === 0}
+                />
+              ) : (
+                <Input
+                  id={`config-${field.name}`}
+                  type="text"
+                  value={values[field.name] ?? ""}
+                  onChange={(e) =>
+                    setValues((prev) => ({
+                      ...prev,
+                      [field.name]: e.target.value,
+                    }))
+                  }
+                  placeholder={field.placeholder}
+                  className="font-mono text-sm"
+                  autoFocus={i === 0}
+                />
+              )}
             </div>
           ))}
 

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { toast } from "sonner";
-import { ArrowLeft, Bot, Key, Settings2 } from "lucide-react";
+import { ArrowLeft, Key, Settings2 } from "lucide-react";
 import { cn } from "@onecli/ui/lib/utils";
 import {
   Dialog,
@@ -16,6 +16,7 @@ import {
 import { Button } from "@onecli/ui/components/button";
 import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
+import { SecretInput } from "@/components/secret-input";
 import {
   Accordion,
   AccordionContent,
@@ -31,9 +32,10 @@ import {
   isHeaderInjection,
   isParamInjection,
   looksLikeAnthropicKey,
+  looksLikeOpenaiKey,
 } from "@/lib/validations/secret";
 
-type SecretType = "anthropic" | "generic";
+type SecretType = "anthropic" | "openai" | "generic";
 
 interface SecretTypeOption {
   value: SecretType;
@@ -44,14 +46,45 @@ interface SecretTypeOption {
   nameDefault: string;
 }
 
+const AnthropicIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 300 300"
+    fill="currentColor"
+    className={className}
+  >
+    <path d="m172.36 49.15 80.42 201.7h44.1L216.46 49.15h-44.1Z" />
+    <path d="m79.07 171.03 27.52-70.88 27.51 70.88H79.07ZM83.53 49.15 3.13 250.85h44.96l16.44-42.36h84.12l16.44 42.36h44.96L129.64 49.15H83.53Z" />
+  </svg>
+);
+
+const OpenAIIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+  >
+    <path d="M22.282 9.821a6 6 0 0 0-.516-4.91 6.05 6.05 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a6 6 0 0 0-3.998 2.9 6.05 6.05 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.05 6.05 0 0 0 6.515 2.9A6 6 0 0 0 13.26 24a6.06 6.06 0 0 0 5.772-4.206 6 6 0 0 0 3.997-2.9 6.06 6.06 0 0 0-.747-7.073M13.26 22.43a4.48 4.48 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.8.8 0 0 0 .392-.681v-6.737l2.02 1.168a.07.07 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494M3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.77.77 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646M2.34 7.896a4.5 4.5 0 0 1 2.366-1.973V11.6a.77.77 0 0 0 .388.677l5.815 3.354-2.02 1.168a.08.08 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855-5.833-3.387L15.119 7.2a.08.08 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667m2.01-3.023-.141-.085-4.774-2.782a.78.78 0 0 0-.785 0L9.409 9.23V6.897a.07.07 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.8.8 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5Z" />
+  </svg>
+);
+
 const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
   {
     value: "anthropic",
     label: "Anthropic API Key",
     description: "Inject your Anthropic key into requests to api.anthropic.com",
-    icon: <Bot className="size-5" />,
+    icon: <AnthropicIcon className="size-5" />,
     hostDefault: "api.anthropic.com",
     nameDefault: "Anthropic Token",
+  },
+  {
+    value: "openai",
+    label: "OpenAI API Key",
+    description: "Inject your OpenAI key into requests to api.openai.com",
+    icon: <OpenAIIcon className="size-5" />,
+    hostDefault: "api.openai.com",
+    nameDefault: "OpenAI Token",
   },
   {
     value: "generic",
@@ -320,7 +353,9 @@ export const SecretDialog = ({
                     ? "Update the secret\u2019s configuration. Leave the value field empty to keep the current value."
                     : type === "anthropic"
                       ? "Your key will be encrypted and injected into requests to api.anthropic.com."
-                      : "Configure a custom secret to inject as a header or URL parameter into matching requests."}
+                      : type === "openai"
+                        ? "Your key will be encrypted and injected into requests to api.openai.com."
+                        : "Configure a custom secret to inject as a header or URL parameter into matching requests."}
               </DialogDescription>
               {type === "generic" && !isEdit && !prefill && (
                 <div className="flex items-center gap-2 pt-1">
@@ -367,7 +402,9 @@ export const SecretDialog = ({
                     placeholder={
                       type === "anthropic"
                         ? "e.g. Anthropic Production Key"
-                        : "e.g. GitHub Token"
+                        : type === "openai"
+                          ? "e.g. OpenAI Production Key"
+                          : "e.g. GitHub Token"
                     }
                     value={name}
                     onChange={(e) => setName(e.target.value)}
@@ -394,14 +431,15 @@ export const SecretDialog = ({
                     </span>
                   )}
                 </Label>
-                <Input
+                <SecretInput
                   ref={valueInputRef}
                   id="secret-value"
-                  type="password"
                   placeholder={
                     type === "anthropic"
                       ? "sk-ant-api03-..."
-                      : "Enter secret value"
+                      : type === "openai"
+                        ? "sk-proj-..."
+                        : "Enter secret value"
                   }
                   value={value}
                   onChange={(e) => {
@@ -412,6 +450,9 @@ export const SecretDialog = ({
                       if (detected === "api-key") setName("Anthropic API Key");
                       else if (detected === "oauth")
                         setName("Anthropic OAuth Token");
+                    }
+                    if (type === "openai" && !name.trim()) {
+                      if (looksLikeOpenaiKey(val)) setName("OpenAI API Key");
                     }
                   }}
                 />
@@ -430,11 +471,29 @@ export const SecretDialog = ({
                         </>
                       )}
                     </p>
+                  ) : type === "openai" &&
+                    value.trim() &&
+                    !looksLikeOpenaiKey(value) ? (
+                    <p className="text-xs text-amber-600 dark:text-amber-400">
+                      {value.startsWith("sk-ant-") ? (
+                        "This looks like an Anthropic key, not an OpenAI key."
+                      ) : value.startsWith("sk-") ? (
+                        "This key looks incomplete. Make sure you copied the full value."
+                      ) : (
+                        <>
+                          Keys typically start with{" "}
+                          <code className="text-[11px]">sk-proj-</code> or{" "}
+                          <code className="text-[11px]">sk-</code>
+                        </>
+                      )}
+                    </p>
                   ) : (
                     <p className="text-muted-foreground text-xs">
                       {type === "anthropic"
                         ? "Paste your API key or OAuth token from the Anthropic Console."
-                        : "Encrypted at rest. You won\u2019t be able to view this value again."}
+                        : type === "openai"
+                          ? "Paste your API key from the OpenAI Dashboard."
+                          : "Encrypted at rest. You won\u2019t be able to view this value again."}
                     </p>
                   )}
                   {type === "anthropic" && <AnthropicKeyBadge value={value} />}
@@ -585,8 +644,7 @@ export const SecretDialog = ({
                     </AccordionTrigger>
                     <AccordionContent className="pb-0">
                       <div className="space-y-4">
-                        {(type === "anthropic" ||
-                          (type === "generic" && !!prefill)) && (
+                        {(type !== "generic" || !!prefill) && (
                           <div className="space-y-2">
                             <Label htmlFor="secret-host">Host pattern</Label>
                             <Input

--- a/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
@@ -68,6 +68,15 @@ export const SecretsContent = ({ typeFilter }: SecretsContentProps) => {
       });
       setCreateOpen(true);
       router.replace(window.location.pathname, { scroll: false });
+    } else if (createType === "openai" && typeFilter === "llm") {
+      paramHandled.current = true;
+      setPrefill({
+        type: "openai",
+        hostPattern: "api.openai.com",
+        name: "OpenAI Token",
+      });
+      setCreateOpen(true);
+      router.replace(window.location.pathname, { scroll: false });
     } else if (createType === "generic" && typeFilter === "generic" && host) {
       paramHandled.current = true;
       setPrefill({
@@ -145,7 +154,9 @@ export const SecretsContent = ({ typeFilter }: SecretsContentProps) => {
         onSaved={fetchSecrets}
         prefill={prefill}
         defaultType={typeFilter === "generic" ? "generic" : undefined}
-        allowedTypes={typeFilter === "llm" ? ["anthropic"] : undefined}
+        allowedTypes={
+          typeFilter === "llm" ? ["anthropic", "openai"] : undefined
+        }
       />
     </div>
   );

--- a/apps/web/src/components/secret-input.tsx
+++ b/apps/web/src/components/secret-input.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { forwardRef, useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Input } from "@onecli/ui/components/input";
+import { cn } from "@onecli/ui/lib/utils";
+
+export interface SecretInputProps {
+  id?: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+  className?: string;
+}
+
+export const SecretInput = forwardRef<HTMLInputElement, SecretInputProps>(
+  ({ id, value, onChange, placeholder, autoFocus, className }, ref) => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+      <div className="relative">
+        <Input
+          ref={ref}
+          id={id}
+          type={visible ? "text" : "password"}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          className={cn("pr-10 font-mono text-sm", className)}
+          autoFocus={autoFocus}
+        />
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+          tabIndex={-1}
+          aria-label={visible ? "Hide secret" : "Show secret"}
+        >
+          {visible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    );
+  },
+);
+
+SecretInput.displayName = "SecretInput";

--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -90,6 +90,15 @@ export const hasAnthropicSecret = async (): Promise<boolean> => {
   return !!secret;
 };
 
+export const hasOpenaiSecret = async (): Promise<boolean> => {
+  const { projectId } = await resolveUser();
+  const secret = await db.secret.findFirst({
+    where: { projectId, type: "openai" },
+    select: { id: true },
+  });
+  return !!secret;
+};
+
 export const getDemoInfo = async () => {
   const { projectId } = await resolveUser();
 
@@ -150,6 +159,41 @@ export const validateAnthropicKey = async (
     return {
       valid: false,
       error: "Could not reach Anthropic API to validate the key.",
+    };
+  }
+};
+
+export const validateOpenaiKey = async (
+  key: string,
+): Promise<{ valid: boolean; error?: string }> => {
+  try {
+    const res = await fetch("https://api.openai.com/v1/models", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${key}`,
+      },
+    });
+
+    if (res.ok) return { valid: true };
+
+    if (res.status === 401) {
+      return { valid: false, error: "Invalid API key." };
+    }
+    if (res.status === 403) {
+      return {
+        valid: false,
+        error: "This key doesn't have permission to access the API.",
+      };
+    }
+
+    return {
+      valid: false,
+      error: `OpenAI API returned an unexpected status (${res.status}).`,
+    };
+  } catch {
+    return {
+      valid: false,
+      error: "Could not reach OpenAI API to validate the key.",
     };
   }
 };

--- a/apps/web/src/lib/services/secret-service.ts
+++ b/apps/web/src/lib/services/secret-service.ts
@@ -12,6 +12,7 @@ import {
 
 const SECRET_TYPE_LABELS: Record<string, string> = {
   anthropic: "Anthropic API Key",
+  openai: "OpenAI API Key",
   generic: "Generic Secret",
 };
 
@@ -103,7 +104,9 @@ export const createSecret = async (
       ? ({
           authMode: detectAnthropicAuthMode(value) ?? "api-key",
         } as Prisma.InputJsonValue)
-      : Prisma.JsonNull;
+      : input.type === "openai"
+        ? ({ authMode: "api-key" } as Prisma.InputJsonValue)
+        : Prisma.JsonNull;
 
   const secret = await db.secret.create({
     data: {
@@ -190,6 +193,8 @@ export const updateSecret = async (
       data.metadata = {
         authMode: detectAnthropicAuthMode(value) ?? "api-key",
       } as Prisma.InputJsonValue;
+    } else if (secret.type === "openai") {
+      data.metadata = { authMode: "api-key" } as Prisma.InputJsonValue;
     }
   }
 

--- a/apps/web/src/lib/validations/secret.ts
+++ b/apps/web/src/lib/validations/secret.ts
@@ -57,7 +57,7 @@ const hostPatternSchema = z
 
 export const createSecretSchema = z.object({
   name: z.string().trim().min(1).max(255),
-  type: z.enum(["anthropic", "generic"]),
+  type: z.enum(["anthropic", "openai", "generic"]),
   value: z.string().min(1).max(10000),
   hostPattern: hostPatternSchema,
   pathPattern: z.string().max(1000).optional(),
@@ -121,3 +121,16 @@ export const parseAnthropicMetadata = (
   }
   return null;
 };
+
+// ── OpenAI key helpers ──────────────────────────────────────────────────
+
+export const OPENAI_KEY_MIN_LENGTH = 40;
+
+/**
+ * Returns true if the value looks like an OpenAI key.
+ * OpenAI keys start with `sk-` but NOT `sk-ant-` (which is Anthropic).
+ */
+export const looksLikeOpenaiKey = (value: string): boolean =>
+  value.startsWith("sk-") &&
+  !value.startsWith("sk-ant-") &&
+  value.length >= OPENAI_KEY_MIN_LENGTH;


### PR DESCRIPTION
## Summary

- **OpenAI secrets**: Add "openai" as a new LLM secret type with Bearer auth injection, brand icon, key auto-detection, and validation hints
- **WebSocket proxy**: Transparent WebSocket proxying through the MITM gateway with credential injection into upgrade handshake, 10-min idle timeout, and policy enforcement
- **SecretInput rewrite**: Replace custom DOM masking with standard password/text toggle for better security and UX
- **Gateway deps**: Add hyper client feature and webpki-roots for upstream WebSocket TLS

## Test plan

- [ ] Verify OpenAI card appears in LLMs tab type selection
- [ ] Verify OpenAI key creation with `sk-proj-` prefix auto-detection
- [ ] Verify gateway injects `Authorization: Bearer` for openai secrets
- [ ] Verify WebSocket upgrade detection and credential injection
- [ ] Verify SecretInput eye toggle works across all credential forms
- [ ] Verify `cargo build` succeeds without `--features cloud`
- [ ] Verify `pnpm check` passes