### PR TITLE
fix: show redirect URI in OAuth credentials dialog

### DIFF
--- a/apps/web/src/app/(dashboard)/connections/_components/app-config-form.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-config-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Check, Copy, Loader2, Settings2 } from "lucide-react";
+import { Loader2, Settings2 } from "lucide-react";
 import { toast } from "sonner";
 import {
   Accordion,
@@ -32,9 +32,8 @@ import {
   deleteAppConfigAction,
   setAppConfigEnabled,
 } from "@/lib/actions/app-config";
-import { APP_URL, IS_CLOUD } from "@/lib/env";
-import { API_ORIGIN } from "@/lib/api-fetch";
-import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { IS_CLOUD } from "@/lib/env";
+import { RedirectUri } from "./redirect-uri";
 
 interface AppConfigFormProps {
   provider: string;
@@ -339,35 +338,5 @@ export const AppConfigForm = ({
         </AlertDialogContent>
       </AlertDialog>
     </Accordion>
-  );
-};
-
-const RedirectUri = ({ provider }: { provider: string }) => {
-  const redirectUri = `${API_ORIGIN || APP_URL}/v1/apps/${provider}/callback`;
-  const { copied, copy } = useCopyToClipboard();
-
-  return (
-    <div className="grid gap-1.5">
-      <Label>Redirect URI</Label>
-      <p className="text-xs text-muted-foreground">
-        Add this URL to your OAuth app&apos;s allowed redirect URIs.
-      </p>
-      <div className="flex items-center gap-3">
-        <div className="flex-1 rounded-md border bg-muted/50 px-3 py-2 font-mono text-sm text-foreground truncate">
-          {redirectUri}
-        </div>
-        <button
-          type="button"
-          onClick={() => copy(redirectUri)}
-          className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-        >
-          {copied ? (
-            <Check className="size-4 text-brand" />
-          ) : (
-            <Copy className="size-4" />
-          )}
-        </button>
-      </div>
-    </div>
   );
 };

--- a/apps/web/src/app/(dashboard)/connections/_components/configure-credentials-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/configure-credentials-dialog.tsx
@@ -16,6 +16,7 @@ import { saveAppConfig, setAppConfigEnabled } from "@/lib/actions/app-config";
 import type { OAuthConfigField } from "@onecli/api/apps/types";
 import { IS_CLOUD } from "@/lib/env";
 import { AppIcon } from "./app-icon";
+import { RedirectUri } from "./redirect-uri";
 
 interface ConfigureCredentialsDialogProps {
   provider: string;
@@ -79,6 +80,7 @@ export const ConfigureCredentialsDialog = ({
 
         <div className="space-y-4 pt-2">
           {hint && <p className="text-muted-foreground text-xs">{hint}</p>}
+          <RedirectUri provider={provider} />
           {fields.map((field, i) => (
             <div key={field.name} className="grid gap-1.5">
               <Label htmlFor={`config-${field.name}`}>

--- a/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { API_ORIGIN } from "@/lib/api-fetch";
+import { APP_URL } from "@/lib/env";
+
+export const RedirectUri = ({ provider }: { provider: string }) => {
+  const redirectUri = `${API_ORIGIN || APP_URL}/v1/apps/${provider}/callback`;
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <div className="grid gap-1.5">
+      <p className="text-xs font-medium text-muted-foreground">Redirect URI</p>
+      <div className="flex min-w-0 items-center gap-2 overflow-hidden rounded-md bg-muted/50 px-3 py-2">
+        <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground select-all">
+          {redirectUri}
+        </code>
+        <button
+          type="button"
+          onClick={() => copy(redirectUri)}
+          className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {copied ? (
+            <Check className="text-brand size-3.5" />
+          ) : (
+            <Copy className="size-3.5" />
+          )}
+        </button>
+      </div>
+      <p className="text-[11px] text-muted-foreground/70">
+        Add this to your OAuth app&apos;s allowed redirect URIs.
+      </p>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Shows the OAuth redirect URI in the credentials setup dialog so users know exactly what callback URL to register with their OAuth provider before entering credentials.

- Extract `RedirectUri` into a shared component (`redirect-uri.tsx`)
- Add it to `ConfigureCredentialsDialog` (first-time setup modal) — shown before credential fields
- Reuse in `AppConfigForm` (app detail page) — replaces inline implementation

## Test plan

- [ ] Open unconfigured OAuth app → click Connect → dialog shows redirect URI with copy button
- [ ] App detail page → credentials accordion → redirect URI still shows
- [ ] Copy button works (check icon feedback)
- [ ] URI matches server-side redirect URI format