### PR TITLE
fix: runtime env vars, credential response, and secret dialog

### DIFF
--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -198,33 +198,23 @@ pub(crate) fn credential_not_found<S>(
 ) -> Response<ForwardBody<S>> {
     let base = dashboard_url();
     let encoded_host = utf8_percent_encode(hostname, NON_ALPHANUMERIC);
-    let encoded_path = utf8_percent_encode(path, NON_ALPHANUMERIC);
     let secret_url =
-        format!("{base}/connections/custom?create=generic&host={encoded_host}&path={encoded_path}");
+        format!("{base}/connections/custom?create=generic&host={encoded_host}&path=%2F%2A");
     with_no_retry(json_error(
         status,
         serde_json::json!({
             "error": "credential_not_found",
             "message": format!(
-                "No credentials configured for {hostname} in OneCLI.\n\n\
-                 A pre-built link is provided in the `secret_url` field, pre-filled with:\n\
-                 - host: {hostname}\n\
-                 - path: {path}\n\n\
-                 Before sending this link to the user, consider whether to adjust it. \
-                 You can build a custom URL with any of these query parameters:\n\
-                 {base}/connections/custom?create=generic&host=<host>&path=<path>&name=<name>&header=<header>&format=<format>\n\n\
-                 Available parameters:\n\
-                 - `host` (required): hostname to match (e.g., api.example.com or *.example.com)\n\
-                 - `path`: path pattern (e.g., /v1/* or /*). Defaults to the exact request path.\n\
-                 - `name`: display name for the secret (e.g., 'Example API Key')\n\
-                 - `header`: HTTP header name to inject (default: Authorization)\n\
-                 - `format`: value format with {{value}} placeholder (default: Bearer {{value}})\n\n\
-                 Examples of when to customize:\n\
-                 - Change path to `/*` if the credential covers all endpoints on the host\n\
-                 - Change header to `X-API-Key` if the API uses a custom header\n\
-                 - Change format to `{{value}}` (raw) if the API expects the token without a prefix\n\n\
-                 Once you've decided on the right link, ask the user to open it. \
-                 They will see a pre-filled form where they paste their API key or token."
+                "No credentials configured for {hostname} in OneCLI.\n\
+                 A pre-built link is provided in the `secret_url` field. \
+                 Before sending this link to the user, append a display name: \
+                 &name=<name> (e.g., &name=Stripe%20API%20Key).\n\
+                 Then ask the user to open the link to add their API key.\n\n\
+                 If you know this API's auth method, you can also customize:\n\
+                 - Custom header: append &header=<name> (default: Authorization)\n\
+                 - Custom format: append &format=<format> using {{value}} as placeholder \
+                 (default: Bearer {{value}}, use just {{value}} for raw token)\n\
+                 - Query param auth instead of header: append &param=<name> (e.g., &param=api_key)"
             ),
             "hostname": hostname,
             "path": path,
@@ -602,10 +592,12 @@ mod tests {
         assert_eq!(json["error"], "credential_not_found");
         assert_eq!(json["hostname"], "api.custom-service.com");
         assert_eq!(json["path"], "/v1/send");
-        assert!(json["secret_url"]
-            .as_str()
-            .unwrap()
-            .contains("create=generic"));
+        let secret_url = json["secret_url"].as_str().unwrap();
+        assert!(secret_url.contains("create=generic"));
+        assert!(
+            secret_url.contains("path=%2F%2A"),
+            "secret_url should use wildcard path, got: {secret_url}"
+        );
         assert!(json["message"]
             .as_str()
             .unwrap()
@@ -613,7 +605,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn credential_not_found_encodes_special_characters() {
+    async fn credential_not_found_uses_wildcard_path_and_preserves_request_path() {
         let resp: Response<TestBody> = credential_not_found(
             StatusCode::FORBIDDEN,
             "api.example.com",
@@ -626,15 +618,14 @@ mod tests {
         };
         let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
         let secret_url = json["secret_url"].as_str().unwrap();
-        // The & and = in the path should be encoded so they don't break the query string
-        assert!(
-            !secret_url.contains("&subject="),
-            "path params must be encoded"
-        );
         assert!(secret_url.contains("create=generic"));
         assert!(
-            !secret_url.contains("method="),
-            "method should not be in URL"
+            secret_url.contains("path=%2F%2A"),
+            "secret_url should always use wildcard path, got: {secret_url}"
+        );
+        assert_eq!(
+            json["path"], "/v1/send?to=user@test.com&subject=hello",
+            "original request path should be preserved in request_path field"
         );
     }
 

--- a/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
@@ -1,19 +1,47 @@
 "use client";
 
 import { Check, Copy } from "lucide-react";
+import Link from "next/link";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { API_ORIGIN } from "@/lib/api-fetch";
-import { APP_URL } from "@/lib/env";
+import { APP_URL, IS_CLOUD } from "@/lib/env";
+
+const useBaseUrl = () => {
+  if (IS_CLOUD) return API_ORIGIN || APP_URL;
+  return typeof window !== "undefined" ? window.location.origin : APP_URL;
+};
 
 export const RedirectUri = ({ provider }: { provider: string }) => {
-  const redirectUri = `${API_ORIGIN || APP_URL}/v1/apps/${provider}/callback`;
+  const redirectUri = `${useBaseUrl()}/v1/apps/${provider}/callback`;
   const { copied, copy } = useCopyToClipboard();
 
   return (
     <div className="grid gap-1.5">
-      <p className="text-xs font-medium text-muted-foreground">Redirect URI</p>
-      <div className="flex min-w-0 items-center gap-2 overflow-hidden rounded-md bg-muted/50 px-3 py-2">
-        <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground select-all">
+      <div className="flex items-baseline gap-2">
+        <p
+          className={
+            IS_CLOUD
+              ? "text-xs font-medium text-muted-foreground"
+              : "text-sm font-medium"
+          }
+        >
+          Redirect URI
+        </p>
+        {!IS_CLOUD && (
+          <Link
+            href="/settings/instance"
+            className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+          >
+            Configure base URL
+          </Link>
+        )}
+      </div>
+      <div
+        className={`flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-3 py-2 ${IS_CLOUD ? "bg-muted/50" : "border"}`}
+      >
+        <code
+          className={`min-w-0 flex-1 truncate font-mono text-xs select-all ${IS_CLOUD ? "text-muted-foreground" : "text-foreground"}`}
+        >
           {redirectUri}
         </code>
         <button
@@ -28,7 +56,13 @@ export const RedirectUri = ({ provider }: { provider: string }) => {
           )}
         </button>
       </div>
-      <p className="text-[11px] text-muted-foreground/70">
+      <p
+        className={
+          IS_CLOUD
+            ? "text-[11px] text-muted-foreground/70"
+            : "text-xs text-muted-foreground"
+        }
+      >
         Add this to your OAuth app&apos;s allowed redirect URIs.
       </p>
     </div>

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -168,6 +168,7 @@ export const SecretDialog = ({
   const [valueFormat, setValueFormat] = useState("Bearer {value}");
   const [paramName, setParamName] = useState("");
   const [paramFormat, setParamFormat] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState("");
 
   const nameError = useMemo(() => validateDisplayName(name), [name]);
   const showNameError = nameTouched && nameError !== null;
@@ -189,6 +190,7 @@ export const SecretDialog = ({
   useEffect(() => {
     if (open) {
       setNameTouched(false);
+      setAdvancedOpen("");
       if (secret) {
         const config = secret.injectionConfig as InjectionConfig | null;
         setStep("form");
@@ -388,6 +390,7 @@ export const SecretDialog = ({
                       setInjectionTarget("header");
                       setHeaderName("Authorization");
                       setValueFormat("Bearer {value}");
+                      setAdvancedOpen("advanced");
                     }}
                   >
                     Header injection
@@ -402,6 +405,7 @@ export const SecretDialog = ({
                       setInjectionTarget("param");
                       setParamName("key");
                       setParamFormat("{value}");
+                      setAdvancedOpen("advanced");
                     }}
                   >
                     URL parameter
@@ -538,116 +542,13 @@ export const SecretDialog = ({
                 </div>
               )}
 
-              {type === "generic" && (
-                <div className="flex items-center gap-3">
-                  <Label
-                    id="inject-as-label"
-                    className="text-muted-foreground shrink-0 text-xs"
-                  >
-                    Inject as
-                  </Label>
-                  <div
-                    className="border-input inline-flex overflow-hidden rounded-md border"
-                    role="radiogroup"
-                    aria-labelledby="inject-as-label"
-                    onKeyDown={(e) => {
-                      if (
-                        ![
-                          "ArrowRight",
-                          "ArrowDown",
-                          "ArrowLeft",
-                          "ArrowUp",
-                        ].includes(e.key)
-                      )
-                        return;
-                      e.preventDefault();
-                      const next =
-                        injectionTarget === "header" ? "param" : "header";
-                      setInjectionTarget(next);
-                      e.currentTarget
-                        .querySelectorAll<HTMLButtonElement>('[role="radio"]')
-                        [next === "header" ? 0 : 1]?.focus();
-                    }}
-                  >
-                    <button
-                      type="button"
-                      role="radio"
-                      aria-checked={injectionTarget === "header"}
-                      tabIndex={injectionTarget === "header" ? 0 : -1}
-                      className={cn(
-                        "border-input px-3 py-1.5 text-xs font-medium transition-colors",
-                        injectionTarget === "header"
-                          ? "bg-accent text-foreground"
-                          : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                      )}
-                      onClick={() => setInjectionTarget("header")}
-                    >
-                      Header
-                    </button>
-                    <button
-                      type="button"
-                      role="radio"
-                      aria-checked={injectionTarget === "param"}
-                      tabIndex={injectionTarget === "param" ? 0 : -1}
-                      className={cn(
-                        "border-input border-l px-3 py-1.5 text-xs font-medium transition-colors",
-                        injectionTarget === "param"
-                          ? "bg-accent text-foreground"
-                          : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                      )}
-                      onClick={() => setInjectionTarget("param")}
-                    >
-                      URL Parameter
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              {type === "generic" && (
-                <div
-                  key={`name-${injectionTarget}`}
-                  className="animate-in fade-in duration-150 space-y-2"
-                >
-                  <Label
-                    htmlFor={
-                      injectionTarget === "header"
-                        ? "secret-header"
-                        : "secret-param"
-                    }
-                  >
-                    {injectionTarget === "header"
-                      ? "Header name"
-                      : "Parameter name"}
-                  </Label>
-                  <Input
-                    id={
-                      injectionTarget === "header"
-                        ? "secret-header"
-                        : "secret-param"
-                    }
-                    placeholder={
-                      injectionTarget === "header"
-                        ? "e.g. Authorization"
-                        : "e.g. api_key"
-                    }
-                    value={
-                      injectionTarget === "header" ? headerName : paramName
-                    }
-                    onChange={(e) =>
-                      injectionTarget === "header"
-                        ? setHeaderName(e.target.value)
-                        : setParamName(e.target.value)
-                    }
-                  />
-                </div>
-              )}
-
               {isPlatformEdit ? null : (
                 <Accordion
                   type="single"
                   collapsible
                   className="border-none"
-                  defaultValue={undefined}
+                  value={advancedOpen}
+                  onValueChange={setAdvancedOpen}
                 >
                   <AccordionItem
                     value="advanced"
@@ -669,7 +570,6 @@ export const SecretDialog = ({
                               placeholder="e.g. api.example.com or *.example.com"
                               value={hostPattern}
                               onChange={(e) => setHostPattern(e.target.value)}
-                              disabled={!!prefill}
                             />
                             {hostPatternError ? (
                               <p className="text-xs text-red-500">
@@ -682,6 +582,116 @@ export const SecretDialog = ({
                                 for wildcard subdomains.
                               </p>
                             )}
+                          </div>
+                        )}
+
+                        {type === "generic" && (
+                          <div className="flex items-center gap-3">
+                            <Label
+                              id="inject-as-label"
+                              className="text-muted-foreground shrink-0 text-xs"
+                            >
+                              Inject as
+                            </Label>
+                            <div
+                              className="border-input inline-flex overflow-hidden rounded-md border"
+                              role="radiogroup"
+                              aria-labelledby="inject-as-label"
+                              onKeyDown={(e) => {
+                                if (
+                                  ![
+                                    "ArrowRight",
+                                    "ArrowDown",
+                                    "ArrowLeft",
+                                    "ArrowUp",
+                                  ].includes(e.key)
+                                )
+                                  return;
+                                e.preventDefault();
+                                const next =
+                                  injectionTarget === "header"
+                                    ? "param"
+                                    : "header";
+                                setInjectionTarget(next);
+                                e.currentTarget
+                                  .querySelectorAll<HTMLButtonElement>(
+                                    '[role="radio"]',
+                                  )
+                                  [next === "header" ? 0 : 1]?.focus();
+                              }}
+                            >
+                              <button
+                                type="button"
+                                role="radio"
+                                aria-checked={injectionTarget === "header"}
+                                tabIndex={injectionTarget === "header" ? 0 : -1}
+                                className={cn(
+                                  "border-input px-3 py-1.5 text-xs font-medium transition-colors",
+                                  injectionTarget === "header"
+                                    ? "bg-accent text-foreground"
+                                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                                )}
+                                onClick={() => setInjectionTarget("header")}
+                              >
+                                Header
+                              </button>
+                              <button
+                                type="button"
+                                role="radio"
+                                aria-checked={injectionTarget === "param"}
+                                tabIndex={injectionTarget === "param" ? 0 : -1}
+                                className={cn(
+                                  "border-input border-l px-3 py-1.5 text-xs font-medium transition-colors",
+                                  injectionTarget === "param"
+                                    ? "bg-accent text-foreground"
+                                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                                )}
+                                onClick={() => setInjectionTarget("param")}
+                              >
+                                URL Parameter
+                              </button>
+                            </div>
+                          </div>
+                        )}
+
+                        {type === "generic" && (
+                          <div
+                            key={`name-${injectionTarget}`}
+                            className="animate-in fade-in duration-150 space-y-2"
+                          >
+                            <Label
+                              htmlFor={
+                                injectionTarget === "header"
+                                  ? "secret-header"
+                                  : "secret-param"
+                              }
+                            >
+                              {injectionTarget === "header"
+                                ? "Header name"
+                                : "Parameter name"}
+                            </Label>
+                            <Input
+                              id={
+                                injectionTarget === "header"
+                                  ? "secret-header"
+                                  : "secret-param"
+                              }
+                              placeholder={
+                                injectionTarget === "header"
+                                  ? "e.g. Authorization"
+                                  : "e.g. api_key"
+                              }
+                              value={
+                                injectionTarget === "header"
+                                  ? headerName
+                                  : paramName
+                              }
+                              onChange={(e) =>
+                                injectionTarget === "header"
+                                  ? setHeaderName(e.target.value)
+                                  : setParamName(e.target.value)
+                              }
+                            />
                           </div>
                         )}
 

--- a/apps/web/src/app/(dashboard)/settings/instance/_components/public-url-card.tsx
+++ b/apps/web/src/app/(dashboard)/settings/instance/_components/public-url-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Check, Copy, ExternalLink } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@onecli/ui/components/card";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+
+export const PublicUrlCard = ({ appUrl }: { appUrl: string }) => {
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Public URL</CardTitle>
+        <CardDescription>
+          The base URL used for OAuth redirect callbacks. Set this to your
+          public IP or tunnel URL if you&apos;re running behind a reverse proxy
+          or tunnel.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center rounded-md border px-3 py-2">
+            <code className="min-w-0 flex-1 truncate font-mono text-sm">
+              {appUrl}
+            </code>
+          </div>
+          <button
+            type="button"
+            onClick={() => copy(appUrl)}
+            className="text-muted-foreground hover:text-foreground shrink-0 rounded-md border p-2 transition-colors"
+          >
+            {copied ? (
+              <Check className="text-brand size-4" />
+            ) : (
+              <Copy className="size-4" />
+            )}
+          </button>
+        </div>
+        <p className="text-muted-foreground text-xs">
+          Configure via the{" "}
+          <code className="bg-muted rounded px-1 py-0.5 text-[11px]">
+            APP_URL
+          </code>{" "}
+          environment variable.{" "}
+          <a
+            href="https://onecli.sh/docs/quickstart"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground inline-flex items-center gap-1 underline underline-offset-2 transition-colors hover:opacity-70"
+          >
+            Learn more
+            <ExternalLink className="size-3" />
+          </a>
+        </p>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/app/(dashboard)/settings/instance/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/instance/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { PageHeader } from "@dashboard/page-header";
+import { APP_URL } from "@/lib/env";
+import { PublicUrlCard } from "./_components/public-url-card";
+
+export const metadata: Metadata = {
+  title: "Instance",
+};
+
+export default function InstancePage() {
+  return (
+    <div className="flex flex-1 flex-col gap-4">
+      <PageHeader
+        title="Instance"
+        description="Instance configuration for your self-hosted deployment."
+      />
+      <PublicUrlCard appUrl={APP_URL} />
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "@onecli/ui/globals.css";
 import "./globals.css";
 import { AuthProvider } from "@/providers/auth-provider";
 import { getAuthMode } from "@/lib/auth/auth-mode";
+import { GATEWAY_API_URL, IS_CLOUD } from "@/lib/env";
 import { QueryProvider } from "@/providers/query-provider";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { Toaster } from "@onecli/ui/components/sonner";
@@ -54,6 +55,15 @@ export default function RootLayout({
 
   return (
     <html lang="en" suppressHydrationWarning className="bg-background">
+      {!IS_CLOUD && (
+        <head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.__GATEWAY_API_URL__=${JSON.stringify(GATEWAY_API_URL)}`,
+            }}
+          />
+        </head>
+      )}
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${sourceSerif.variable}`}
         suppressHydrationWarning

--- a/apps/web/src/hooks/use-vault-status.ts
+++ b/apps/web/src/hooks/use-vault-status.ts
@@ -2,8 +2,18 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
-import { GATEWAY_API_URL } from "@/lib/env";
+import { GATEWAY_API_URL, IS_CLOUD } from "@/lib/env";
 import { getGatewayFetchOptions } from "@/lib/gateway-auth";
+
+const getGatewayApiUrl = (): string => {
+  if (IS_CLOUD) return GATEWAY_API_URL;
+  return (
+    (typeof window !== "undefined" &&
+      ((window as unknown as Record<string, unknown>)
+        .__GATEWAY_API_URL__ as string)) ||
+    GATEWAY_API_URL
+  );
+};
 
 export interface VaultStatus<T = unknown> {
   connected: boolean;
@@ -24,7 +34,7 @@ export const useVaultStatus = <T = unknown>(provider: string = "bitwarden") => {
     try {
       const { headers, credentials } = await getGatewayFetchOptions();
       const resp = await fetch(
-        `${GATEWAY_API_URL}/v1/vault/${provider}/status`,
+        `${getGatewayApiUrl()}/v1/vault/${provider}/status`,
         {
           headers,
           credentials,
@@ -67,7 +77,7 @@ export const useVaultPair = (
       try {
         const { headers, credentials } = await getGatewayFetchOptions();
         const resp = await fetch(
-          `${GATEWAY_API_URL}/v1/vault/${provider}/pair`,
+          `${getGatewayApiUrl()}/v1/vault/${provider}/pair`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json", ...headers },
@@ -111,11 +121,14 @@ export const useVaultDisconnect = (
     setDisconnecting(true);
     try {
       const { headers, credentials } = await getGatewayFetchOptions();
-      const resp = await fetch(`${GATEWAY_API_URL}/v1/vault/${provider}/pair`, {
-        method: "DELETE",
-        headers,
-        credentials,
-      });
+      const resp = await fetch(
+        `${getGatewayApiUrl()}/v1/vault/${provider}/pair`,
+        {
+          method: "DELETE",
+          headers,
+          credentials,
+        },
+      );
       if (resp.ok) {
         toast.success("Vault disconnected");
         await fetchStatus();

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -13,7 +13,9 @@
 
 /** Web app base URL (e.g., `https://app.onecli.sh` or `http://localhost:10254`). */
 export const APP_URL =
-  process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:10254";
+  process.env.APP_URL ??
+  process.env.NEXT_PUBLIC_APP_URL ??
+  "http://localhost:10254";
 
 /** API server URL used by browser-side code for general API calls. */
 export const API_URL =
@@ -21,7 +23,9 @@ export const API_URL =
 
 /** Gateway HTTP API URL for vault, cache, and approval calls. */
 export const GATEWAY_API_URL =
-  process.env.NEXT_PUBLIC_GATEWAY_API_URL ?? "http://localhost:10255";
+  process.env.GATEWAY_API_URL ??
+  process.env.NEXT_PUBLIC_GATEWAY_API_URL ??
+  "http://localhost:10255";
 
 /**
  * Gateway CONNECT proxy address used by server-side code when the web app
@@ -53,12 +57,17 @@ export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET ?? "";
 // ── Cloud: Cognito ──────────────────────────────────────────────────────
 
 export const COGNITO_CLIENT_ID =
-  process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? "";
+  process.env.COGNITO_CLIENT_ID ??
+  process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ??
+  "";
 
-export const COGNITO_DOMAIN = process.env.NEXT_PUBLIC_COGNITO_DOMAIN ?? "";
+export const COGNITO_DOMAIN =
+  process.env.COGNITO_DOMAIN ?? process.env.NEXT_PUBLIC_COGNITO_DOMAIN ?? "";
 
 export const COGNITO_USER_POOL_ID =
-  process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? "";
+  process.env.COGNITO_USER_POOL_ID ??
+  process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ??
+  "";
 
 // ── Cloud: Stripe ───────────────────────────────────────────────────────
 

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -8,6 +8,7 @@ import {
   User,
   KeyRound,
   ShieldCheck,
+  Globe,
 } from "lucide-react";
 import type { NavItem } from "@/app/(dashboard)/_components/nav-main";
 
@@ -32,6 +33,10 @@ export const navItems: NavItem[] = [
 ];
 
 export const settingsSections: SettingsNavSection[] = [
+  {
+    label: "General",
+    items: [{ title: "Instance", url: "/settings/instance", icon: Globe }],
+  },
   {
     label: "Account",
     items: [

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,8 +34,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-onecli}:${POSTGRES_PASSWORD:-onecli}@postgres:5432/${POSTGRES_DB:-onecli}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-}
-      NEXT_PUBLIC_APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}
       APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}
+      GATEWAY_API_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_GATEWAY_PORT:-10255}
     volumes:
       - app-data:/app/data
     env_file:

--- a/packages/api/src/apps/app-permissions/linkedin.ts
+++ b/packages/api/src/apps/app-permissions/linkedin.ts
@@ -12,6 +12,7 @@ export const linkedinPermissions: AppPermissionDefinition = {
           description: "Get the authenticated user's profile information",
           hostPattern: "api.linkedin.com",
           pathPattern: "/v2/userinfo",
+          aliasPatterns: ["/v2/me"],
           method: "GET",
         },
         {
@@ -20,6 +21,7 @@ export const linkedinPermissions: AppPermissionDefinition = {
           description: "List posts by the authenticated user",
           hostPattern: "api.linkedin.com",
           pathPattern: "/rest/posts*",
+          aliasPatterns: ["/v2/ugcPosts*", "/v2/shares*"],
           method: "GET",
         },
       ],
@@ -33,6 +35,7 @@ export const linkedinPermissions: AppPermissionDefinition = {
           description: "Create a new post on LinkedIn",
           hostPattern: "api.linkedin.com",
           pathPattern: "/rest/posts",
+          aliasPatterns: ["/v2/ugcPosts", "/v2/shares"],
           method: "POST",
         },
         {
@@ -41,6 +44,7 @@ export const linkedinPermissions: AppPermissionDefinition = {
           description: "Delete an existing post",
           hostPattern: "api.linkedin.com",
           pathPattern: "/rest/posts/*",
+          aliasPatterns: ["/v2/ugcPosts/*", "/v2/shares/*"],
           method: "DELETE",
         },
         {
@@ -49,7 +53,17 @@ export const linkedinPermissions: AppPermissionDefinition = {
           description: "Comment on a post",
           hostPattern: "api.linkedin.com",
           pathPattern: "/rest/socialActions/*/comments",
+          aliasPatterns: ["/v2/socialActions/*/comments"],
           method: "POST",
+        },
+        {
+          id: "delete_comment",
+          name: "Delete comment",
+          description: "Delete a comment from a post",
+          hostPattern: "api.linkedin.com",
+          pathPattern: "/rest/socialActions/*/comments/*",
+          aliasPatterns: ["/v2/socialActions/*/comments/*"],
+          method: "DELETE",
         },
         {
           id: "create_reaction",
@@ -57,7 +71,23 @@ export const linkedinPermissions: AppPermissionDefinition = {
           description: "Add a reaction to a post",
           hostPattern: "api.linkedin.com",
           pathPattern: "/rest/reactions*",
+          aliasPatterns: [
+            "/rest/socialActions/*/likes",
+            "/v2/socialActions/*/likes",
+          ],
           method: "POST",
+        },
+        {
+          id: "delete_reaction",
+          name: "Remove reaction",
+          description: "Remove a reaction from a post",
+          hostPattern: "api.linkedin.com",
+          pathPattern: "/rest/reactions/*",
+          aliasPatterns: [
+            "/rest/socialActions/*/likes/*",
+            "/v2/socialActions/*/likes/*",
+          ],
+          method: "DELETE",
         },
       ],
     },

--- a/packages/api/src/apps/app-permissions/types.ts
+++ b/packages/api/src/apps/app-permissions/types.ts
@@ -4,6 +4,7 @@ export interface AppTool {
   description: string;
   hostPattern: string;
   pathPattern: string;
+  aliasPatterns?: string[];
   method?: string;
 }
 

--- a/packages/api/src/apps/cloud-app-registry.ts
+++ b/packages/api/src/apps/cloud-app-registry.ts
@@ -81,4 +81,12 @@ export const cloudApps: AppDefinition[] = [
     connectionMethod: { type: "cloud_only" },
     available: false,
   },
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    icon: "/icons/hubspot.svg",
+    description: "CRM contacts, companies, deals, and tickets.",
+    connectionMethod: { type: "cloud_only" },
+    available: false,
+  },
 ];

--- a/packages/api/src/services/policy-rule-service.ts
+++ b/packages/api/src/services/policy-rule-service.ts
@@ -184,6 +184,7 @@ export const listAppPermissionRules = async (
       action: true,
       metadata: true,
       conditions: true,
+      pathPattern: true,
     },
   });
 };
@@ -194,6 +195,11 @@ export interface AppPermissionChange {
   tool: AppTool;
 }
 
+const allPatterns = (tool: AppTool): string[] => [
+  tool.pathPattern,
+  ...(tool.aliasPatterns ?? []),
+];
+
 export const setAppPermissionsService = async (
   scope: ResourceScope,
   provider: string,
@@ -202,34 +208,53 @@ export const setAppPermissionsService = async (
   conditions?: RuleCondition[],
 ) => {
   const existing = await listAppPermissionRules(scope, provider);
-  const existingByToolId = new Map(
-    existing
-      .filter(
-        (r): r is typeof r & { metadata: { toolId: string } } =>
-          r.metadata != null &&
-          typeof r.metadata === "object" &&
-          "toolId" in r.metadata,
-      )
-      .map((r) => [r.metadata.toolId, r]),
-  );
 
-  const toCreate: AppPermissionChange[] = [];
+  const existingByToolId = new Map<string, typeof existing>();
+  for (const r of existing) {
+    if (
+      r.metadata == null ||
+      typeof r.metadata !== "object" ||
+      !("toolId" in r.metadata)
+    )
+      continue;
+    const toolId = (r.metadata as { toolId: string }).toolId;
+    const arr = existingByToolId.get(toolId) ?? [];
+    arr.push(r);
+    existingByToolId.set(toolId, arr);
+  }
+
+  const toCreateRules: {
+    change: AppPermissionChange;
+    pathPattern: string;
+  }[] = [];
   const toUpdate: { ruleId: string; action: string }[] = [];
   const toDelete: string[] = [];
 
   const conditionsProvided = conditions !== undefined;
 
   for (const change of changes) {
-    const existingRule = existingByToolId.get(change.toolId);
+    const existingRules = existingByToolId.get(change.toolId) ?? [];
 
     if (change.permission === "allow") {
-      if (existingRule) toDelete.push(existingRule.id);
-    } else if (existingRule) {
-      if (existingRule.action !== change.permission || conditionsProvided) {
-        toUpdate.push({ ruleId: existingRule.id, action: change.permission });
+      for (const rule of existingRules) {
+        toDelete.push(rule.id);
+      }
+    } else if (existingRules.length > 0) {
+      for (const rule of existingRules) {
+        if (rule.action !== change.permission || conditionsProvided) {
+          toUpdate.push({ ruleId: rule.id, action: change.permission });
+        }
+      }
+      const existingPatterns = new Set(existingRules.map((r) => r.pathPattern));
+      for (const pattern of allPatterns(change.tool)) {
+        if (!existingPatterns.has(pattern)) {
+          toCreateRules.push({ change, pathPattern: pattern });
+        }
       }
     } else {
-      toCreate.push(change);
+      for (const pattern of allPatterns(change.tool)) {
+        toCreateRules.push({ change, pathPattern: pattern });
+      }
     }
   }
 
@@ -259,21 +284,21 @@ export const setAppPermissionsService = async (
       });
     }
 
-    for (const create of toCreate) {
+    for (const { change, pathPattern } of toCreateRules) {
       await tx.policyRule.create({
         data: {
           ...scopeCreate(scope),
           agentId: isOrgScope(scope) ? null : undefined,
-          name: `${appName}: ${create.tool.name}`,
-          hostPattern: create.tool.hostPattern,
-          pathPattern: create.tool.pathPattern,
-          method: create.tool.method ?? null,
-          action: create.permission,
+          name: `${change.tool.name}`,
+          hostPattern: change.tool.hostPattern,
+          pathPattern,
+          method: change.tool.method ?? null,
+          action: change.permission,
           enabled: true,
           metadata: {
             source: "app_permission",
             provider,
-            toolId: create.toolId,
+            toolId: change.toolId,
           },
           ...(conditionsProvided && conditions.length > 0
             ? { conditions }
@@ -284,7 +309,7 @@ export const setAppPermissionsService = async (
   });
 
   return {
-    created: toCreate.length,
+    created: toCreateRules.length,
     updated: toUpdate.length,
     deleted: toDelete.length,
   };


### PR DESCRIPTION
## Summary

- Add runtime env var fallback chains for `APP_URL`, `COGNITO_*`, `GATEWAY_API_URL` so self-hosted deployments can override build-time defaults
- Inject `GATEWAY_API_URL` at runtime via `<script>` tag (self-hosted only) for vault calls
- Use `window.location.origin` for OAuth redirect URI base in self-hosted
- Simplify `credential_not_found` gateway response: always use `/*` wildcard path, prescriptive message for agents
- Restructure generic secret dialog: show only Name, Value, Host in main form; move inject-as, header/param to Advanced settings
- Add `/settings/instance` page showing Public URL for self-hosted deployments
- Restyle redirect URI component with "Configure base URL" link (self-hosted only)
- Remove redundant `NEXT_PUBLIC_APP_URL` from docker-compose
- Add `GATEWAY_API_URL` to docker-compose for self-hosted gateway access
- Add HubSpot to cloud app registry
- Add LinkedIn app permissions