### PR TITLE
refactor: URL-based context resolution and scoped dashboard URLs

### DIFF
--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -240,7 +240,7 @@ impl PolicyEngine {
                     warn!(
                         host_pattern = %secret.host_pattern,
                         secret_type = %secret.type_,
-                        error = %e,
+                        error = ?e,
                         "skipping secret: decryption failed (wrong key or format mismatch)"
                     );
                     continue;
@@ -470,7 +470,7 @@ impl PolicyEngine {
                 warn!(
                     connection_id = %conn.id,
                     provider = %conn.provider,
-                    error = %e,
+                    error = ?e,
                     "app connection decrypt failed (wrong key or format mismatch)"
                 );
                 return Ok(AppConnectionResult::NoConnections);
@@ -756,7 +756,7 @@ impl PolicyEngine {
                                 .await;
                         }
                         Err(e) => {
-                            debug!(provider = %provider, cred_type, error = %e, "credential refresh failed");
+                            debug!(provider = %provider, cred_type, error = ?e, "credential refresh failed");
                         }
                     }
                 } else if let Some(refresh_token) =
@@ -792,7 +792,7 @@ impl PolicyEngine {
                                     .await;
                             }
                             Err(e) => {
-                                debug!(provider = %provider, error = %e, "token refresh failed");
+                                debug!(provider = %provider, error = ?e, "token refresh failed");
                             }
                         }
                     }
@@ -830,7 +830,7 @@ impl PolicyEngine {
                 }
             }
             Err(e) => {
-                debug!(provider = %provider, error = %e, "failed to encrypt refreshed credentials");
+                debug!(provider = %provider, error = ?e, "failed to encrypt refreshed credentials");
             }
         }
     }

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -268,7 +268,7 @@ impl GatewayServer {
 
             tokio::spawn(async move {
                 if let Err(e) = handle_connection(stream, peer_addr, state, router).await {
-                    warn!(peer = %peer_addr, error = %e, "connection error");
+                    warn!(peer = %peer_addr, error = ?e, "connection error");
                 }
             });
         }
@@ -621,7 +621,7 @@ async fn handle_connect(
                     tunnel::tunnel(upgraded, &host).await
                 };
                 if let Err(e) = result {
-                    warn!(host = %host, error = %e, "connection error");
+                    warn!(host = %host, error = ?e, "connection error");
                 }
             }
             Err(e) => {

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -178,6 +178,7 @@ pub(crate) async fn forward_request(
                 method.as_str(),
                 &path,
                 rule_name,
+                proxy_ctx.project_id.as_deref(),
             ));
         }
         PolicyDecision::RateLimited {
@@ -351,7 +352,7 @@ pub(crate) async fn forward_request(
             let mut guard = ApprovalGuard::new(approval_id.clone(), Arc::clone(approval_store));
 
             if let Err(e) = approval_store.store(&approval).await {
-                warn!(url = %url, error = %e, "failed to store pending approval");
+                warn!(url = %url, error = ?e, "failed to store pending approval");
                 guard.defuse();
                 approval_store.remove(&approval_id).await;
                 return Ok(response::approval_store_unavailable());
@@ -455,7 +456,7 @@ pub(crate) async fn forward_request(
                 )
                 .await
                 .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "body transform failed, forwarding empty body");
+                    tracing::warn!(error = ?e, "body transform failed, forwarding empty body");
                     reqwest::Body::from(vec![])
                 })
             } else {
@@ -528,6 +529,7 @@ pub(crate) async fn forward_request(
                 provider,
                 display_name,
                 proxy_ctx.agent_id.as_deref(),
+                proxy_ctx.project_id.as_deref(),
             ));
         }
 
@@ -539,6 +541,7 @@ pub(crate) async fn forward_request(
                 provider,
                 display_name,
                 proxy_ctx.agent_name.as_deref(),
+                proxy_ctx.project_id.as_deref(),
             ));
         }
 
@@ -549,12 +552,18 @@ pub(crate) async fn forward_request(
                 status,
                 hostname,
                 proxy_ctx.agent_name.as_deref(),
+                proxy_ctx.project_id.as_deref(),
             ));
         }
 
         // 3. Unknown host — no credentials at all, guide user to create a secret.
         info!(method = %method, url = %url, status = %status.as_u16(), "credential not found");
-        return Ok(response::credential_not_found(status, hostname, &path));
+        return Ok(response::credential_not_found(
+            status,
+            hostname,
+            &path,
+            proxy_ctx.project_id.as_deref(),
+        ));
     }
 
     // Some APIs (e.g. Google) return 400 instead of 401 for invalid/missing API keys.
@@ -581,6 +590,7 @@ pub(crate) async fn forward_request(
                     provider,
                     display_name,
                     proxy_ctx.agent_id.as_deref(),
+                    proxy_ctx.project_id.as_deref(),
                 ));
             }
             if let Some((provider, display_name)) =
@@ -592,6 +602,7 @@ pub(crate) async fn forward_request(
                     provider,
                     display_name,
                     proxy_ctx.agent_name.as_deref(),
+                    proxy_ctx.project_id.as_deref(),
                 ));
             }
             if apps::provider_for_host(hostname).is_some() {
@@ -600,6 +611,7 @@ pub(crate) async fn forward_request(
                     StatusCode::BAD_REQUEST,
                     hostname,
                     proxy_ctx.agent_name.as_deref(),
+                    proxy_ctx.project_id.as_deref(),
                 ));
             }
             info!(method = %method, url = %url, status = 400, "auth-related 400 — credential not found");
@@ -607,6 +619,7 @@ pub(crate) async fn forward_request(
                 StatusCode::BAD_REQUEST,
                 hostname,
                 &path,
+                proxy_ctx.project_id.as_deref(),
             ));
         }
 

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -120,7 +120,7 @@ pub(super) async fn mitm(
                                         Ok(resp)
                                     }
                                     Err(e) => {
-                                        warn!(host = %host, error = %e, "WebSocket handler failed");
+                                        warn!(host = %host, error = ?e, "WebSocket handler failed");
                                         Ok(response::resolution_failed())
                                     }
                                 }
