### PR TITLE
fix: show cloud upsell instead of infinite spinner in get-started dialog

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
@@ -92,7 +92,7 @@ export const GetStartedDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        {loading ? (
+        {loading && IS_CLOUD ? (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="text-muted-foreground size-5 animate-spin" />
           </div>
@@ -160,9 +160,18 @@ export const GetStartedDialog = ({
                       </div>
                     </div>
                   ) : (
-                    <div className="flex items-center justify-center py-6">
-                      <Loader2 className="text-muted-foreground size-4 animate-spin" />
-                    </div>
+                    <p className="text-muted-foreground rounded-lg border p-4 text-sm">
+                      One-command install is available with{" "}
+                      <a
+                        href="https://app.onecli.sh"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-foreground font-medium underline underline-offset-2"
+                      >
+                        OneCLI Cloud
+                      </a>
+                      .
+                    </p>
                   )}
                 </div>
               )}


### PR DESCRIPTION
## Summary

- In OSS mode, the Get Started dialog showed an infinite loading spinner because `getInstallInfo()` returns null for cloud-only install commands
- Now shows "One-command install is available with OneCLI Cloud" message instead
- Both Coding Agents and Install NanoClaw tabs show the same cloud upsell in OSS mode

## Test plan

- [ ] Open Get Started dialog in OSS mode → no spinner, shows cloud upsell
- [ ] Cloud mode still shows install commands correctly