### PR TITLE
fix: settings nav org-awareness and proxy cookie validation

### DIFF
--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -27,7 +27,9 @@ export default function DashboardLayout({
     signOutRef.current = signOut;
   }, [signOut]);
 
-  const isSettings = pathname.startsWith("/settings");
+  const isSettings =
+    pathname.startsWith("/settings") ||
+    /^\/org\/[^/]+\/settings(\/|$)/.test(pathname);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {

--- a/apps/web/src/app/(dashboard)/settings/_components/settings-mobile-nav.tsx
+++ b/apps/web/src/app/(dashboard)/settings/_components/settings-mobile-nav.tsx
@@ -3,11 +3,13 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@onecli/ui/lib/utils";
-import { settingsSections } from "@/lib/nav-config";
+import { getSettingsSections } from "@/lib/nav-config";
+import { ORG_PATH_RE } from "@/lib/navigation";
 
 export const SettingsMobileNav = () => {
   const pathname = usePathname();
-  const items = settingsSections.flatMap((s) => s.items);
+  const orgId = pathname.match(ORG_PATH_RE)?.[1];
+  const items = getSettingsSections(orgId).flatMap((s) => s.items);
 
   return (
     <nav className="flex gap-1 overflow-x-auto border-b px-4 py-2 scrollbar-hide md:hidden">

--- a/apps/web/src/app/(dashboard)/settings/_components/settings-nav.tsx
+++ b/apps/web/src/app/(dashboard)/settings/_components/settings-nav.tsx
@@ -3,14 +3,17 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@onecli/ui/lib/utils";
-import { settingsSections } from "@/lib/nav-config";
+import { getSettingsSections } from "@/lib/nav-config";
+import { ORG_PATH_RE } from "@/lib/navigation";
 
 export const SettingsNav = () => {
   const pathname = usePathname();
+  const orgId = pathname.match(ORG_PATH_RE)?.[1];
+  const sections = getSettingsSections(orgId);
 
   return (
     <nav className="space-y-5">
-      {settingsSections.map((section) => (
+      {sections.map((section) => (
         <div key={section.label} className="space-y-1">
           <p className="text-muted-foreground px-2 pb-1 text-xs font-medium">
             {section.label}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -23,7 +23,7 @@ export default function NotFound() {
         The page you&apos;re looking for doesn&apos;t exist.
       </p>
       <Link
-        href="/overview"
+        href="/"
         className="text-brand text-sm underline underline-offset-4"
       >
         Go to Dashboard

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -32,7 +32,11 @@ export const navItems: NavItem[] = [
   { title: "Settings", url: "/settings", icon: Settings },
 ];
 
-export const settingsSections: SettingsNavSection[] = [
+export const getSettingsSections = (
+  // Cloud override uses orgId to prefix URLs with /org/<id>
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  orgId?: string,
+): SettingsNavSection[] => [
   {
     label: "General",
     items: [{ title: "Instance", url: "/settings/instance", icon: Globe }],
@@ -51,3 +55,5 @@ export const settingsSections: SettingsNavSection[] = [
     ],
   },
 ];
+
+export const settingsSections = getSettingsSections();

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -29,8 +29,6 @@ const getSetupError = (): SetupErrorCode | null => {
   return null;
 };
 
-const DEFAULT_ORG_COOKIE = "onecli-default-org";
-
 export const proxy = (request: NextRequest) => {
   const { pathname } = request.nextUrl;
 
@@ -73,19 +71,9 @@ export const proxy = (request: NextRequest) => {
     requestHeaders.set("x-organization-id", orgId);
   }
 
-  const response = NextResponse.next({
+  return NextResponse.next({
     request: { headers: requestHeaders },
   });
-
-  if (orgId) {
-    response.cookies.set(DEFAULT_ORG_COOKIE, orgId, {
-      path: "/",
-      maxAge: 60 * 60 * 24 * 365,
-      sameSite: "lax",
-    });
-  }
-
-  return response;
 };
 
 export const config = {


### PR DESCRIPTION
## Summary

- Settings nav components now use `getSettingsSections(orgId)` instead of static `settingsSections` import, enabling org-scoped URLs when an org ID is present in the pathname
- Dashboard layout `isSettings` check expanded to also match `/org/*/settings` paths
- Proxy middleware no longer sets default-org cookie from URL (prevents cookie poisoning from invalid org URLs — cookie is now set by validated client component)
- `nav-config.ts` exports `getSettingsSections()` function alongside backward-compatible `settingsSections` static array

## Changed files (6)
- `layout.tsx` — isSettings regex for org settings paths
- `settings-nav.tsx` / `settings-mobile-nav.tsx` — dynamic sections from `getSettingsSections(orgId)`
- `nav-config.ts` — `getSettingsSections(orgId?)` function export
- `proxy.ts` — removed cookie setting from middleware
- `not-found.tsx` — minor update