### PR TITLE
fix: include hostname in injection cache key (#251)

### DIFF
--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -374,7 +374,7 @@ impl PolicyEngine {
         project_id: &str,
         cache: &dyn CacheStore,
     ) -> Result<AppConnectionResult, ConnectError> {
-        let cache_key = format!("app_injection:{project_id}:{}", conn.id);
+        let cache_key = format!("app_injection:{project_id}:{}:{hostname}", conn.id);
 
         if let Some(cached) = cache.get::<CachedAppInjection>(&cache_key).await {
             debug!(connection_id = %conn.id, "app injection: cache hit");


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The gateway's app injection cache key (`app_injection:{project_id}:{connection_id}`) does not include the hostname. When the same connection (e.g. GitHub) is used across multiple hosts with different auth strategies, the first host to resolve poisons the cache for subsequent hosts.

In practice: if `api.github.com` resolves first (Bearer auth), then `github.com` git operations (which require Basic auth) fail with 401 because they receive the cached Bearer rules.

Fixes #251

## What is the new behavior?

The cache key now includes the hostname (`app_injection:{project_id}:{connection_id}:{hostname}`), so each host gets its own correctly-typed injection rules cached independently.

- `api.github.com` caches Bearer rules
- `github.com` caches BasicXAccessToken rules
- No cross-contamination regardless of request order

## Additional context

Reproduced locally by hitting `api.github.com` then `github.com/...git/info/refs` through the proxy in sequence. The first call succeeds, the second returns 401. After the 60s cache TTL expires, calling `github.com` first works fine, confirming the ordering dependency. Cache invalidation (prefix-based `del_by_prefix`) continues to work correctly since it matches on `app_injection:{project_id}:`.