### PR TITLE
feat: generic body transform pattern and gateway restructure

### DIFF
--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -33,6 +33,14 @@ pub(crate) enum RequestFinalizer {
     AwsAssumeRole,
 }
 
+/// Body transformation applied to specific requests after header injection.
+/// The handler internally decides whether to act based on host, method, and path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BodyTransform {
+    /// Inject agent identity trailer into GitHub commit messages.
+    GitHubCommitTrailer,
+}
+
 /// How a host rule matches incoming hostnames.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum HostPattern {
@@ -135,6 +143,9 @@ pub(crate) struct AppProvider {
     /// Optional request finalizer for providers needing full request transformation
     /// (e.g., AWS SigV4 signing). Called after injection, before forwarding.
     pub(crate) finalizer: Option<RequestFinalizer>,
+    /// Optional body transform for provider-specific request modifications.
+    /// The handler decides per-request whether to act.
+    pub(crate) body_transform: Option<BodyTransform>,
 }
 
 /// Shared refresh config for Atlassian OAuth APIs (Jira, Confluence).
@@ -231,6 +242,37 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
+    },
+    AppProvider {
+        provider: "github-app",
+        display_name: "GitHub App",
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("api.github.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+            },
+            HostRule {
+                pattern: HostPattern::Exact("github.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::BasicXAccessToken,
+                intercept: false,
+            },
+            HostRule {
+                pattern: HostPattern::Exact("raw.githubusercontent.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+            },
+        ],
+        refresh: None,
+        metadata_headers: &[],
+        credential_headers: &[],
+        host_rewrite: None,
+        finalizer: None,
+        body_transform: Some(BodyTransform::GitHubCommitTrailer),
     },
     AppProvider {
         provider: "gmail",
@@ -261,6 +303,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-calendar",
@@ -284,6 +327,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-drive",
@@ -313,6 +357,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-docs",
@@ -328,6 +373,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-sheets",
@@ -343,6 +389,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-slides",
@@ -358,6 +405,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-tasks",
@@ -373,6 +421,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-forms",
@@ -388,6 +437,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-classroom",
@@ -403,6 +453,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-admin",
@@ -418,6 +469,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-analytics",
@@ -433,6 +485,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-search-console",
@@ -456,6 +509,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-meet",
@@ -471,6 +525,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "google-photos",
@@ -486,6 +541,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "jira",
@@ -501,6 +557,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "confluence",
@@ -516,6 +573,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "youtube",
@@ -545,6 +603,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "vertex-ai",
@@ -571,6 +630,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "todoist",
@@ -586,6 +646,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "resend",
@@ -601,6 +662,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "cloudflare",
@@ -616,6 +678,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "notion",
@@ -631,6 +694,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "dropbox",
@@ -654,6 +718,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "aws",
@@ -690,6 +755,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         ],
         host_rewrite: None,
         finalizer: Some(RequestFinalizer::AwsSigV4),
+        body_transform: None,
     },
     AppProvider {
         provider: "mongodb-atlas",
@@ -705,6 +771,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "flyio",
@@ -728,6 +795,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "linkedin",
@@ -743,6 +811,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
     AppProvider {
         provider: "supabase",
@@ -758,6 +827,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
         credential_headers: &[],
         host_rewrite: None,
         finalizer: None,
+        body_transform: None,
     },
 ];
 
@@ -785,6 +855,14 @@ pub(crate) fn finalizer_for_host(hostname: &str) -> Option<RequestFinalizer> {
 /// Return the request finalizer for a specific provider by ID.
 pub(crate) fn finalizer_for_provider(provider: &str) -> Option<RequestFinalizer> {
     all_providers().find_map(|p| (p.provider == provider).then_some(p.finalizer).flatten())
+}
+
+pub(crate) fn body_transform_for_provider(provider: &str) -> Option<BodyTransform> {
+    all_providers().find_map(|p| {
+        (p.provider == provider)
+            .then_some(p.body_transform)
+            .flatten()
+    })
 }
 
 /// Given a hostname, return the first matching provider's (id, display_name).
@@ -1239,6 +1317,131 @@ pub(crate) async fn refresh_via_client_credentials(
         .as_secs() as i64;
 
     Ok((access_token, now + expires_in))
+}
+
+/// Refresh an access token for a GitHub App installation.
+/// Signs a JWT with RS256 using the app's private key, then exchanges it for
+/// a short-lived installation access token (1h TTL).
+pub(crate) async fn refresh_github_app_token(
+    private_key_pem: &str,
+    app_id: &str,
+    installation_id: &str,
+) -> anyhow::Result<(String, i64)> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs() as i64;
+
+    #[derive(serde::Serialize)]
+    struct Claims {
+        iss: String,
+        iat: i64,
+        exp: i64,
+    }
+
+    let claims = Claims {
+        iss: app_id.to_string(),
+        iat: now - 60,
+        exp: now + 600,
+    };
+
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_pem.as_bytes())
+        .map_err(|e| anyhow::anyhow!("invalid GitHub App private key: {e}"))?;
+
+    let jwt = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+        &claims,
+        &key,
+    )
+    .map_err(|e| anyhow::anyhow!("GitHub App JWT signing failed: {e}"))?;
+
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "https://api.github.com/app/installations/{installation_id}/access_tokens"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "onecli-gateway")
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("GitHub App token request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow::anyhow!(
+            "GitHub App token exchange failed ({status}): {body}"
+        ));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("GitHub App token response parse failed: {e}"))?;
+
+    let token = body
+        .get("token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("GitHub App token response missing 'token' field"))?
+        .to_string();
+
+    let expires_at_str = body
+        .get("expires_at")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("GitHub App token response missing 'expires_at' field"))?;
+
+    let expires_at = time::OffsetDateTime::parse(
+        expires_at_str,
+        &time::format_description::well_known::Rfc3339,
+    )
+    .map_err(|e| anyhow::anyhow!("failed to parse expires_at '{expires_at_str}': {e}"))?
+    .unix_timestamp();
+
+    Ok((token, expires_at))
+}
+
+/// Attempt to refresh credentials for a known credential type.
+/// Returns `None` if the type is not recognized (falls through to standard OAuth refresh).
+pub(crate) async fn try_refresh_credentials(
+    cred_type: &str,
+    creds: &serde_json::Value,
+) -> Option<anyhow::Result<(String, i64)>> {
+    match cred_type {
+        "github_app" => {
+            let pk = creds.get("private_key").and_then(|v| v.as_str());
+            let aid = creds.get("app_id").and_then(|v| v.as_str());
+            let iid = creds.get("installation_id").and_then(|v| v.as_str());
+            let (Some(pk), Some(aid), Some(iid)) = (pk, aid, iid) else {
+                return Some(Err(anyhow::anyhow!(
+                    "GitHub App credentials incomplete, cannot refresh"
+                )));
+            };
+            Some(refresh_github_app_token(pk, aid, iid).await)
+        }
+        "service_account" => {
+            let pk = creds.get("private_key").and_then(|v| v.as_str());
+            let email = creds.get("client_email").and_then(|v| v.as_str());
+            let (Some(pk), Some(email)) = (pk, email) else {
+                return Some(Err(anyhow::anyhow!(
+                    "service account credentials incomplete, cannot refresh"
+                )));
+            };
+            Some(refresh_via_service_account(pk, email).await)
+        }
+        "client_credentials" => {
+            let id = creds.get("client_id").and_then(|v| v.as_str());
+            let secret = creds.get("client_secret").and_then(|v| v.as_str());
+            let url = creds.get("token_url").and_then(|v| v.as_str());
+            let (Some(id), Some(secret), Some(url)) = (id, secret, url) else {
+                return Some(Err(anyhow::anyhow!(
+                    "client_credentials incomplete, cannot refresh"
+                )));
+            };
+            Some(refresh_via_client_credentials(url, id, secret).await)
+        }
+        _ => None,
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -66,6 +66,10 @@ pub(crate) enum AppConnectionResult {
         connection_label: Option<String>,
         /// Provider-specific request finalizer (e.g., SigV4 vs AssumeRole).
         finalizer: Option<apps::RequestFinalizer>,
+        /// Provider-specific body transform (e.g., commit trailer injection).
+        body_transform: Option<apps::BodyTransform>,
+        /// Provider name of the resolved connection (e.g., "github-app", "datadog").
+        provider: String,
     },
     /// No app connections available for this provider.
     NoConnections,
@@ -366,6 +370,8 @@ impl PolicyEngine {
             let mut resolved_rewrite_host: Option<String> = None;
             let mut resolved_label: Option<String> = None;
             let mut resolved_finalizer: Option<apps::RequestFinalizer> = None;
+            let mut resolved_body_transform: Option<apps::BodyTransform> = None;
+            let mut resolved_provider: Option<String> = None;
             for conn in app_connections {
                 if let AppConnectionResult::Rules {
                     rules: r,
@@ -373,6 +379,8 @@ impl PolicyEngine {
                     rewrite_host,
                     connection_label,
                     finalizer,
+                    body_transform,
+                    provider,
                 } = self
                     .resolve_connection_injections(
                         conn,
@@ -393,6 +401,12 @@ impl PolicyEngine {
                     if finalizer.is_some() {
                         resolved_finalizer = finalizer;
                     }
+                    if body_transform.is_some() {
+                        resolved_body_transform = body_transform;
+                    }
+                    if resolved_provider.is_none() {
+                        resolved_provider = Some(provider);
+                    }
                     match (earliest_expires_at, token_expires_at) {
                         (None, exp) => earliest_expires_at = exp,
                         (Some(cur), Some(exp)) if exp < cur => earliest_expires_at = Some(exp),
@@ -406,6 +420,8 @@ impl PolicyEngine {
                 rewrite_host: resolved_rewrite_host,
                 connection_label: resolved_label,
                 finalizer: resolved_finalizer,
+                body_transform: resolved_body_transform,
+                provider: resolved_provider.unwrap_or_default(),
             });
         }
 
@@ -443,6 +459,8 @@ impl PolicyEngine {
                 rewrite_host: cached.rewrite_host,
                 connection_label: cached.connection_label,
                 finalizer: apps::finalizer_for_provider(&conn.provider),
+                body_transform: apps::body_transform_for_provider(&conn.provider),
+                provider: conn.provider.clone(),
             });
         }
 
@@ -559,6 +577,8 @@ impl PolicyEngine {
             rewrite_host,
             connection_label: conn.label.clone(),
             finalizer: apps::finalizer_for_provider(&conn.provider),
+            body_transform: apps::body_transform_for_provider(&conn.provider),
+            provider: conn.provider.clone(),
         })
     }
 
@@ -718,13 +738,19 @@ impl PolicyEngine {
             if expires_at < now {
                 let cred_type = creds.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
-                // Cloud-specific credential refresh (e.g., GitHub App JWT)
-                if let Some(result) =
+                // Try cloud-specific refresh first, then shared credential types
+                let refresh_result = if let Some(r) =
                     crate::cloud_apps::try_refresh_credentials(cred_type, &creds).await
                 {
+                    Some(r)
+                } else {
+                    apps::try_refresh_credentials(cred_type, &creds).await
+                };
+
+                if let Some(result) = refresh_result {
                     match result {
                         Ok((new_token, new_expires_at)) => {
-                            debug!(provider = %provider, cred_type, "refreshed cloud credential");
+                            debug!(provider = %provider, cred_type, "refreshed credential");
                             token = Some(new_token.clone());
                             effective_expires_at = Some(new_expires_at);
 
@@ -734,69 +760,8 @@ impl PolicyEngine {
                                 .await;
                         }
                         Err(e) => {
-                            warn!(provider = %provider, cred_type, error = %e, "cloud credential refresh failed");
+                            debug!(provider = %provider, cred_type, error = %e, "credential refresh failed");
                         }
-                    }
-                } else if cred_type == "service_account" {
-                    // Service account: sign JWT with private key
-                    let private_key = creds.get("private_key").and_then(|v| v.as_str());
-                    let client_email = creds.get("client_email").and_then(|v| v.as_str());
-
-                    if let (Some(pk), Some(email)) = (private_key, client_email) {
-                        match apps::refresh_via_service_account(pk, email).await {
-                            Ok((new_token, new_expires_at)) => {
-                                debug!(provider = %provider, "refreshed service account token via JWT");
-                                token = Some(new_token.clone());
-                                effective_expires_at = Some(new_expires_at);
-
-                                creds["access_token"] = serde_json::Value::String(new_token);
-                                creds["expires_at"] = serde_json::json!(new_expires_at);
-                                self.persist_refreshed_credentials(connection_id, provider, &creds)
-                                    .await;
-                            }
-                            Err(e) => {
-                                debug!(provider = %provider, error = %e, "service account JWT refresh failed");
-                            }
-                        }
-                    } else {
-                        debug!(
-                            provider = %provider,
-                            has_private_key = private_key.is_some(),
-                            has_client_email = client_email.is_some(),
-                            "service account credentials incomplete, cannot refresh"
-                        );
-                    }
-                } else if cred_type == "client_credentials" {
-                    let client_id = creds.get("client_id").and_then(|v| v.as_str());
-                    let client_secret = creds.get("client_secret").and_then(|v| v.as_str());
-                    let token_url = creds.get("token_url").and_then(|v| v.as_str());
-
-                    if let (Some(id), Some(secret), Some(url)) =
-                        (client_id, client_secret, token_url)
-                    {
-                        match apps::refresh_via_client_credentials(url, id, secret).await {
-                            Ok((new_token, new_expires_at)) => {
-                                debug!(provider = %provider, "refreshed client_credentials token");
-                                token = Some(new_token.clone());
-                                effective_expires_at = Some(new_expires_at);
-
-                                creds["access_token"] = serde_json::Value::String(new_token);
-                                creds["expires_at"] = serde_json::json!(new_expires_at);
-                                self.persist_refreshed_credentials(connection_id, provider, &creds)
-                                    .await;
-                            }
-                            Err(e) => {
-                                debug!(provider = %provider, error = %e, "client_credentials token refresh failed");
-                            }
-                        }
-                    } else {
-                        debug!(
-                            provider = %provider,
-                            has_client_id = client_id.is_some(),
-                            has_client_secret = client_secret.is_some(),
-                            has_token_url = token_url.is_some(),
-                            "client_credentials incomplete, cannot refresh"
-                        );
                     }
                 } else if let Some(refresh_token) =
                     creds.get("refresh_token").and_then(|v| v.as_str())

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -13,10 +13,8 @@
 //! - [`tunnel`]: direct TCP tunneling for non-intercepted domains
 //! - [`response`]: pre-built gateway error responses
 
-mod aws_sigv4;
-#[cfg(feature = "cloud")]
-#[path = "cloud/aws_sts.rs"]
-mod aws_sts;
+mod body;
+mod finalizers;
 pub(crate) mod forward;
 #[cfg(not(feature = "cloud"))]
 mod hooks;
@@ -25,6 +23,7 @@ mod hooks;
 mod hooks;
 mod mitm;
 mod response;
+mod transforms;
 mod tunnel;
 mod websocket;
 
@@ -639,6 +638,7 @@ async fn handle_http_proxy(
 
     // Per-request app connection disambiguation
     let mut resolved_finalizer: Option<crate::apps::RequestFinalizer> = None;
+    let mut resolved_body_transform: Option<crate::apps::BodyTransform> = None;
     if resolved.injection_rules.is_empty() && !resolved.app_connections.is_empty() {
         let oid = resolved.organization_id.as_deref().unwrap_or("");
         let pid = resolved.project_id.as_deref().unwrap_or("");
@@ -655,10 +655,14 @@ async fn handle_http_proxy(
             .await
         {
             Ok(AppConnectionResult::Rules {
-                rules, finalizer, ..
+                rules,
+                finalizer,
+                body_transform,
+                ..
             }) => {
                 resolved.injection_rules = rules;
                 resolved_finalizer = finalizer;
+                resolved_body_transform = body_transform;
             }
             Ok(AppConnectionResult::Ambiguous { connections }) => {
                 return Ok(response::multiple_connections_axum(&connections));
@@ -716,6 +720,7 @@ async fn handle_http_proxy(
         rewrite_host: None,
         connection_label: None,
         finalizer: resolved_finalizer,
+        body_transform: resolved_body_transform,
     };
 
     let http_client =

--- a/apps/gateway/src/gateway/body.rs
+++ b/apps/gateway/src/gateway/body.rs
@@ -1,0 +1,49 @@
+//! Shared body buffering utilities for the gateway pipeline.
+
+use anyhow::Context as _;
+use http_body_util::BodyExt;
+use hyper::body::Bytes;
+
+const MAX_BODY_SIZE: usize = 10 * 1024 * 1024; // 10 MB
+
+/// Buffer a streaming `reqwest::Body` into bytes, enforcing size during read.
+///
+/// Rejects the body as soon as accumulated bytes exceed `MAX_BODY_SIZE`,
+/// preventing OOM on large uploads without buffering the entire payload first.
+pub(crate) async fn buffer_body(mut body: reqwest::Body) -> anyhow::Result<Bytes> {
+    let mut buf = Vec::with_capacity(4096);
+
+    while let Some(frame_result) = body.frame().await {
+        let frame = frame_result.context("reading request body")?;
+        if let Some(data) = frame.data_ref() {
+            if buf.len() + data.len() > MAX_BODY_SIZE {
+                anyhow::bail!("request body exceeds {MAX_BODY_SIZE} byte limit");
+            }
+            buf.extend_from_slice(data);
+        }
+    }
+
+    Ok(Bytes::from(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn buffer_body_rejects_oversized() {
+        let oversized = vec![0u8; MAX_BODY_SIZE + 1];
+        let body = reqwest::Body::from(oversized);
+        let result = buffer_body(body).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds"),);
+    }
+
+    #[tokio::test]
+    async fn buffer_body_accepts_within_limit() {
+        let data = vec![42u8; 1024];
+        let body = reqwest::Body::from(data.clone());
+        let result = buffer_body(body).await.expect("should succeed");
+        assert_eq!(result.as_ref(), data.as_slice());
+    }
+}

--- a/apps/gateway/src/gateway/finalizers.rs
+++ b/apps/gateway/src/gateway/finalizers.rs
@@ -1,0 +1,4 @@
+pub(crate) mod aws_sigv4;
+#[cfg(feature = "cloud")]
+#[path = "../cloud/aws_sts.rs"]
+pub(crate) mod aws_sts;

--- a/apps/gateway/src/gateway/finalizers/aws_sigv4.rs
+++ b/apps/gateway/src/gateway/finalizers/aws_sigv4.rs
@@ -11,15 +11,14 @@ use aws_sigv4::http_request::{
     SigningSettings,
 };
 use aws_sigv4::sign::v4;
-use http_body_util::BodyExt;
-use hyper::body::Bytes;
 use hyper::header::{HeaderName, HeaderValue};
+
+use super::super::body::buffer_body;
 
 const AWS_ACCESS_KEY_HEADER: &str = "x-onecli-aws-access-key-id";
 const AWS_SECRET_KEY_HEADER: &str = "x-onecli-aws-secret-access-key";
 const AWS_SESSION_TOKEN_HEADER: &str = "x-onecli-aws-session-token";
 const AWS_REGION_HEADER: &str = "x-onecli-aws-region";
-const MAX_BODY_SIZE: usize = 10 * 1024 * 1024; // 10 MB
 
 #[derive(Clone)]
 pub(crate) struct AwsCredentials {
@@ -200,29 +199,6 @@ pub(crate) fn sign_request(
     Ok(())
 }
 
-/// Buffer a streaming `reqwest::Body` into bytes, enforcing size during read.
-///
-/// Rejects the body as soon as accumulated bytes exceed `MAX_BODY_SIZE`,
-/// preventing OOM on large uploads (e.g., S3 PutObject) without buffering
-/// the entire payload first.
-pub(crate) async fn buffer_body(mut body: reqwest::Body) -> anyhow::Result<Bytes> {
-    let mut buf = Vec::with_capacity(4096);
-
-    while let Some(frame_result) = body.frame().await {
-        let frame = frame_result.context("reading request body for SigV4 signing")?;
-        if let Some(data) = frame.data_ref() {
-            if buf.len() + data.len() > MAX_BODY_SIZE {
-                anyhow::bail!(
-                    "request body exceeds {MAX_BODY_SIZE} byte limit for AWS SigV4 signing"
-                );
-            }
-            buf.extend_from_slice(data);
-        }
-    }
-
-    Ok(Bytes::from(buf))
-}
-
 /// Sign an outgoing AWS request.
 ///
 /// Extracts credentials from internal headers, buffers the body, signs
@@ -396,22 +372,5 @@ mod tests {
         assert!(!headers.contains_key(AWS_SECRET_KEY_HEADER));
         assert!(!headers.contains_key(AWS_SESSION_TOKEN_HEADER));
         assert!(!headers.contains_key(AWS_REGION_HEADER));
-    }
-
-    #[tokio::test]
-    async fn buffer_body_rejects_oversized() {
-        let oversized = vec![0u8; MAX_BODY_SIZE + 1];
-        let body = reqwest::Body::from(oversized);
-        let result = buffer_body(body).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("exceeds"),);
-    }
-
-    #[tokio::test]
-    async fn buffer_body_accepts_within_limit() {
-        let data = vec![42u8; 1024];
-        let body = reqwest::Body::from(data.clone());
-        let result = buffer_body(body).await.expect("should succeed");
-        assert_eq!(result.as_ref(), data.as_slice());
     }
 }

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -387,13 +387,40 @@ pub(crate) async fn forward_request(
         body
     };
 
+    // ── Provider-specific body transformation ────────────────────
+    let forward_body = match rules.body_transform {
+        Some(crate::apps::BodyTransform::GitHubCommitTrailer) => {
+            if let (Some(agent_name), Some(project_id)) = (
+                proxy_ctx.agent_name.as_deref(),
+                proxy_ctx.project_id.as_deref(),
+            ) {
+                super::transforms::github_commit_trailer::try_inject_trailer(
+                    host,
+                    &method,
+                    &path,
+                    forward_body,
+                    agent_name,
+                    project_id,
+                )
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "body transform failed, forwarding empty body");
+                    reqwest::Body::from(vec![])
+                })
+            } else {
+                forward_body
+            }
+        }
+        None => forward_body,
+    };
+
     // ── Provider-specific request signing ─────────────────────────
     let forward_body = match rules
         .finalizer
         .or_else(|| crate::apps::finalizer_for_host(host.split(':').next().unwrap_or(host)))
     {
         Some(crate::apps::RequestFinalizer::AwsSigV4) => {
-            super::aws_sigv4::finalize_request(
+            super::finalizers::aws_sigv4::finalize_request(
                 host,
                 method.as_str(),
                 &upstream_path,
@@ -404,7 +431,7 @@ pub(crate) async fn forward_request(
         }
         #[cfg(feature = "cloud")]
         Some(crate::apps::RequestFinalizer::AwsAssumeRole) => {
-            super::aws_sts::finalize_request(
+            super::finalizers::aws_sts::finalize_request(
                 host,
                 method.as_str(),
                 &upstream_path,

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -197,6 +197,9 @@ pub(crate) struct ResolvedRules {
     /// Provider-specific request finalizer resolved from the app connection.
     /// When set, takes precedence over the host-based finalizer lookup.
     pub finalizer: Option<crate::apps::RequestFinalizer>,
+    /// Provider-specific body transform resolved from the app connection.
+    /// The handler decides per-request whether to act.
+    pub body_transform: Option<crate::apps::BodyTransform>,
 }
 
 /// Result of per-request rule resolution including app connection disambiguation.
@@ -251,6 +254,7 @@ async fn resolve_rules(
     let mut rewrite_host: Option<String> = None;
     let mut connection_label: Option<String> = None;
     let mut finalizer: Option<crate::apps::RequestFinalizer> = None;
+    let mut body_transform: Option<crate::apps::BodyTransform> = None;
 
     // If no secret rules, try app connections (per-request disambiguation)
     if injection_rules.is_empty() && !resp.app_connections.is_empty() {
@@ -271,12 +275,15 @@ async fn resolve_rules(
                 rewrite_host: rh,
                 connection_label: cl,
                 finalizer: f,
+                body_transform: bt,
+                ..
             } => {
                 injection_rules = rules;
                 token_expires_at = exp;
                 rewrite_host = rh;
                 connection_label = cl;
                 finalizer = f;
+                body_transform = bt;
             }
             AppConnectionResult::Ambiguous { connections } => {
                 return Ok(ResolveResult::Ambiguous(connections));
@@ -340,6 +347,7 @@ async fn resolve_rules(
             rewrite_host,
             connection_label,
             finalizer,
+            body_transform,
         },
         app_connections: resp.app_connections,
     })

--- a/apps/gateway/src/gateway/transforms.rs
+++ b/apps/gateway/src/gateway/transforms.rs
@@ -1,0 +1,1 @@
+pub(crate) mod github_commit_trailer;

--- a/apps/gateway/src/gateway/transforms/github_commit_trailer.rs
+++ b/apps/gateway/src/gateway/transforms/github_commit_trailer.rs
@@ -1,0 +1,237 @@
+//! Inject agent identity into GitHub commit bodies.
+//!
+//! When the gateway creates commits on behalf of an agent using a GitHub App
+//! installation token, the commit has no natural author identity. This module
+//! prefixes the agent name onto the commit message and appends an
+//! `On-Behalf-Of` trailer for traceability.
+//!
+//! Invoked via the `BodyTransform::GitHubCommitTrailer` dispatch in `forward.rs`.
+//! All GitHub-specific logic (host, method, path checks) is encapsulated here.
+
+use hyper::Method;
+use tracing::debug;
+
+/// Agent identity to inject into commit messages.
+struct AgentCommitIdentity<'a> {
+    agent_name: &'a str,
+    project_id: &'a str,
+}
+
+/// Attempt to inject a commit identity trailer into the request body.
+///
+/// Checks internally whether this is a GitHub commit-creating endpoint.
+/// Returns the body unchanged if no modification is needed.
+pub(crate) async fn try_inject_trailer(
+    host: &str,
+    method: &Method,
+    path: &str,
+    body: reqwest::Body,
+    agent_name: &str,
+    project_id: &str,
+) -> anyhow::Result<reqwest::Body> {
+    if !is_commit_request(host, method, path) {
+        return Ok(body);
+    }
+
+    let identity = AgentCommitIdentity {
+        agent_name,
+        project_id,
+    };
+
+    let bytes = super::super::body::buffer_body(body).await?;
+    match inject_commit_trailer(&bytes, &identity) {
+        Some(modified) => Ok(reqwest::Body::from(modified)),
+        None => Ok(reqwest::Body::from(bytes)),
+    }
+}
+
+/// Check if this request targets a GitHub commit-creating endpoint.
+fn is_commit_request(host: &str, method: &Method, path: &str) -> bool {
+    let hostname = host.split(':').next().unwrap_or(host);
+    if hostname != "api.github.com" {
+        return false;
+    }
+
+    if !matches!(method, &Method::PUT | &Method::POST) {
+        return false;
+    }
+
+    is_commit_endpoint(method, path)
+}
+
+/// Prefixes the agent name and appends an `On-Behalf-Of` trailer to the
+/// commit message. Returns `None` if no modification was needed.
+fn inject_commit_trailer(body: &[u8], identity: &AgentCommitIdentity) -> Option<Vec<u8>> {
+    let mut json: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let obj = json.as_object_mut()?;
+
+    let message = obj
+        .get_mut("message")
+        .and_then(|v| v.as_str().map(String::from))?;
+    let prefix = format!("[{}] ", identity.agent_name);
+    let trailer = format!(
+        "\n\nOn-Behalf-Of: {}[onecli] ({})",
+        identity.agent_name, identity.project_id
+    );
+    if message.contains("On-Behalf-Of:") {
+        return None;
+    }
+
+    let new_message = if message.starts_with(&prefix) {
+        format!("{message}{trailer}")
+    } else {
+        format!("{prefix}{message}{trailer}")
+    };
+    obj.insert(
+        "message".to_string(),
+        serde_json::Value::String(new_message),
+    );
+
+    debug!(
+        agent = identity.agent_name,
+        "injected On-Behalf-Of trailer into commit message"
+    );
+    serde_json::to_vec(&json).ok()
+}
+
+/// Returns true if the path matches a GitHub commit-creating endpoint
+/// that uses a `message` field for the commit message.
+///
+/// Note: merge endpoints (POST /merges, PUT /pulls/:number/merge) are
+/// excluded because they use `commit_message`/`commit_title` with
+/// different semantics (appended to auto-generated messages).
+fn is_commit_endpoint(method: &Method, path: &str) -> bool {
+    let path = path.split('?').next().unwrap_or(path);
+
+    // PUT /repos/:owner/:repo/contents/:path
+    if method == Method::PUT && is_contents_path(path) {
+        return true;
+    }
+
+    // POST /repos/:owner/:repo/git/commits
+    if method == Method::POST && is_git_commits_path(path) {
+        return true;
+    }
+
+    false
+}
+
+fn is_contents_path(path: &str) -> bool {
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    segments.len() >= 5 && segments[0] == "repos" && segments[3] == "contents"
+}
+
+fn is_git_commits_path(path: &str) -> bool {
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    segments.len() == 5
+        && segments[0] == "repos"
+        && segments[3] == "git"
+        && segments[4] == "commits"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_contents_put() {
+        assert!(is_commit_request(
+            "api.github.com",
+            &Method::PUT,
+            "/repos/owner/repo/contents/path/to/file.md",
+        ));
+    }
+
+    #[test]
+    fn detects_git_commits_post() {
+        assert!(is_commit_request(
+            "api.github.com",
+            &Method::POST,
+            "/repos/owner/repo/git/commits",
+        ));
+    }
+
+    #[test]
+    fn skips_merge_endpoints() {
+        assert!(!is_commit_request(
+            "api.github.com",
+            &Method::POST,
+            "/repos/owner/repo/merges",
+        ));
+        assert!(!is_commit_request(
+            "api.github.com",
+            &Method::PUT,
+            "/repos/owner/repo/pulls/42/merge",
+        ));
+    }
+
+    #[test]
+    fn skips_non_commit_endpoints() {
+        assert!(!is_commit_request(
+            "api.github.com",
+            &Method::POST,
+            "/repos/owner/repo/issues",
+        ));
+    }
+
+    #[test]
+    fn skips_get_requests() {
+        assert!(!is_commit_request(
+            "api.github.com",
+            &Method::GET,
+            "/repos/owner/repo/contents/file.md",
+        ));
+    }
+
+    #[test]
+    fn skips_non_github_host() {
+        assert!(!is_commit_request(
+            "api.gitlab.com",
+            &Method::PUT,
+            "/repos/owner/repo/contents/file.md",
+        ));
+    }
+
+    #[test]
+    fn injects_trailer() {
+        let body = serde_json::json!({
+            "message": "Create file",
+            "content": "SGVsbG8=",
+        });
+        let identity = AgentCommitIdentity {
+            agent_name: "deploy-bot",
+            project_id: "proj_abc123",
+        };
+
+        let result = inject_commit_trailer(body.to_string().as_bytes(), &identity).unwrap();
+        let modified: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        let msg = modified["message"].as_str().unwrap();
+        assert!(msg.starts_with("[deploy-bot] Create file"));
+        assert!(msg.contains("On-Behalf-Of: deploy-bot[onecli] (proj_abc123)"));
+    }
+
+    #[test]
+    fn does_not_duplicate_trailer() {
+        let body = serde_json::json!({
+            "message": "Create file\n\nOn-Behalf-Of: someone",
+            "content": "SGVsbG8=",
+        });
+        let identity = AgentCommitIdentity {
+            agent_name: "deploy-bot",
+            project_id: "proj_abc123",
+        };
+
+        let result = inject_commit_trailer(body.to_string().as_bytes(), &identity);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn handles_path_with_query_string() {
+        assert!(is_commit_request(
+            "api.github.com",
+            &Method::PUT,
+            "/repos/owner/repo/contents/file.md?ref=main",
+        ));
+    }
+}

--- a/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agent-card.tsx
@@ -58,7 +58,7 @@ interface AgentCardProps {
   agent: {
     id: string;
     name: string;
-    identifier: string;
+    identifier: string | null;
     accessToken: string;
     isDefault: boolean;
     secretMode: SecretMode;
@@ -170,7 +170,7 @@ export const AgentCard = ({
 
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
             <code className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono">
-              {agent.identifier}
+              {agent.identifier ?? agent.name}
             </code>
             <span className="text-muted-foreground">
               Created {new Date(agent.createdAt).toLocaleDateString()}

--- a/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/agents-content.tsx
@@ -14,7 +14,7 @@ import { CreateAgentDialog } from "./create-agent-dialog";
 interface Agent {
   id: string;
   name: string;
-  identifier: string;
+  identifier: string | null;
   accessToken: string;
   isDefault: boolean;
   secretMode: SecretMode;


### PR DESCRIPTION
## Summary

Introduces a generic body transform system for the gateway, restructures modules into `finalizers/` and `transforms/` directories, and moves the GitHub App provider to shared code.

### Body Transform Pattern
- New `BodyTransform` enum mirroring `RequestFinalizer` — defined on `AppProvider`, threaded through connection resolution, dispatched generically in `forward.rs`
- First implementation: `GitHubCommitTrailer` — injects agent name prefix and `On-Behalf-Of` trailer into GitHub commit messages (Contents API and Git commits API)
- Adding a new body transform for another provider = add enum variant + handler module + set on provider definition

### Gateway Restructure
- `finalizers/` directory: `aws_sigv4.rs` moved here (modern Rust file naming, no `mod.rs`)
- `transforms/` directory: `github_commit_trailer.rs` lives here
- `body.rs`: extracted `buffer_body` from `aws_sigv4` into shared utility

### GitHub App Provider
- Moved from cloud-only (`cloud_apps.rs`) to shared (`apps.rs`) — available in both OSS and cloud builds
- Token refresh (`refresh_github_app_token`) moved to shared `apps.rs`
- Credential refresh consolidated into `apps::try_refresh_credentials` (handles `github_app`, `service_account`, `client_credentials`)

### Other
- Fix agent card identifier type to handle nullable (backwards compat)

## Files changed
```
 apps/gateway/src/apps.rs                                    | 203 +++
 apps/gateway/src/connect.rs                                 |  95 +-
 apps/gateway/src/gateway.rs                                 |  15 +-
 apps/gateway/src/gateway/body.rs                            |  49 + (new)
 apps/gateway/src/gateway/finalizers.rs                      |   4 + (new)
 apps/gateway/src/gateway/{aws_sigv4.rs => finalizers/...}   |  45 -
 apps/gateway/src/gateway/forward.rs                         |  31 +-
 apps/gateway/src/gateway/mitm.rs                            |   8 +
 apps/gateway/src/gateway/transforms.rs                      |   1 + (new)
 apps/gateway/src/gateway/transforms/github_commit_trailer.rs| 230 +++ (new)
 apps/web/.../agents/_components/agent-card.tsx               |   4 +-
 apps/web/.../agents/_components/agents-content.tsx           |   2 +-
```