### PR TITLE
fix: use runtime env vars for self-hosted deployments

### DIFF
--- a/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
@@ -1,19 +1,47 @@
 "use client";
 
 import { Check, Copy } from "lucide-react";
+import Link from "next/link";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { API_ORIGIN } from "@/lib/api-fetch";
-import { APP_URL } from "@/lib/env";
+import { APP_URL, IS_CLOUD } from "@/lib/env";
+
+const useBaseUrl = () => {
+  if (IS_CLOUD) return API_ORIGIN || APP_URL;
+  return typeof window !== "undefined" ? window.location.origin : APP_URL;
+};
 
 export const RedirectUri = ({ provider }: { provider: string }) => {
-  const redirectUri = `${API_ORIGIN || APP_URL}/v1/apps/${provider}/callback`;
+  const redirectUri = `${useBaseUrl()}/v1/apps/${provider}/callback`;
   const { copied, copy } = useCopyToClipboard();
 
   return (
     <div className="grid gap-1.5">
-      <p className="text-xs font-medium text-muted-foreground">Redirect URI</p>
-      <div className="flex min-w-0 items-center gap-2 overflow-hidden rounded-md bg-muted/50 px-3 py-2">
-        <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground select-all">
+      <div className="flex items-baseline gap-2">
+        <p
+          className={
+            IS_CLOUD
+              ? "text-xs font-medium text-muted-foreground"
+              : "text-sm font-medium"
+          }
+        >
+          Redirect URI
+        </p>
+        {!IS_CLOUD && (
+          <Link
+            href="/settings/instance"
+            className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+          >
+            Configure base URL
+          </Link>
+        )}
+      </div>
+      <div
+        className={`flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-3 py-2 ${IS_CLOUD ? "bg-muted/50" : "border"}`}
+      >
+        <code
+          className={`min-w-0 flex-1 truncate font-mono text-xs select-all ${IS_CLOUD ? "text-muted-foreground" : "text-foreground"}`}
+        >
           {redirectUri}
         </code>
         <button
@@ -28,7 +56,13 @@ export const RedirectUri = ({ provider }: { provider: string }) => {
           )}
         </button>
       </div>
-      <p className="text-[11px] text-muted-foreground/70">
+      <p
+        className={
+          IS_CLOUD
+            ? "text-[11px] text-muted-foreground/70"
+            : "text-xs text-muted-foreground"
+        }
+      >
         Add this to your OAuth app&apos;s allowed redirect URIs.
       </p>
     </div>

--- a/apps/web/src/app/(dashboard)/settings/instance/_components/public-url-card.tsx
+++ b/apps/web/src/app/(dashboard)/settings/instance/_components/public-url-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Check, Copy, ExternalLink } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@onecli/ui/components/card";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+
+export const PublicUrlCard = ({ appUrl }: { appUrl: string }) => {
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Public URL</CardTitle>
+        <CardDescription>
+          The base URL used for OAuth redirect callbacks. Set this to your
+          public IP or tunnel URL if you&apos;re running behind a reverse proxy
+          or tunnel.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center rounded-md border px-3 py-2">
+            <code className="min-w-0 flex-1 truncate font-mono text-sm">
+              {appUrl}
+            </code>
+          </div>
+          <button
+            type="button"
+            onClick={() => copy(appUrl)}
+            className="text-muted-foreground hover:text-foreground shrink-0 rounded-md border p-2 transition-colors"
+          >
+            {copied ? (
+              <Check className="text-brand size-4" />
+            ) : (
+              <Copy className="size-4" />
+            )}
+          </button>
+        </div>
+        <p className="text-muted-foreground text-xs">
+          Configure via the{" "}
+          <code className="bg-muted rounded px-1 py-0.5 text-[11px]">
+            APP_URL
+          </code>{" "}
+          environment variable.{" "}
+          <a
+            href="https://onecli.sh/docs/quickstart"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground inline-flex items-center gap-1 underline underline-offset-2 transition-colors hover:opacity-70"
+          >
+            Learn more
+            <ExternalLink className="size-3" />
+          </a>
+        </p>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/app/(dashboard)/settings/instance/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/instance/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { PageHeader } from "@dashboard/page-header";
+import { APP_URL } from "@/lib/env";
+import { PublicUrlCard } from "./_components/public-url-card";
+
+export const metadata: Metadata = {
+  title: "Instance",
+};
+
+export default function InstancePage() {
+  return (
+    <div className="flex flex-1 flex-col gap-4">
+      <PageHeader
+        title="Instance"
+        description="Instance configuration for your self-hosted deployment."
+      />
+      <PublicUrlCard appUrl={APP_URL} />
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "@onecli/ui/globals.css";
 import "./globals.css";
 import { AuthProvider } from "@/providers/auth-provider";
 import { getAuthMode } from "@/lib/auth/auth-mode";
+import { GATEWAY_API_URL, IS_CLOUD } from "@/lib/env";
 import { QueryProvider } from "@/providers/query-provider";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { Toaster } from "@onecli/ui/components/sonner";
@@ -54,6 +55,15 @@ export default function RootLayout({
 
   return (
     <html lang="en" suppressHydrationWarning className="bg-background">
+      {!IS_CLOUD && (
+        <head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.__GATEWAY_API_URL__=${JSON.stringify(GATEWAY_API_URL)}`,
+            }}
+          />
+        </head>
+      )}
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${sourceSerif.variable}`}
         suppressHydrationWarning

--- a/apps/web/src/hooks/use-vault-status.ts
+++ b/apps/web/src/hooks/use-vault-status.ts
@@ -2,8 +2,18 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
-import { GATEWAY_API_URL } from "@/lib/env";
+import { GATEWAY_API_URL, IS_CLOUD } from "@/lib/env";
 import { getGatewayFetchOptions } from "@/lib/gateway-auth";
+
+const getGatewayApiUrl = (): string => {
+  if (IS_CLOUD) return GATEWAY_API_URL;
+  return (
+    (typeof window !== "undefined" &&
+      ((window as unknown as Record<string, unknown>)
+        .__GATEWAY_API_URL__ as string)) ||
+    GATEWAY_API_URL
+  );
+};
 
 export interface VaultStatus<T = unknown> {
   connected: boolean;
@@ -24,7 +34,7 @@ export const useVaultStatus = <T = unknown>(provider: string = "bitwarden") => {
     try {
       const { headers, credentials } = await getGatewayFetchOptions();
       const resp = await fetch(
-        `${GATEWAY_API_URL}/v1/vault/${provider}/status`,
+        `${getGatewayApiUrl()}/v1/vault/${provider}/status`,
         {
           headers,
           credentials,
@@ -67,7 +77,7 @@ export const useVaultPair = (
       try {
         const { headers, credentials } = await getGatewayFetchOptions();
         const resp = await fetch(
-          `${GATEWAY_API_URL}/v1/vault/${provider}/pair`,
+          `${getGatewayApiUrl()}/v1/vault/${provider}/pair`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json", ...headers },
@@ -111,11 +121,14 @@ export const useVaultDisconnect = (
     setDisconnecting(true);
     try {
       const { headers, credentials } = await getGatewayFetchOptions();
-      const resp = await fetch(`${GATEWAY_API_URL}/v1/vault/${provider}/pair`, {
-        method: "DELETE",
-        headers,
-        credentials,
-      });
+      const resp = await fetch(
+        `${getGatewayApiUrl()}/v1/vault/${provider}/pair`,
+        {
+          method: "DELETE",
+          headers,
+          credentials,
+        },
+      );
       if (resp.ok) {
         toast.success("Vault disconnected");
         await fetchStatus();

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -13,7 +13,9 @@
 
 /** Web app base URL (e.g., `https://app.onecli.sh` or `http://localhost:10254`). */
 export const APP_URL =
-  process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:10254";
+  process.env.APP_URL ??
+  process.env.NEXT_PUBLIC_APP_URL ??
+  "http://localhost:10254";
 
 /** API server URL used by browser-side code for general API calls. */
 export const API_URL =
@@ -21,7 +23,9 @@ export const API_URL =
 
 /** Gateway HTTP API URL for vault, cache, and approval calls. */
 export const GATEWAY_API_URL =
-  process.env.NEXT_PUBLIC_GATEWAY_API_URL ?? "http://localhost:10255";
+  process.env.GATEWAY_API_URL ??
+  process.env.NEXT_PUBLIC_GATEWAY_API_URL ??
+  "http://localhost:10255";
 
 /**
  * Gateway CONNECT proxy address used by server-side code when the web app
@@ -53,12 +57,17 @@ export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET ?? "";
 // ── Cloud: Cognito ──────────────────────────────────────────────────────
 
 export const COGNITO_CLIENT_ID =
-  process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
+  process.env.COGNITO_CLIENT_ID ??
+  process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ??
+  "";
 
-export const COGNITO_DOMAIN = process.env.NEXT_PUBLIC_COGNITO_DOMAIN ?? "";
+export const COGNITO_DOMAIN =
+  process.env.COGNITO_DOMAIN ?? process.env.NEXT_PUBLIC_COGNITO_DOMAIN ?? "";
 
 export const COGNITO_USER_POOL_ID =
-  process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
+  process.env.COGNITO_USER_POOL_ID ??
+  process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ??
+  "";
 
 // ── Cloud: Stripe ───────────────────────────────────────────────────────
 

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -8,6 +8,7 @@ import {
   User,
   KeyRound,
   ShieldCheck,
+  Globe,
 } from "lucide-react";
 import type { NavItem } from "@/app/(dashboard)/_components/nav-main";
 
@@ -32,6 +33,10 @@ export const navItems: NavItem[] = [
 ];
 
 export const settingsSections: SettingsNavSection[] = [
+  {
+    label: "General",
+    items: [{ title: "Instance", url: "/settings/instance", icon: Globe }],
+  },
   {
     label: "Account",
     items: [

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,8 +34,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-onecli}:${POSTGRES_PASSWORD:-onecli}@postgres:5432/${POSTGRES_DB:-onecli}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-}
-      NEXT_PUBLIC_APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}
       APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}
+      GATEWAY_API_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_GATEWAY_PORT:-10255}
     volumes:
       - app-data:/app/data
     env_file:

--- a/packages/api/src/apps/cloud-app-registry.ts
+++ b/packages/api/src/apps/cloud-app-registry.ts
@@ -81,4 +81,12 @@ export const cloudApps: AppDefinition[] = [
     connectionMethod: { type: "cloud_only" },
     available: false,
   },
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    icon: "/icons/hubspot.svg",
+    description: "CRM contacts, companies, deals, and tickets.",
+    connectionMethod: { type: "cloud_only" },
+    available: false,
+  },
 ];


### PR DESCRIPTION
## Summary

- Add runtime fallback chains in `env.ts` for `APP_URL`, `COGNITO_*`, and `GATEWAY_API_URL` so self-hosted deployments can override build-time defaults
- Inject `GATEWAY_API_URL` at runtime via `<script>` tag (self-hosted only) so vault calls reach the correct gateway host
- Add `/settings/instance` page showing the Public URL with copy button and docs link
- Restyle redirect URI component with a "Configure base URL" link for self-hosted users
- Use `window.location.origin` for OAuth redirect URI base in self-hosted (instead of baked build-time value)
- Remove redundant `NEXT_PUBLIC_APP_URL` from `docker-compose.yml` (already covered by `APP_URL`)
- Set `GATEWAY_API_URL` in `docker-compose.yml` derived from bind host and gateway port
- Add HubSpot to cloud app registry