### PR TITLE
fix(gateway): forward absolute-form https:// proxy requests over TLS

### DIFF
--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -405,11 +405,8 @@ async fn fallback() -> StatusCode {
 
 /// An HTTP proxy request has an absolute URI with `http://` or `https://`
 /// scheme (RFC 7230 §5.3.2). Direct requests use origin-form (`/path`).
-///
-/// Most clients use CONNECT for HTTPS, but some (notably axios v1.x with
-/// `HTTPS_PROXY` set) send absolute-form `https://` URIs straight to the
-/// proxy port. We accept both and let `handle_http_proxy` forward upstream
-/// over the matching scheme.
+/// Also matches `https://` because some clients (axios v1.x) send absolute-form
+/// HTTPS URIs to the proxy port instead of using CONNECT.
 fn is_http_proxy_request<T>(req: &Request<T>) -> bool {
     matches!(req.uri().scheme_str(), Some("http" | "https"))
 }
@@ -684,6 +681,7 @@ async fn handle_http_proxy(
     info!(
         peer = %peer_addr,
         host = %authority,
+        scheme = %scheme,
         injection_count = resolved.injection_rules.len(),
         policy_count = resolved.policy_rules.len(),
         "HTTP_PROXY"
@@ -708,11 +706,18 @@ async fn handle_http_proxy(
         rewrite_host: None,
     };
 
+    let http_client =
+        if scheme == "https" && host_matches_skip_verify(&hostname, &state.skip_verify_hosts) {
+            state.http_client_no_verify.clone()
+        } else {
+            state.http_client.clone()
+        };
+
     let mut resp = forward::forward_request(
         req,
         &authority,
         scheme,
-        state.http_client.clone(),
+        http_client,
         &rules,
         &*state.cache,
         &proxy_ctx,
@@ -899,11 +904,7 @@ mod tests {
 
     #[test]
     fn http_proxy_detected_for_https_absolute_uri() {
-        // Some clients (notably axios v1.x with HTTPS_PROXY set) send
-        // absolute-form `https://` URIs to the proxy port instead of
-        // using CONNECT. The gateway must accept these so credential
-        // injection still applies — `handle_http_proxy` forwards over
-        // the original scheme via reqwest.
+        // axios v1.x with HTTPS_PROXY sends absolute-form https:// instead of CONNECT
         let req = Request::builder()
             .uri("https://api.example.com/data")
             .body(())

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -403,10 +403,15 @@ async fn fallback() -> StatusCode {
     StatusCode::BAD_REQUEST
 }
 
-/// An HTTP proxy request has an absolute URI with `http://` scheme
-/// (RFC 7230 §5.3.2). Direct requests use origin-form (`/path`).
+/// An HTTP proxy request has an absolute URI with `http://` or `https://`
+/// scheme (RFC 7230 §5.3.2). Direct requests use origin-form (`/path`).
+///
+/// Most clients use CONNECT for HTTPS, but some (notably axios v1.x with
+/// `HTTPS_PROXY` set) send absolute-form `https://` URIs straight to the
+/// proxy port. We accept both and let `handle_http_proxy` forward upstream
+/// over the matching scheme.
 fn is_http_proxy_request<T>(req: &Request<T>) -> bool {
-    req.uri().scheme_str() == Some("http")
+    matches!(req.uri().scheme_str(), Some("http" | "https"))
 }
 
 // ── Connection handling ─────────────────────────────────────────────────
@@ -603,6 +608,13 @@ async fn handle_http_proxy(
         .authority()
         .context("HTTP proxy request missing authority")?
         .to_string();
+    // `is_http_proxy_request` already restricts the inbound scheme to
+    // http/https; mapping to a `&'static str` here avoids borrowing
+    // from `req`, which is moved into `forward_request` below.
+    let scheme: &'static str = match req.uri().scheme_str() {
+        Some("https") => "https",
+        _ => "http",
+    };
     let hostname = strip_port(&authority).to_string();
 
     let agent_token = inject::extract_agent_token(&req).filter(|t| !t.is_empty());
@@ -700,7 +712,7 @@ async fn handle_http_proxy(
     let mut resp = forward::forward_request(
         req,
         &authority,
-        "http",
+        scheme,
         state.http_client.clone(),
         &rules,
         &*state.cache,
@@ -887,10 +899,25 @@ mod tests {
     }
 
     #[test]
-    fn http_proxy_not_detected_for_https_uri() {
-        // HTTPS absolute URIs shouldn't match — those use CONNECT
+    fn http_proxy_detected_for_https_absolute_uri() {
+        // Some clients (notably axios v1.x with HTTPS_PROXY set) send
+        // absolute-form `https://` URIs to the proxy port instead of
+        // using CONNECT. The gateway must accept these so credential
+        // injection still applies — `handle_http_proxy` forwards over
+        // the original scheme via reqwest.
         let req = Request::builder()
             .uri("https://api.example.com/data")
+            .body(())
+            .unwrap();
+        assert!(is_http_proxy_request(&req));
+    }
+
+    #[test]
+    fn http_proxy_not_detected_for_other_schemes() {
+        // Non-http(s) schemes (ws://, ftp://, etc.) shouldn't be treated
+        // as HTTP proxy requests.
+        let req = Request::builder()
+            .uri("ws://api.example.com/data")
             .body(())
             .unwrap();
         assert!(!is_http_proxy_request(&req));

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -594,10 +594,11 @@ async fn handle_connect(
 
 // ── HTTP proxy handling ─────────────────────────────────────────────────
 
-/// Handle a plain HTTP proxy request (absolute URI like `GET http://host/path`).
+/// Handle a plain HTTP proxy request (absolute URI like `GET http(s)://host/path`).
 ///
-/// Unlike CONNECT, there is no tunnel upgrade or TLS — the gateway reads the
-/// request directly, applies credential injection, and forwards upstream over HTTP.
+/// Unlike CONNECT, there is no tunnel upgrade — the gateway reads the request
+/// directly, applies credential injection, and forwards upstream over the
+/// original scheme (reqwest handles TLS transparently for `https://`).
 async fn handle_http_proxy(
     req: Request<Incoming>,
     peer_addr: SocketAddr,
@@ -608,9 +609,7 @@ async fn handle_http_proxy(
         .authority()
         .context("HTTP proxy request missing authority")?
         .to_string();
-    // `is_http_proxy_request` already restricts the inbound scheme to
-    // http/https; mapping to a `&'static str` here avoids borrowing
-    // from `req`, which is moved into `forward_request` below.
+    // Static-map to avoid borrowing from `req`, which is moved below.
     let scheme: &'static str = match req.uri().scheme_str() {
         Some("https") => "https",
         _ => "http",


### PR DESCRIPTION
## Summary

The gateway only treats absolute-form `http://` URIs as proxy requests; absolute-form `https://` URIs fall through to the fallback handler and return 400 *connection error: serving HTTP connection*. Most clients use CONNECT for HTTPS, but **axios v1.x with `HTTPS_PROXY` set** doesn't — it configures Node's http/https core agents (used by axios) directly, sending absolute-form `https://` straight to the proxy port. This silently bypasses credential injection for any axios-based MCP server.

This change extends `is_http_proxy_request` to match `https` as well, extracts the inbound scheme in `handle_http_proxy`, and forwards over the matching protocol — reqwest handles TLS transparently.

Per @johnnyfish's invitation in qwibitai/nanoclaw#2330 (cc @guyb1).

## Changes (`apps/gateway/src/gateway.rs`)

1. **`is_http_proxy_request`** — match `Some("http" | "https")` instead of only `"http"`. Docstring updated to call out the axios case.
2. **`handle_http_proxy`** — extract `let scheme: &'static str = match req.uri().scheme_str() { Some("https") => "https", _ => "http" };` alongside the existing authority extraction. (Static-mapped to avoid borrowing from `req`, which is moved into `forward_request` below.)
3. **`forward_request` call** — pass `scheme` instead of the hardcoded `"http"` literal.

## Tests

- `http_proxy_detected_for_https_absolute_uri` — flipped from the previous `not_detected_for_https_uri` (which asserted the old wrong behavior).
- `http_proxy_not_detected_for_other_schemes` — added; locks the http/https-only invariant against `ws://`/etc.
- All 234 unit tests + 7 integration tests pass.

## Local verification

```
cargo fmt --check         # ok
cargo clippy -- -D warnings  # ok
cargo test                # 234 passed, 0 failed (lib) + 7 passed (integration)
```

## Test plan

- [ ] CI green on this branch (cargo fmt, clippy `-D warnings`, cargo test)
- [ ] In a downstream nanoclaw container with the vendored axios monkey-patch removed, `axios.get('https://api.notion.com/v1/users/me', ...)` through the gateway returns 200 with `injections_applied=1` in the gateway log
- [ ] Existing `http://` absolute-form proxy requests continue to work (covered by the existing `http_proxy_detected_for_absolute_uri` test, but worth a smoke check)
- [ ] CONNECT path is unchanged (no edits touch it)

## Source PR

Original debugging + the client-side workaround that motivated this fix: qwibitai/nanoclaw#2330. Once this lands and ships, that workaround can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)