### PR TITLE
feat: inherit parent agent permissions when creating sub-agents

### DIFF
--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -51,6 +51,7 @@ export const agentRoutes = () => {
       requireProjectId(auth),
       parsed.data.name,
       parsed.data.identifier,
+      parsed.data.parentIdentifier,
     );
     invalidateGatewayCache(c.req.raw);
     return c.json(agent, 201);

--- a/packages/api/src/services/agent-service.ts
+++ b/packages/api/src/services/agent-service.ts
@@ -47,6 +47,7 @@ export const createAgent = async (
   projectId: string,
   name: string,
   identifier: string,
+  parentIdentifier?: string,
 ) => {
   const trimmed = name.trim();
   if (!trimmed || trimmed.length > 255) {
@@ -75,6 +76,28 @@ export const createAgent = async (
     );
   }
 
+  let inheritedSecretMode: SecretMode = "all";
+  let parentSecretIds: string[] = [];
+  let parentAppConnectionIds: string[] = [];
+
+  if (parentIdentifier) {
+    const parent = await db.agent.findFirst({
+      where: { projectId, identifier: parentIdentifier },
+      select: {
+        secretMode: true,
+        agentSecrets: { select: { secretId: true } },
+        agentAppConnections: { select: { appConnectionId: true } },
+      },
+    });
+    if (parent) {
+      inheritedSecretMode = parent.secretMode as SecretMode;
+      parentSecretIds = parent.agentSecrets.map((s) => s.secretId);
+      parentAppConnectionIds = parent.agentAppConnections.map(
+        (c) => c.appConnectionId,
+      );
+    }
+  }
+
   const accessToken = generateAccessToken();
 
   try {
@@ -83,7 +106,7 @@ export const createAgent = async (
         name: trimmed,
         identifier: trimmedIdentifier,
         accessToken,
-        secretMode: "all",
+        secretMode: inheritedSecretMode,
         projectId,
       },
       select: {
@@ -94,16 +117,32 @@ export const createAgent = async (
       },
     });
 
-    // Auto-assign the first anthropic secret if one exists
-    const anthropicSecret = await db.secret.findFirst({
-      where: { projectId, type: "anthropic" },
-      select: { id: true },
-      orderBy: { createdAt: "asc" },
-    });
+    if (parentSecretIds.length > 0) {
+      await db.agentSecret.createMany({
+        data: parentSecretIds.map((secretId) => ({
+          agentId: agent.id,
+          secretId,
+        })),
+      });
+    } else {
+      const anthropicSecret = await db.secret.findFirst({
+        where: { projectId, type: "anthropic" },
+        select: { id: true },
+        orderBy: { createdAt: "asc" },
+      });
+      if (anthropicSecret) {
+        await db.agentSecret.create({
+          data: { agentId: agent.id, secretId: anthropicSecret.id },
+        });
+      }
+    }
 
-    if (anthropicSecret) {
-      await db.agentSecret.create({
-        data: { agentId: agent.id, secretId: anthropicSecret.id },
+    if (parentAppConnectionIds.length > 0) {
+      await db.agentAppConnection.createMany({
+        data: parentAppConnectionIds.map((appConnectionId) => ({
+          agentId: agent.id,
+          appConnectionId,
+        })),
       });
     }
 

--- a/packages/api/src/validations/agent.ts
+++ b/packages/api/src/validations/agent.ts
@@ -8,6 +8,13 @@ export const createAgentSchema = z.object({
     message:
       "Identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens",
   }),
+  parentIdentifier: z
+    .string()
+    .regex(IDENTIFIER_REGEX, {
+      message:
+        "Parent identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens",
+    })
+    .optional(),
 });
 
 export const renameAgentSchema = z.object({


### PR DESCRIPTION
## Summary

- Accept optional `parentIdentifier` on `POST /v1/agents`
- When provided, child agent inherits parent's `secretMode` (all/selective)
- If parent is selective, copies parent's secret and app connection assignments to child
- If parent not found, falls back to default behavior (secretMode: all)
- Permissions are inherited once at creation time (snapshot, not live link)

Fixes the privilege escalation where sub-agents spawned by a restricted parent would default to `secretMode: "all"` with full credential access.

Closes #297