### PR TITLE
fix: center dashboard content and unify page widths

### DIFF
--- a/apps/web/src/app/(dashboard)/agents/loading.tsx
+++ b/apps/web/src/app/(dashboard)/agents/loading.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from "@dashboard/page-header";
 
 export default function AgentsLoading() {
   return (
-    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-6">
       <PageHeader
         title="Agents"
         description="Manage agents that connect to the gateway and receive injected credentials."

--- a/apps/web/src/app/(dashboard)/agents/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function AgentsPage() {
   return (
-    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-6">
       <PageHeader
         title="Agents"
         description="Manage agents that connect to the gateway and receive injected credentials."

--- a/apps/web/src/app/(dashboard)/connections/layout.tsx
+++ b/apps/web/src/app/(dashboard)/connections/layout.tsx
@@ -9,5 +9,5 @@ export default function ConnectionsLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="flex flex-1 flex-col gap-6 max-w-5xl">{children}</div>;
+  return <div className="flex flex-1 flex-col gap-6">{children}</div>;
 }

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -101,7 +101,9 @@ export default function DashboardLayout({
           )}
           <ScrollArea className="h-full min-h-0 min-w-0 flex-1 [&>[data-radix-scroll-area-viewport]]:!overflow-x-hidden">
             {isSettings && <SettingsMobileNav />}
-            <main className="min-w-0 p-4 sm:p-6">{children}</main>
+            <main className="mx-auto min-w-0 max-w-5xl p-4 sm:p-6">
+              {children}
+            </main>
           </ScrollArea>
         </div>
       </SidebarInset>

--- a/apps/web/src/app/(dashboard)/overview/_components/overview-content.tsx
+++ b/apps/web/src/app/(dashboard)/overview/_components/overview-content.tsx
@@ -21,7 +21,7 @@ export const OverviewContent = () => {
   }, []);
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col gap-6 max-w-5xl">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         title="Overview"
         description="Your OneCLI dashboard at a glance."

--- a/apps/web/src/app/(dashboard)/overview/loading.tsx
+++ b/apps/web/src/app/(dashboard)/overview/loading.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from "@dashboard/page-header";
 
 export default function OverviewLoading() {
   return (
-    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-6">
       <PageHeader
         title="Overview"
         description="Your OneCLI dashboard at a glance."

--- a/apps/web/src/app/(dashboard)/rules/loading.tsx
+++ b/apps/web/src/app/(dashboard)/rules/loading.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from "@dashboard/page-header";
 
 export default function RulesLoading() {
   return (
-    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-6">
       <PageHeader
         title="Rules"
         description="Control what your agents can and cannot access."

--- a/apps/web/src/app/(dashboard)/rules/page.tsx
+++ b/apps/web/src/app/(dashboard)/rules/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function RulesPage() {
   return (
-    <div className="flex flex-1 flex-col gap-6 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-6">
       <PageHeader
         title="Rules"
         description="Control what your agents can and cannot access."

--- a/apps/web/src/app/(dashboard)/settings/api-keys/loading.tsx
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/loading.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from "@dashboard/page-header";
 
 export default function ApiKeysLoading() {
   return (
-    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-4">
       <PageHeader
         title="API Keys"
         description="Manage your API keys for OneCLI services."

--- a/apps/web/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function ApiKeysPage() {
   return (
-    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-4">
       <PageHeader
         title="API Keys"
         description="Manage your API keys for OneCLI services."

--- a/apps/web/src/app/(dashboard)/settings/encryption/loading.tsx
+++ b/apps/web/src/app/(dashboard)/settings/encryption/loading.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from "@dashboard/page-header";
 
 export default function EncryptionLoading() {
   return (
-    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-4">
       <PageHeader
         title="Encryption"
         description="Configure how your secrets are encrypted."

--- a/apps/web/src/app/(dashboard)/settings/encryption/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/encryption/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function EncryptionPage() {
   return (
-    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-4">
       <PageHeader
         title="Encryption"
         description="Configure how your secrets are encrypted."

--- a/apps/web/src/app/(dashboard)/settings/loading.tsx
+++ b/apps/web/src/app/(dashboard)/settings/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@onecli/ui/components/skeleton";
 
 export default function SettingsLoading() {
   return (
-    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-4">
       <div className="space-y-2">
         <Skeleton className="h-8 w-32" />
         <Skeleton className="h-4 w-56" />

--- a/apps/web/src/app/(dashboard)/settings/profile/loading.tsx
+++ b/apps/web/src/app/(dashboard)/settings/profile/loading.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from "@dashboard/page-header";
 
 export default function ProfileLoading() {
   return (
-    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-4">
       <PageHeader
         title="Profile"
         description="Manage your personal information."

--- a/apps/web/src/app/(dashboard)/settings/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/profile/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function ProfilePage() {
   return (
-    <div className="flex flex-1 flex-col gap-4 max-w-5xl">
+    <div className="flex flex-1 flex-col gap-4">
       <PageHeader
         title="Profile"
         description="Manage your personal information."


### PR DESCRIPTION
Move max-width and centering to the dashboard layout wrapper. All pages inherit max-w-5xl + mx-auto from layout.tsx instead of setting their own widths. Fixes inconsistent page widths (some were max-w-3xl, others max-w-5xl) and left-aligned content on wide screens.