### PR TITLE
feat: make Vertex AI quotaProjectId optional and support dynamic credential stubs

### DIFF
--- a/packages/api/src/apps/types.ts
+++ b/packages/api/src/apps/types.ts
@@ -113,12 +113,19 @@ export interface AppDefinition {
   labelHint?: string;
   teamOnly?: boolean;
   /** Credential stubs for provisioners to write so MCP servers can boot. */
-  credentialStubs?: {
-    /** Full destination path (e.g., "~/.config/gcloud/application_default_credentials.json"). */
-    path: string;
-    /** Stub content with "onecli-managed" sentinel values. */
-    content: Record<string, unknown>;
-  }[];
+  credentialStubs?:
+    | {
+        /** Full destination path (e.g., "~/.config/gcloud/application_default_credentials.json"). */
+        path: string;
+        /** Stub content with "onecli-managed" sentinel values. */
+        content: Record<string, unknown>;
+      }[]
+    | ((credentials?: Record<string, unknown>) => {
+        /** Full destination path (e.g., "~/.config/gcloud/application_default_credentials.json"). */
+        path: string;
+        /** Stub content with "onecli-managed" sentinel values. */
+        content: Record<string, unknown>;
+      }[]);
   /** OAuth apps can be configured with custom credentials (BYOC). */
   configurable?: {
     fields: OAuthConfigField[];

--- a/packages/api/src/apps/vertex-ai.ts
+++ b/packages/api/src/apps/vertex-ai.ts
@@ -30,12 +30,9 @@ const signJwt = (privateKey: string, clientEmail: string): string => {
 const exchangeServiceAccount = async (
   fields: Record<string, string>,
 ): Promise<OAuthExchangeResult> => {
-  const { privateKey, clientEmail, projectId } = fields;
+  const { privateKey, clientEmail, quotaProjectId } = fields;
   if (!privateKey || !clientEmail) {
     throw new Error("Service account email and private key are required");
-  }
-  if (!projectId) {
-    throw new Error("GCP Project ID is required");
   }
 
   const jwt = signJwt(privateKey, clientEmail);
@@ -82,12 +79,12 @@ const exchangeServiceAccount = async (
       access_token: tokenData.access_token,
       private_key: privateKey,
       client_email: clientEmail,
-      project_id: projectId,
+      project_id: quotaProjectId,
       expires_at: expiresAt,
     },
     scopes: [CLOUD_PLATFORM_SCOPE],
     metadata: {
-      quotaProjectId: projectId,
+      quotaProjectId,
       username: clientEmail,
     },
   };
@@ -195,10 +192,11 @@ export const vertexAi: AppDefinition = {
         group: "service_account",
       },
       {
-        name: "projectId",
-        label: "GCP Project ID",
+        name: "quotaProjectId",
+        label: "GCP Project ID (optional)",
         description: "Google Cloud project ID for quota and billing",
         placeholder: "my-gcp-project",
+        optional: true,
         group: "service_account",
       },
       {
@@ -233,9 +231,10 @@ export const vertexAi: AppDefinition = {
       },
       {
         name: "quotaProjectId",
-        label: "GCP Project ID",
+        label: "GCP Project ID (optional)",
         description: "Google Cloud project ID for quota and billing",
         placeholder: "my-gcp-project",
+        optional: true,
         group: "authorized_user",
       },
     ],
@@ -246,7 +245,7 @@ export const vertexAi: AppDefinition = {
       keyMap: {
         private_key: "privateKey",
         client_email: "clientEmail",
-        project_id: "projectId",
+        project_id: "quotaProjectId",
         refresh_token: "refreshToken",
         client_id: "clientId",
         client_secret: "clientSecret",
@@ -256,18 +255,25 @@ export const vertexAi: AppDefinition = {
   },
   labelHint: 'e.g. "prod-project", "experiments"',
   available: true,
-  credentialStubs: [
-    {
-      path: "~/.config/gcloud/application_default_credentials.json",
-      content: {
-        account: "onecli-managed",
-        client_id: "onecli-managed",
-        client_secret: "onecli-managed",
-        quota_project_id: "onecli-managed",
-        refresh_token: "onecli-managed",
-        type: "authorized_user",
-        universe_domain: "googleapis.com",
+  credentialStubs: (credentials) => {
+    const stub: Record<string, unknown> = {
+      account: "onecli-managed",
+      client_id: "onecli-managed",
+      client_secret: "onecli-managed",
+      refresh_token: "onecli-managed",
+      type: "authorized_user",
+      universe_domain: "googleapis.com",
+    };
+
+    if (!credentials || credentials.quota_project_id) {
+      stub.quota_project_id = "onecli-managed";
+    }
+
+    return [
+      {
+        path: "~/.config/gcloud/application_default_credentials.json",
+        content: stub,
       },
-    },
-  ],
+    ];
+  },
 };

--- a/packages/api/src/routes/apps.ts
+++ b/packages/api/src/routes/apps.ts
@@ -89,7 +89,10 @@ export const appRoutes = () => {
               connectedAt: connection.connectedAt,
             }
           : null,
-        credentialStubs: a.credentialStubs ?? [],
+        credentialStubs:
+          typeof a.credentialStubs === "function"
+            ? a.credentialStubs()
+            : (a.credentialStubs ?? []),
       };
     });
 
@@ -235,7 +238,10 @@ export const appRoutes = () => {
             connectedAt: connection.connectedAt,
           }
         : null,
-      credentialStubs: appDef.credentialStubs ?? [],
+      credentialStubs:
+        typeof appDef.credentialStubs === "function"
+          ? appDef.credentialStubs()
+          : (appDef.credentialStubs ?? []),
       hint,
     });
   });
@@ -518,6 +524,7 @@ export const appRoutes = () => {
       appDef.connectionMethod.fields.some((f) => f.group)
     ) {
       requiredFields = appDef.connectionMethod.fields.filter((f) => {
+        if ("optional" in f && f.optional) return false;
         if (!f.group) return true;
         if (fields.privateKey) return f.group === "service_account";
         return f.group === "authorized_user";


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The quotaProjectId (GCP project ID) is optional for Vertex AI authentication.
Users can authenticate via service account or authorized user credentials
without specifying a quota project ID. However, the connection validation was
incorrectly treating it as required, causing configuration failures when
the field was omitted.

## What is the current behavior?

Configuring the vertex ai app from API fails with a "GCP Project ID is required" error. See openkaiden/kaiden#1882

## What is the new behavior?

Changes:
- Add `optional` field type to credentials_import connection method
- Mark quotaProjectId as optional in both service_account and authorized_user groups
- Update validation logic to respect optional field declarations
- Support dynamic credential stub generation via functions
- Only include quota_project_id in generated ADC stub if actually provided

This allows users with minimal credentials to connect to Vertex AI without
redundant configuration, while still including the field when available.
