### PR TITLE
feat: support ONECLI_VERSION env var in install script

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - onecli
 
   onecli:
-    image: ghcr.io/onecli/onecli:latest
+    image: ghcr.io/onecli/onecli:${ONECLI_VERSION:-latest}
     container_name: onecli
     restart: unless-stopped
     depends_on:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,10 @@
 #   export ONECLI_GATEWAY_PORT=11255
 #   curl -fsSL https://onecli.sh/install | sh
 #
+# Pin a specific version:
+#   export ONECLI_VERSION=1.2.0
+#   curl -fsSL https://onecli.sh/install | sh
+#
 # This script checks for Docker, downloads the docker-compose.yml,
 # and starts OneCLI (app + PostgreSQL) on ports 10254 and 10255 by default.
 
@@ -100,6 +104,12 @@ main() {
   fi
   export ONECLI_BIND_HOST
   echo "  Bind host: $ONECLI_BIND_HOST"
+
+  # ── Resolve version ──
+
+  ONECLI_VERSION="${ONECLI_VERSION:-latest}"
+  export ONECLI_VERSION
+  echo "  Version:   $ONECLI_VERSION"
 
   # ── Download docker-compose.yml ──
 


### PR DESCRIPTION
## Summary
- Add `ONECLI_VERSION` environment variable to pin a specific Docker image tag during install
- Defaults to `latest` when unset, preserving existing behavior
- Documented in install script header alongside other env var options

## Test plan
- [ ] Run install script without `ONECLI_VERSION` set — confirm it pulls `latest`
- [ ] Run with `export ONECLI_VERSION=1.19.1` — confirm it pulls the pinned tag
- [ ] Verify `docker compose config` resolves the image tag correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)