@@ -145,7 +145,10 @@ pub(super) async fn mitm(
                                         );
                                         Ok(resp)
                                     }
-                                    Err(e) => Err(e),
+                                    Err(e) => {
+                                        warn!(host = %host, error = ?e, "request forwarding failed");
+                                        Ok::<_, anyhow::Error>(response::resolution_failed())
+                                    }
                                 }
                             }
                         }

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -32,6 +32,13 @@ fn dashboard_url() -> &'static str {
     })
 }
 
+fn scoped_url(base: &str, path: &str, project_id: Option<&str>) -> String {
+    match project_id {
+        Some(pid) => format!("{base}/p/{pid}{path}"),
+        None => format!("{base}{path}"),
+    }
+}
+
 /// Build a JSON error response with the given status code and body.
 /// Used by `forward_request` (MITM and HTTP proxy forwarding path).
 fn json_error<S>(status: StatusCode, body: serde_json::Value) -> Response<ForwardBody<S>> {
@@ -107,8 +114,9 @@ pub(crate) fn app_not_connected<S>(
     provider: &str,
     display_name: &str,
     agent_name: Option<&str>,
+    project_id: Option<&str>,
 ) -> Response<ForwardBody<S>> {
-    let base = dashboard_url();
+    let base = scoped_url(dashboard_url(), "", project_id);
     let connect_url = match agent_name {
         Some(name) => format!(
             "{base}/connections?connect={provider}&source=agent&agent_name={}",
@@ -135,8 +143,9 @@ pub(crate) fn app_not_connected_unknown_provider<S>(
     status: StatusCode,
     hostname: &str,
     agent_name: Option<&str>,
+    project_id: Option<&str>,
 ) -> Response<ForwardBody<S>> {
-    let base = dashboard_url();
+    let base = scoped_url(dashboard_url(), "", project_id);
     let encoded_host = utf8_percent_encode(hostname, NON_ALPHANUMERIC);
     let connect_url = match agent_name {
         Some(name) => format!(
@@ -169,8 +178,9 @@ pub(crate) fn access_restricted<S>(
     provider: &str,
     display_name: &str,
     agent_id: Option<&str>,
+    project_id: Option<&str>,
 ) -> Response<ForwardBody<S>> {
-    let base = dashboard_url();
+    let base = scoped_url(dashboard_url(), "", project_id);
     let manage_url = match agent_id {
         Some(id) => format!("{base}/agents?manage={}", id.get(..8).unwrap_or(id)),
         None => format!("{base}/agents"),
@@ -195,8 +205,9 @@ pub(crate) fn credential_not_found<S>(
     status: StatusCode,
     hostname: &str,
     path: &str,
+    project_id: Option<&str>,
 ) -> Response<ForwardBody<S>> {
-    let base = dashboard_url();
+    let base = scoped_url(dashboard_url(), "", project_id);
     let encoded_host = utf8_percent_encode(hostname, NON_ALPHANUMERIC);
     let secret_url =
         format!("{base}/connections/custom?create=generic&host={encoded_host}&path=%2F%2A");
@@ -298,7 +309,9 @@ pub(crate) fn blocked_by_policy<S>(
     method: &str,
     path: &str,
     rule_name: &str,
+    project_id: Option<&str>,
 ) -> Response<ForwardBody<S>> {
+    let rules_url = scoped_url(dashboard_url(), "/rules", project_id);
     with_no_retry(json_error(
         StatusCode::FORBIDDEN,
         serde_json::json!({
@@ -311,7 +324,7 @@ pub(crate) fn blocked_by_policy<S>(
             "rule_name": rule_name,
             "method": method,
             "path": path,
-            "dashboard_url": "https://app.onecli.sh/rules",
+            "dashboard_url": rules_url,
         }),
     ))
 }
@@ -369,7 +382,7 @@ mod tests {
     #[test]
     fn app_not_connected_preserves_status() {
         let resp: Response<TestBody> =
-            app_not_connected(StatusCode::UNAUTHORIZED, "gmail", "Gmail", None);
+            app_not_connected(StatusCode::UNAUTHORIZED, "gmail", "Gmail", None, None);
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(
             resp.headers().get("content-type").unwrap(),
@@ -381,7 +394,7 @@ mod tests {
     #[tokio::test]
     async fn app_not_connected_body_contains_provider_and_connect_url() {
         let resp: Response<TestBody> =
-            app_not_connected(StatusCode::FORBIDDEN, "github", "GitHub", None);
+            app_not_connected(StatusCode::FORBIDDEN, "github", "GitHub", None, None);
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
         // Extract body bytes from Either::Left(Full<Bytes>)
@@ -414,6 +427,7 @@ mod tests {
             "gmail",
             "Gmail",
             Some("ChartDB Assistant"),
+            None,
         );
         use http_body_util::BodyExt;
         let body = match resp.into_body() {
@@ -435,6 +449,7 @@ mod tests {
             "gmail",
             "Gmail",
             Some("Agent & Co=1"),
+            None,
         );
         use http_body_util::BodyExt;
         let body = match resp.into_body() {
@@ -460,6 +475,7 @@ mod tests {
             StatusCode::UNAUTHORIZED,
             "www.googleapis.com",
             Some("Claude Code"),
+            None,
         );
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         use http_body_util::BodyExt;
@@ -482,8 +498,12 @@ mod tests {
 
     #[tokio::test]
     async fn app_not_connected_unknown_provider_without_agent_name() {
-        let resp: Response<TestBody> =
-            app_not_connected_unknown_provider(StatusCode::FORBIDDEN, "www.googleapis.com", None);
+        let resp: Response<TestBody> = app_not_connected_unknown_provider(
+            StatusCode::FORBIDDEN,
+            "www.googleapis.com",
+            None,
+            None,
+        );
         use http_body_util::BodyExt;
         let body = match resp.into_body() {
             Either::Left(full) => full.collect().await.expect("collect full body").to_bytes(),
@@ -508,6 +528,7 @@ mod tests {
             "resend",
             "Resend",
             Some("abc12345-def"),
+            None,
         );
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         assert_eq!(
@@ -524,6 +545,7 @@ mod tests {
             "resend",
             "Resend",
             Some("abc12345-long-id"),
+            None,
         );
         use http_body_util::BodyExt;
         let body = match resp.into_body() {
@@ -546,7 +568,7 @@ mod tests {
     #[tokio::test]
     async fn access_restricted_body_without_agent_id() {
         let resp: Response<TestBody> =
-            access_restricted(StatusCode::FORBIDDEN, "github", "GitHub", None);
+            access_restricted(StatusCode::FORBIDDEN, "github", "GitHub", None, None);
         use http_body_util::BodyExt;
         let body = match resp.into_body() {
             Either::Left(full) => full.collect().await.expect("collect full body").to_bytes(),
@@ -560,7 +582,7 @@ mod tests {
     #[tokio::test]
     async fn access_restricted_short_agent_id() {
         let resp: Response<TestBody> =
-            access_restricted(StatusCode::FORBIDDEN, "resend", "Resend", Some("abc"));
+            access_restricted(StatusCode::FORBIDDEN, "resend", "Resend", Some("abc"), None);
         use http_body_util::BodyExt;
         let body = match resp.into_body() {
             Either::Left(full) => full.collect().await.expect("collect full body").to_bytes(),
@@ -579,6 +601,7 @@ mod tests {
             StatusCode::UNAUTHORIZED,
             "api.custom-service.com",
             "/v1/send",
+            None,
         );
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(resp.headers().get("x-should-retry").unwrap(), "false");
@@ -610,6 +633,7 @@ mod tests {
             StatusCode::FORBIDDEN,
             "api.example.com",
             "/v1/send?to=user@test.com&subject=hello",
+            None,
         );
         use http_body_util::BodyExt;
         let body = match resp.into_body() {
@@ -700,7 +724,8 @@ mod tests {
 
     #[test]
     fn blocked_by_policy_has_correct_status_and_headers() {
-        let resp: Response<TestBody> = blocked_by_policy("POST", "/api/v1/send", "Block sending");
+        let resp: Response<TestBody> =
+            blocked_by_policy("POST", "/api/v1/send", "Block sending", None);
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         assert_eq!(
             resp.headers().get("content-type").unwrap(),

--- a/apps/gateway/src/gateway/websocket.rs
+++ b/apps/gateway/src/gateway/websocket.rs
@@ -106,7 +106,12 @@ pub(super) async fn handle_websocket(
     match &decision {
         PolicyDecision::Blocked { rule_name } => {
             warn!(host = %host, path = %path, rule = %rule_name, "WebSocket BLOCKED by policy rule");
-            return Ok(response::blocked_by_policy("GET", &path, rule_name));
+            return Ok(response::blocked_by_policy(
+                "GET",
+                &path,
+                rule_name,
+                proxy_ctx.project_id.as_deref(),
+            ));
         }
         PolicyDecision::RateLimited {
             limit,
@@ -123,6 +128,7 @@ pub(super) async fn handle_websocket(
                 "GET",
                 &path,
                 "Manual approval required",
+                proxy_ctx.project_id.as_deref(),
             ));
         }
         PolicyDecision::Allow => {}

--- a/apps/gateway/src/vault/bitwarden.rs
+++ b/apps/gateway/src/vault/bitwarden.rs
@@ -214,7 +214,7 @@ impl BitwardenVaultProvider {
             Some(v) => match decrypt_connection_data(&self.crypto, v).await {
                 Ok(cd) => Some(cd),
                 Err(e) => {
-                    warn!(error = %e, project_id, "failed to decrypt vault connection data");
+                    warn!(error = ?e, project_id, "failed to decrypt vault connection data");
                     None
                 }
             },

--- a/apps/web/src/app/(connect)/app-connect/[provider]/page.tsx
+++ b/apps/web/src/app/(connect)/app-connect/[provider]/page.tsx
@@ -10,13 +10,15 @@ interface Props {
     message?: string;
     connectionId?: string;
     agent_name?: string;
-    org?: string;
+    projectId?: string;
+    orgId?: string;
   }>;
 }
 
 export default async function ConnectPage({ params, searchParams }: Props) {
   const { provider } = await params;
-  const { status, message, connectionId, agent_name, org } = await searchParams;
+  const { status, message, connectionId, agent_name, projectId, orgId } =
+    await searchParams;
 
   const app = getApp(provider);
   if (!app || !app.available) notFound();
@@ -60,7 +62,8 @@ export default async function ConnectPage({ params, searchParams }: Props) {
       errorMessage={message}
       connectionId={connectionId}
       agentName={agent_name}
-      org={org === "true"}
+      projectId={projectId}
+      orgId={orgId}
     />
   );
 }

--- a/apps/web/src/app/(connect)/app-connect/_components/connect-flow.tsx
+++ b/apps/web/src/app/(connect)/app-connect/_components/connect-flow.tsx
@@ -38,9 +38,10 @@ interface ConnectFlowProps {
   errorMessage?: string;
   connectionId?: string;
   agentName?: string;
-  org?: boolean;
   preContent?: ReactNode;
   hiddenFields?: Record<string, string>;
+  projectId?: string;
+  orgId?: string;
 }
 
 export const ConnectFlow = ({
@@ -50,9 +51,10 @@ export const ConnectFlow = ({
   errorMessage,
   connectionId,
   agentName,
-  org,
   preContent,
   hiddenFields,
+  projectId: explicitProjectId,
+  orgId,
 }: ConnectFlowProps) => {
   const [state, setState] = useState<FlowState>(
     status === "success" ? "success" : status === "error" ? "error" : "ready",
@@ -68,17 +70,17 @@ export const ConnectFlow = ({
     const params = new URLSearchParams();
     if (connectionId) params.set("connectionId", connectionId);
     if (agentName) params.set("agent_name", agentName);
-    if (org) params.set("org", "true");
 
     const token = await getAuthToken();
     if (token) params.set("_token", token);
-    const projectId = getProjectId();
+    const projectId = explicitProjectId || getProjectId();
     if (projectId) params.set("_project", projectId);
+    if (orgId) params.set("_org", orgId);
 
     const qs = params.toString();
     const authorizeUrl = `${API_ORIGIN}/v1/apps/${app.id}/authorize${qs ? `?${qs}` : ""}`;
     window.location.href = authorizeUrl;
-  }, [app.id, connectionId, agentName, org]);
+  }, [app.id, connectionId, agentName, explicitProjectId, orgId]);
 
   // Countdown timer for auto-redirect
   useEffect(() => {
@@ -131,9 +133,10 @@ export const ConnectFlow = ({
         fields={app.fields}
         fileImport={app.fileImport}
         connectionId={connectionId}
-        org={org}
         preContent={preContent}
         hiddenFields={hiddenFields}
+        projectId={explicitProjectId}
+        orgId={orgId}
         onSuccess={() => setState("success")}
         onError={(msg) => {
           setError(msg);

--- a/apps/web/src/app/(connect)/app-connect/_components/credentials-flow.tsx
+++ b/apps/web/src/app/(connect)/app-connect/_components/credentials-flow.tsx
@@ -36,11 +36,12 @@ export interface CredentialsFlowProps {
   fields: CredentialsFlowField[];
   fileImport?: FileImportConfig;
   connectionId?: string;
-  org?: boolean;
   preContent?: ReactNode;
   hiddenFields?: Record<string, string>;
   onSuccess: () => void;
   onError: (message: string) => void;
+  projectId?: string;
+  orgId?: string;
 }
 
 export const CredentialsFlow = ({
@@ -48,11 +49,12 @@ export const CredentialsFlow = ({
   fields,
   fileImport,
   connectionId,
-  org,
   preContent,
   hiddenFields,
   onSuccess,
   onError,
+  projectId,
+  orgId,
 }: CredentialsFlowProps) => {
   const [values, setValues] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
@@ -123,8 +125,11 @@ export const CredentialsFlow = ({
         body: JSON.stringify({
           fields: { ...values, ...hiddenFields },
           connectionId,
-          ...(org ? { org: true } : {}),
         }),
+        headers: {
+          ...(projectId ? { "X-Project-Id": projectId } : {}),
+          ...(orgId ? { "X-Organization-Id": orgId } : {}),
+        },
       });
       if (!resp.ok) {
         const data = (await resp.json()) as { error?: string };

--- a/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
@@ -12,7 +12,11 @@ import { checkAppConfigExists as defaultCheckConfig } from "@/lib/actions/app-co
 import { Card } from "@onecli/ui/components/card";
 import { useAppMessages } from "@/hooks/use-app-connected";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
-import { withProjectPrefix } from "@/lib/navigation";
+import {
+  PROJECT_PATH_RE,
+  ORG_PATH_RE,
+  withProjectPrefix,
+} from "@/lib/navigation";
 import type { OAuthPermission } from "@onecli/api/apps/types";
 import {
   getAppPermissionDefinition,
@@ -155,7 +159,12 @@ export const AppDetail = ({
     const top = Math.round(window.screenY + (window.outerHeight - h) / 2);
     const params = new URLSearchParams();
     if (connectionId) params.set("connectionId", connectionId);
-    if (pageScope === "organization") params.set("org", "true");
+    const projectMatch = pathname.match(PROJECT_PATH_RE)?.[1];
+    if (projectMatch) params.set("projectId", projectMatch);
+    if (pageScope === "organization") {
+      const orgMatch = pathname.match(ORG_PATH_RE)?.[1];
+      if (orgMatch) params.set("orgId", orgMatch);
+    }
     const qs = params.toString();
     const url = `/app-connect/${app.id}${qs ? `?${qs}` : ""}`;
     window.open(

--- a/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
-import { withProjectPrefix } from "@/lib/navigation";
+import {
+  PROJECT_PATH_RE,
+  ORG_PATH_RE,
+  withProjectPrefix,
+} from "@/lib/navigation";
 import { ChevronRight } from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
 import { Skeleton } from "@onecli/ui/components/skeleton";
@@ -123,7 +127,12 @@ export const AppsTab = ({
     const top = Math.round(window.screenY + (window.outerHeight - h) / 2);
     const searchParams = new URLSearchParams();
     if (options?.agentName) searchParams.set("agent_name", options.agentName);
-    if (pageScope === "organization") searchParams.set("org", "true");
+    const projectMatch = pathname.match(PROJECT_PATH_RE)?.[1];
+    if (projectMatch) searchParams.set("projectId", projectMatch);
+    if (pageScope === "organization") {
+      const orgMatch = pathname.match(ORG_PATH_RE)?.[1];
+      if (orgMatch) searchParams.set("orgId", orgMatch);
+    }
     const qs = searchParams.toString();
     window.open(
       `/app-connect/${provider}${qs ? `?${qs}` : ""}`,
@@ -370,7 +379,7 @@ const AppRow = ({
             />
           </svg>
           <span className="text-[11px] font-semibold tracking-wide text-brand">
-            Pro
+            Team
           </span>
         </span>
       ) : (

--- a/apps/web/src/lib/actions/agents.ts
+++ b/apps/web/src/lib/actions/agents.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import type { SecretMode } from "@onecli/api/services/agent-service";
 import {
   listAgents,
@@ -23,17 +23,17 @@ import {
 } from "@onecli/api/services/audit-service";
 
 export const getAgents = async () => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return listAgents(projectId);
 };
 
 export const getDefaultAgent = async () => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return getDefaultAgentService(projectId);
 };
 
 export const createAgent = async (name: string, identifier: string) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => createAgentService(projectId, name, identifier),
     (agent) => ({
@@ -48,7 +48,7 @@ export const createAgent = async (name: string, identifier: string) => {
 };
 
 export const setDefaultAgent = async (agentId: string): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => setDefaultAgentService(projectId, agentId),
     () => ({
@@ -63,7 +63,7 @@ export const setDefaultAgent = async (agentId: string): Promise<void> => {
 };
 
 export const deleteAgent = async (agentId: string): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => deleteAgentService(projectId, agentId),
     () => ({
@@ -81,7 +81,7 @@ export const renameAgent = async (
   agentId: string,
   name: string,
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => renameAgentService(projectId, agentId, name),
     () => ({
@@ -96,7 +96,7 @@ export const renameAgent = async (
 };
 
 export const regenerateAgentToken = async (agentId: string) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => regenerateAgentTokenService(projectId, agentId),
     () => ({
@@ -111,7 +111,7 @@ export const regenerateAgentToken = async (agentId: string) => {
 };
 
 export const getAgentSecrets = async (agentId: string) => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return getAgentSecretsService(projectId, agentId);
 };
 
@@ -119,7 +119,7 @@ export const updateAgentSecretMode = async (
   agentId: string,
   mode: SecretMode,
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => updateAgentSecretModeService(projectId, agentId, mode),
     () => ({
@@ -137,7 +137,7 @@ export const updateAgentSecrets = async (
   agentId: string,
   secretIds: string[],
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => updateAgentSecretsService(projectId, agentId, secretIds),
     () => ({
@@ -152,7 +152,7 @@ export const updateAgentSecrets = async (
 };
 
 export const getAgentAppConnections = async (agentId: string) => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return getAgentAppConnectionsService(projectId, agentId);
 };
 
@@ -160,7 +160,7 @@ export const updateAgentAppConnections = async (
   agentId: string,
   appConnectionIds: string[],
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () =>
       updateAgentAppConnectionsService(projectId, agentId, appConnectionIds),

--- a/apps/web/src/lib/actions/api-key.ts
+++ b/apps/web/src/lib/actions/api-key.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import {
   getApiKey as getApiKeyService,
   regenerateApiKey as regenerateApiKeyService,
@@ -12,12 +12,12 @@ import {
 } from "@onecli/api/services/audit-service";
 
 export const getApiKey = async () => {
-  const { userId, projectId } = await resolveUser();
+  const { userId, projectId } = await resolveProjectContext();
   return getApiKeyService(userId, { projectId });
 };
 
 export const regenerateApiKey = async () => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => regenerateApiKeyService(userId, { projectId }),
     () => ({

--- a/apps/web/src/lib/actions/app-config.ts
+++ b/apps/web/src/lib/actions/app-config.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import { getApp } from "@onecli/api/apps/registry";
 import {
   withAudit,
@@ -20,7 +20,7 @@ export const saveAppConfig = async (
   provider: string,
   values: Record<string, string>,
 ) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   const app = getApp(provider);
   if (!app?.configurable) {
     throw new Error(`Provider "${provider}" is not configurable`);
@@ -46,12 +46,12 @@ export const saveAppConfig = async (
 };
 
 export const getAppConfigStatus = async (provider: string) => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return getAppConfig({ projectId }, provider);
 };
 
 export const deleteAppConfigAction = async (provider: string) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
 
   return withAudit(
     () => deleteAppConfig({ projectId }, provider),
@@ -86,7 +86,7 @@ export const getAvailableEnvDefaults = async (): Promise<string[]> => {
 export const checkAppConfigExists = async (
   provider: string,
 ): Promise<boolean> => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return hasAppConfigService({ projectId }, provider);
 };
 
@@ -95,7 +95,7 @@ export const checkAppConfigExists = async (
  * Use this instead of calling checkAppConfigExists in a loop.
  */
 export const getConfiguredProviders = async (): Promise<string[]> => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return listConfiguredProviders({ projectId });
 };
 
@@ -103,7 +103,7 @@ export const setAppConfigEnabled = async (
   provider: string,
   enabled: boolean,
 ) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
 
   return withAudit(
     () => toggleAppConfigEnabled({ projectId }, provider, enabled),

--- a/apps/web/src/lib/actions/connections.ts
+++ b/apps/web/src/lib/actions/connections.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { db } from "@onecli/db";
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import {
   withAudit,
   AUDIT_ACTIONS,
@@ -14,17 +14,17 @@ import {
 } from "@onecli/api/services/connection-service";
 
 export const getAppConnections = async () => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return listConnections({ projectId });
 };
 
 export const getAppConnectionsByProvider = async (provider: string) => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return listConnectionsByProvider({ projectId }, provider);
 };
 
 export const getVaultConnections = async () => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return db.vaultConnection.findMany({
     where: { projectId },
     select: {
@@ -39,7 +39,7 @@ export const getVaultConnections = async () => {
 };
 
 export const disconnectAppConnection = async (connectionId: string) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
 
   return withAudit(
     () => deleteConnection({ projectId }, connectionId),

--- a/apps/web/src/lib/actions/gateway-cache.ts
+++ b/apps/web/src/lib/actions/gateway-cache.ts
@@ -3,7 +3,7 @@
 import { db } from "@onecli/db";
 import { cookies } from "next/headers";
 import { GATEWAY_API_URL } from "@/lib/env";
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 
 /**
  * Invalidate the gateway's CONNECT response cache for the current account.
@@ -17,7 +17,7 @@ export const invalidateGatewayCache = async () => {
     const headers: Record<string, string> = {};
 
     // Prefer API key auth — works regardless of gateway auth mode
-    const { projectId } = await resolveUser();
+    const { projectId } = await resolveProjectContext();
     const apiKey = await db.apiKey.findFirst({
       where: { projectId },
       select: { key: true },

--- a/apps/web/src/lib/actions/request-logs.ts
+++ b/apps/web/src/lib/actions/request-logs.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import {
   getRecentRequestLogs,
   getRequestLogs,
@@ -8,11 +8,11 @@ import {
 } from "@onecli/api/services/request-log-service";
 
 export const getRecentActivity = async () => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return getRecentRequestLogs(projectId, 5);
 };
 
 export const getActivityPage = async (params: ActivityPageParams = {}) => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return getRequestLogs(projectId, params);
 };

--- a/apps/web/src/lib/actions/resolve-user.ts
+++ b/apps/web/src/lib/actions/resolve-user.ts
@@ -17,7 +17,7 @@ export interface UserContext {
  * active project. Always validates the session server-side — never trusts
  * client input.
  */
-export const resolveUser = async (): Promise<UserContext> => {
+export const resolveProjectContext = async (): Promise<UserContext> => {
   const session = await getServerSession();
   if (!session) throw new Error("Not authenticated");
 

--- a/apps/web/src/lib/actions/rules.ts
+++ b/apps/web/src/lib/actions/rules.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import {
   listPolicyRules,
   createPolicyRule as createPolicyRuleService,
@@ -24,12 +24,12 @@ import {
 import type { RuleCondition } from "@onecli/api/validations/policy-rule";
 
 export const getRules = async () => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return listPolicyRules({ projectId });
 };
 
 export const createRule = async (input: CreatePolicyRuleInput) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => createPolicyRuleService({ projectId }, input),
     (rule) => ({
@@ -47,7 +47,7 @@ export const updateRule = async (
   ruleId: string,
   input: UpdatePolicyRuleInput,
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => updatePolicyRuleService({ projectId }, ruleId, input),
     () => ({
@@ -62,7 +62,7 @@ export const updateRule = async (
 };
 
 export const deleteRule = async (ruleId: string): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => deletePolicyRuleService({ projectId }, ruleId),
     () => ({
@@ -84,7 +84,7 @@ export type AppPermissionState = {
 export const getAppPermissionStates = async (
   provider: string,
 ): Promise<Record<string, AppPermissionState>> => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   const rules = await listAppPermissionRules({ projectId }, provider);
 
   const states: Record<string, AppPermissionState> = {};
@@ -105,7 +105,7 @@ export const setAppPermissions = async (
   changes: { toolId: string; permission: AppPermissionLevel }[],
   conditions?: RuleCondition[],
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   const def = getAppPermissionDefinition(provider);
   if (!def)
     throw new Error(`No permission definition for provider: ${provider}`);
@@ -153,7 +153,7 @@ export const setAppPermissions = async (
 export const getOverlappingRuleCountForApp = async (
   provider: string,
 ): Promise<number> => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   const def = getAppPermissionDefinition(provider);
   if (!def) return 0;
   const hostPatterns = [

--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { db } from "@onecli/db";
-import { resolveUser } from "@/lib/actions/resolve-user";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import { APP_URL, API_URL, GATEWAY_BASE_URL } from "@/lib/env";
 import {
   listSecrets,
@@ -18,12 +18,12 @@ import {
 } from "@onecli/api/services/audit-service";
 
 export const getSecrets = async () => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   return listSecrets({ projectId });
 };
 
 export const createSecret = async (input: CreateSecretInput) => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => createSecretService({ projectId }, input),
     (secret) => ({
@@ -38,7 +38,7 @@ export const createSecret = async (input: CreateSecretInput) => {
 };
 
 export const deleteSecret = async (secretId: string): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => deleteSecretService({ projectId }, secretId),
     () => ({
@@ -53,7 +53,7 @@ export const deleteSecret = async (secretId: string): Promise<void> => {
 };
 
 export const getInstallInfo = async () => {
-  const { projectId, userId } = await resolveUser();
+  const { projectId, userId } = await resolveProjectContext();
 
   const [apiKey, agent] = await Promise.all([
     db.apiKey.findFirst({
@@ -76,7 +76,7 @@ export const getInstallInfo = async () => {
 };
 
 export const hasAnthropicSecret = async (): Promise<boolean> => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   const secret = await db.secret.findFirst({
     where: { projectId, type: "anthropic" },
     select: { id: true },
@@ -85,7 +85,7 @@ export const hasAnthropicSecret = async (): Promise<boolean> => {
 };
 
 export const hasOpenaiSecret = async (): Promise<boolean> => {
-  const { projectId } = await resolveUser();
+  const { projectId } = await resolveProjectContext();
   const secret = await db.secret.findFirst({
     where: { projectId, type: "openai" },
     select: { id: true },
@@ -174,7 +174,7 @@ export const updateSecret = async (
   secretId: string,
   input: UpdateSecretInput,
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveUser();
+  const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
     () => updateSecretService({ projectId }, secretId, input),
     () => ({

--- a/apps/web/src/lib/components/pro-app-dialog.tsx
+++ b/apps/web/src/lib/components/pro-app-dialog.tsx
@@ -70,7 +70,7 @@ export const ProAppDialog = ({
               />
             </svg>
             <span className="text-[11px] font-semibold tracking-wide text-brand">
-              Pro
+              Team
             </span>
           </div>
 

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,9 +1,9 @@
 /**
  * Matches `/p/<projectId>` at the start of a pathname and captures the id.
  * Shared across sidebar, header, and navigation helpers so the pattern stays
- * consistent. Accepts both 16-char nanoid slugs and 36-char UUIDs.
+ * consistent.
  */
-export const PROJECT_PATH_RE = /^\/p\/([a-z]{16}|[0-9a-f-]{36})(?=\/|$)/;
+export const PROJECT_PATH_RE = /^\/p\/([^/]+)(?=\/|$)/;
 
 /**
  * Prefix an absolute dashboard path with `/p/<projectId>` if the current
@@ -15,6 +15,8 @@ export const PROJECT_PATH_RE = /^\/p\/([a-z]{16}|[0-9a-f-]{36})(?=\/|$)/;
  * In OSS the regex never matches (no `/p/<id>/` URLs exist) so the input
  * path is returned unchanged — this is a no-op for self-hosted users.
  */
+export const ORG_PATH_RE = /^\/org\/([^/]+)(?=\/|$)/;
+
 export const withProjectPrefix = (
   currentPathname: string,
   targetPath: string,

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -6,6 +6,7 @@ import {
   NEXTAUTH_SECRET,
   SECRET_ENCRYPTION_KEY,
 } from "@/lib/env";
+import { PROJECT_PATH_RE, ORG_PATH_RE } from "@/lib/navigation";
 
 type SetupErrorCode = "oauth-misconfigured" | "missing-encryption-key";
 
@@ -28,38 +29,7 @@ const getSetupError = (): SetupErrorCode | null => {
   return null;
 };
 
-// Cloud-only: legacy unscoped dashboard routes that should redirect to their
-// project-scoped equivalents. The cookie set by /p/[projectId] navigation or
-// switchProjectAction is the source of truth for "active project". If the
-// cookie is missing (first visit, signed out, etc.) we fall through to the
-// auth flow / projects landing.
-const UNSCOPED_REDIRECTS = new Set([
-  "/overview",
-  "/agents",
-  "/connections",
-  "/rules",
-]);
-
-const ACTIVE_PROJECT_COOKIE = "onecli-project-id";
-
-const cloudUnscopedRedirect = (request: NextRequest): NextResponse | null => {
-  if (!IS_CLOUD) return null;
-  const { pathname } = request.nextUrl;
-
-  // Match exact unscoped paths and their nested subroutes
-  // (e.g. /connections/apps, /connections/secrets/...).
-  const matchedPrefix = [...UNSCOPED_REDIRECTS].find(
-    (p) => pathname === p || pathname.startsWith(`${p}/`),
-  );
-  if (!matchedPrefix) return null;
-
-  const projectId = request.cookies.get(ACTIVE_PROJECT_COOKIE)?.value;
-  if (!projectId) return null;
-
-  const url = request.nextUrl.clone();
-  url.pathname = `/p/${projectId}${pathname}`;
-  return NextResponse.redirect(url);
-};
+const DEFAULT_ORG_COOKIE = "onecli-default-org";
 
 export const proxy = (request: NextRequest) => {
   const { pathname } = request.nextUrl;
@@ -79,10 +49,43 @@ export const proxy = (request: NextRequest) => {
     );
   }
 
-  const cloudRedirect = cloudUnscopedRedirect(request);
-  if (cloudRedirect) return cloudRedirect;
+  if (!IS_CLOUD) {
+    const scopeStripped = pathname
+      .replace(PROJECT_PATH_RE, "")
+      .replace(ORG_PATH_RE, "");
+    if (scopeStripped !== pathname) {
+      const url = request.nextUrl.clone();
+      url.pathname = scopeStripped || "/";
+      return NextResponse.redirect(url);
+    }
+    return NextResponse.next();
+  }
 
-  return NextResponse.next();
+  const requestHeaders = new Headers(request.headers);
+
+  const projectId = pathname.match(PROJECT_PATH_RE)?.[1];
+  if (projectId) {
+    requestHeaders.set("x-project-id", projectId);
+  }
+
+  const orgId = pathname.match(ORG_PATH_RE)?.[1];
+  if (orgId) {
+    requestHeaders.set("x-organization-id", orgId);
+  }
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  if (orgId) {
+    response.cookies.set(DEFAULT_ORG_COOKIE, orgId, {
+      path: "/",
+      maxAge: 60 * 60 * 24 * 365,
+      sameSite: "lax",
+    });
+  }
+
+  return response;
 };
 
 export const config = {

--- a/packages/api/src/lib/dashboard-url.ts
+++ b/packages/api/src/lib/dashboard-url.ts
@@ -1,0 +1,11 @@
+import { APP_URL } from "./env";
+
+export const dashboardUrl = (
+  path: string,
+  scope?: { projectId?: string; organizationId?: string },
+): string => {
+  if (scope?.projectId) return `${APP_URL}/p/${scope.projectId}${path}`;
+  if (scope?.organizationId)
+    return `${APP_URL}/org/${scope.organizationId}${path}`;
+  return `${APP_URL}${path}`;
+};

--- a/packages/api/src/lib/oauth-state.ts
+++ b/packages/api/src/lib/oauth-state.ts
@@ -2,7 +2,7 @@ import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { IS_CLOUD, OAUTH_STATE_SECRET, SECRET_ENCRYPTION_KEY } from "./env";
 
 export interface OAuthStatePayload {
-  projectId: string;
+  projectId?: string;
   provider: string;
   nonce: string;
   [key: string]: unknown;

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -56,6 +56,8 @@ export const auth = (options?: AuthOptions) => {
         headers.set("authorization", `Bearer ${queryToken}`);
         const queryProject = url.searchParams.get("_project");
         if (queryProject) headers.set("x-project-id", queryProject);
+        const queryOrg = url.searchParams.get("_org");
+        if (queryOrg) headers.set("x-organization-id", queryOrg);
 
         authResult = await authenticateSession(
           new Request(c.req.url, { headers }),

--- a/packages/api/src/middleware/auth/resolve.ts
+++ b/packages/api/src/middleware/auth/resolve.ts
@@ -23,14 +23,7 @@ export const resolveProjectId = async (
   request: Request,
   userId: string,
 ): Promise<string | null> => {
-  const headerProjectId =
-    request.headers.get("x-project-id") ??
-    request.headers
-      .get("cookie")
-      ?.split("; ")
-      .find((c) => c.startsWith("onecli-project-id="))
-      ?.split("=")[1] ??
-    null;
+  const headerProjectId = request.headers.get("x-project-id");
 
   if (headerProjectId) {
     const memberOrgIds = await db.user

--- a/packages/api/src/routes/apps.ts
+++ b/packages/api/src/routes/apps.ts
@@ -12,6 +12,7 @@ import {
   generateNonce,
 } from "../lib/oauth-state";
 import { APP_URL, NODE_ENV } from "../lib/env";
+import { dashboardUrl } from "../lib/dashboard-url";
 import {
   invalidateGatewayCache,
   invalidateGatewayCacheForAccount,
@@ -172,7 +173,7 @@ export const appRoutes = () => {
 
     const hint = isConfigured
       ? `Your MCP server needs local credential stub files to start. Create them in the format and location the MCP server expects, but use 'onecli-managed' as a placeholder for all secrets. See ${docsBaseURL}/${provider}.md for examples (fallback: ${docsBaseURL}/general-app.md ). The OneCLI gateway handles real OAuth token exchange at request time.`
-      : `This app is not configured yet. Go to ${APP_URL}/connections?connect=${provider} to set up your credentials.`;
+      : `This app is not configured yet. Go to ${dashboardUrl(`/connections?connect=${provider}`, { projectId })} to set up your credentials.`;
 
     return c.json({
       id: appDef.id,
@@ -295,6 +296,10 @@ export const appRoutes = () => {
       const state = verifyOAuthState(stateParam);
       if (!state || state.provider !== provider) {
         return errorRedirect("Invalid state parameter");
+      }
+
+      if (!state.projectId) {
+        return errorRedirect("Missing project in state");
       }
 
       const stateProject = await db.project.findUnique({
@@ -448,7 +453,6 @@ export const appRoutes = () => {
     const body = (await c.req.json().catch(() => null)) as {
       fields?: Record<string, string>;
       connectionId?: string;
-      org?: boolean;
     } | null;
     if (!body?.fields) {
       return c.json({ error: "Missing fields in request body" }, 400);
@@ -506,18 +510,16 @@ export const appRoutes = () => {
 
     const connectionOpts = { scopes, metadata };
 
-    if (body.org) {
-      const orgResponse = await getOAuthOrg().tryHandleOrgConnect(
-        auth,
-        c.req.raw,
-        provider,
-        credentials,
-        connectionOpts,
-        body.connectionId,
-        fields,
-      );
-      if (orgResponse) return orgResponse;
-    }
+    const orgResponse = await getOAuthOrg().tryHandleOrgConnect(
+      auth,
+      c.req.raw,
+      provider,
+      credentials,
+      connectionOpts,
+      body.connectionId,
+      fields,
+    );
+    if (orgResponse) return orgResponse;
 
     await getConnectionHooks().beforeConnect(auth.organizationId, appDef);
 

--- a/packages/api/src/routes/auth-session.ts
+++ b/packages/api/src/routes/auth-session.ts
@@ -108,6 +108,7 @@ export const authSessionRoutes = () => {
           email: dbUser.email,
           name: dbUser.name,
           projectId,
+          organizationId: defaultProject.organizationId,
         });
       }
 


### PR DESCRIPTION
## Summary

Replace cookie-based project/org context with URL-derived context for multi-tab safety and architectural clarity.

### Context resolution
- `resolveUser` renamed to `resolveProjectContext` — clearer intent (project-scoped context)
- Middleware injects `x-project-id` and `x-organization-id` request headers from URL path
- API client (`apiFetch`) reads project/org from `window.location.pathname` instead of cookies
- Auth middleware extracts `_org` from query params alongside existing `_project`
- `resolveProjectId` in auth middleware simplified to header-only (removed cookie fallback)

### Connect flow
- `org=true` boolean flag replaced with explicit `orgId` parameter
- OAuth authorize URL passes `_org=<id>` for org-scoped connections
- Credentials flow passes `X-Organization-Id` header
- Org OAuth handler validates membership before using explicit org ID

### Scoped URLs
- Gateway response URLs include `/p/<projectId>` scope when project context is available
- `dashboardUrl()` helper for consistent scoped URL construction in API routes
- Stripe checkout/portal URLs use org-scoped paths
- OSS middleware strips scope prefixes for backward compatibility

### Other
- `ORG_PATH_RE` added to `lib/navigation.ts` (format-agnostic regex)
- `PROJECT_PATH_RE` relaxed to `[^/]+` (validation happens server-side)
- OAuth state `projectId` made optional for org-scoped flows
- Session endpoint returns `organizationId` alongside `projectId`

## Changed files (30)
- `lib/actions/*` — function rename (`resolveUser` → `resolveProjectContext`)
- `lib/navigation.ts` — added `ORG_PATH_RE`, relaxed `PROJECT_PATH_RE`
- `proxy.ts` — middleware header injection + OSS scope stripping
- `connect-flow.tsx`, `credentials-flow.tsx` — explicit `orgId` replaces `org` boolean
- `app-detail.tsx`, `apps-tab.tsx` — extract org from URL for popup params
- `packages/api/src/middleware/auth*` — `_org` extraction, cookie fallback removed
- `packages/api/src/routes/apps.ts` — scoped hint URL, removed `body.org`
- `packages/api/src/lib/dashboard-url.ts` — new helper
- `apps/gateway/src/gateway/response.rs` — scoped URLs with project_id param