### PR TITLE
feat: org policy mode, scoped gateway URLs, and connect param fix

### DIFF
--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -48,6 +48,9 @@ pub(crate) struct ConnectResponse {
     /// Normalized plan name for quota enforcement ("free", "pro", "team").
     #[serde(default)]
     pub plan: String,
+    /// Organization policy mode: "allow" (default) or "deny" (block by default).
+    #[serde(default)]
+    pub policy_mode: String,
 }
 
 /// Result of per-request app connection resolution.
@@ -199,6 +202,7 @@ impl PolicyEngine {
             agent_identifier: agent.identifier.clone(),
             access_restricted,
             plan,
+            policy_mode: agent.policy_mode.clone(),
         })
     }
 
@@ -688,6 +692,7 @@ impl PolicyEngine {
                     "manual_approval" => PolicyAction::ManualApproval {
                         rule_id: r.id.clone(),
                     },
+                    "allow" => PolicyAction::Allow,
                     _ => return None,
                 };
                 Some(PolicyRule {
@@ -1075,6 +1080,7 @@ mod tests {
             agent_identifier: None,
             access_restricted: false,
             plan: "pro".to_string(),
+            policy_mode: "allow".to_string(),
         };
 
         store
@@ -1118,6 +1124,7 @@ mod tests {
             agent_identifier: None,
             access_restricted: false,
             plan: "pro".to_string(),
+            policy_mode: "allow".to_string(),
         };
 
         // Pre-populate cache with the key format that resolve() uses
@@ -1157,6 +1164,7 @@ mod tests {
             agent_identifier: None,
             access_restricted: true,
             plan: "pro".to_string(),
+            policy_mode: "allow".to_string(),
         };
 
         store

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -29,6 +29,7 @@ pub(crate) struct AgentRow {
     pub organization_id: String,
     pub secret_mode: String,
     pub subscription_status: String,
+    pub policy_mode: String,
 }
 
 /// A secret row from the `secrets` table.
@@ -137,7 +138,7 @@ pub(crate) async fn find_agent_by_token(
     access_token: &str,
 ) -> Result<Option<AgentRow>> {
     sqlx::query_as::<_, AgentRow>(
-        r#"SELECT a.id, a.name, a.identifier, a.project_id, p.organization_id, a.secret_mode, o.subscription_status
+        r#"SELECT a.id, a.name, a.identifier, a.project_id, p.organization_id, a.secret_mode, o.subscription_status, o.policy_mode
            FROM agents a
            JOIN projects p ON a.project_id = p.id
            JOIN organizations o ON p.organization_id = o.id
@@ -218,7 +219,7 @@ pub(crate) async fn find_policy_rules_by_project(
                   action, rate_limit, rate_limit_window, conditions
            FROM policy_rules
            WHERE project_id = $1 AND enabled = true
-             AND action IN ('block', 'rate_limit', 'manual_approval')"#,
+             AND action IN ('block', 'rate_limit', 'manual_approval', 'allow')"#,
     )
     .bind(project_id)
     .fetch_all(pool)
@@ -236,7 +237,7 @@ pub(crate) async fn find_policy_rules_by_org(
                   action, rate_limit, rate_limit_window, conditions
            FROM policy_rules
            WHERE organization_id = $1 AND scope = 'organization' AND enabled = true
-             AND action IN ('block', 'rate_limit', 'manual_approval')"#,
+             AND action IN ('block', 'rate_limit', 'manual_approval', 'allow')"#,
     )
     .bind(organization_id)
     .fetch_all(pool)

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -762,6 +762,7 @@ async fn handle_http_proxy(
         connection_label: None,
         finalizer: resolved_finalizer,
         body_transform: resolved_body_transform,
+        policy_mode: resolved.policy_mode,
     };
 
     let http_client =

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -156,11 +156,31 @@ pub(crate) async fn forward_request(
         &rules.policy_rules,
         agent_token,
         cache,
+        &rules.policy_mode,
+        !rules.injection_rules.is_empty(),
     )
     .await;
 
-    // ── Early return for block / rate-limit (no body needed) ─────
+    // ── Early return for block / rate-limit / default-deny (no body needed) ───
     match &decision {
+        PolicyDecision::BlockedByDefaultPolicy => {
+            warn!(method = %method, url = %url, "BLOCKED by default deny policy");
+            emit_policy_telemetry(
+                proxy_ctx,
+                host,
+                &method,
+                &path,
+                start,
+                StatusCode::FORBIDDEN,
+                crate::telemetry_core::RequestDecision::BlockedByDefaultPolicy,
+            );
+            return Ok(response::blocked_by_default_policy(
+                method.as_str(),
+                &path,
+                host,
+                proxy_ctx.project_id.as_deref(),
+            ));
+        }
         PolicyDecision::Blocked { rule_name } => {
             warn!(method = %method, url = %url, rule = %rule_name, "BLOCKED by policy rule");
             emit_policy_telemetry(

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -201,6 +201,8 @@ pub(crate) struct ResolvedRules {
     /// Provider-specific body transform resolved from the app connection.
     /// The handler decides per-request whether to act.
     pub body_transform: Option<crate::apps::BodyTransform>,
+    /// Organization policy mode: "allow" (default) or "deny" (block by default).
+    pub policy_mode: String,
 }
 
 /// Result of per-request rule resolution including app connection disambiguation.
@@ -348,6 +350,7 @@ async fn resolve_rules(
             connection_label,
             finalizer,
             body_transform,
+            policy_mode: resp.policy_mode,
         },
         app_connections: resp.app_connections,
     })

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -329,6 +329,33 @@ pub(crate) fn blocked_by_policy<S>(
     ))
 }
 
+/// 403 Forbidden — no allow rule matched in deny-by-default mode.
+pub(crate) fn blocked_by_default_policy<S>(
+    method: &str,
+    path: &str,
+    host: &str,
+    project_id: Option<&str>,
+) -> Response<ForwardBody<S>> {
+    let base = scoped_url(dashboard_url(), "", project_id);
+    let hostname = host.split(':').next().unwrap_or(host);
+    let encoded_host = utf8_percent_encode(hostname, NON_ALPHANUMERIC);
+    with_no_retry(json_error(
+        StatusCode::FORBIDDEN,
+        serde_json::json!({
+            "error": "blocked_by_default_policy",
+            "message": format!(
+                "Your organization's default-deny policy blocked this request. \
+                 {method} {hostname}{path} requires an explicit allow rule. \
+                 Create one in your OneCLI dashboard."
+            ),
+            "method": method,
+            "host": hostname,
+            "path": path,
+            "dashboard_url": format!("{base}/rules?create=allow&host={encoded_host}"),
+        }),
+    ))
+}
+
 /// 429 Too Many Requests — request rate-limited by a policy rule.
 pub(crate) fn rate_limited<S>(
     limit: u64,

--- a/apps/gateway/src/gateway/websocket.rs
+++ b/apps/gateway/src/gateway/websocket.rs
@@ -100,10 +100,28 @@ pub(super) async fn handle_websocket(
         .unwrap_or_else(|| "/".to_string());
 
     let agent_token = proxy_ctx.agent_token.as_deref().unwrap_or("");
-    let decision =
-        policy::evaluate("GET", &path, None, &rules.policy_rules, agent_token, cache).await;
+    let decision = policy::evaluate(
+        "GET",
+        &path,
+        None,
+        &rules.policy_rules,
+        agent_token,
+        cache,
+        &rules.policy_mode,
+        !rules.injection_rules.is_empty(),
+    )
+    .await;
 
     match &decision {
+        PolicyDecision::BlockedByDefaultPolicy => {
+            warn!(host = %host, path = %path, "WebSocket BLOCKED by default deny policy");
+            return Ok(response::blocked_by_default_policy(
+                "GET",
+                &path,
+                host,
+                proxy_ctx.project_id.as_deref(),
+            ));
+        }
         PolicyDecision::Blocked { rule_name } => {
             warn!(host = %host, path = %path, rule = %rule_name, "WebSocket BLOCKED by policy rule");
             return Ok(response::blocked_by_policy(

--- a/apps/gateway/src/policy.rs
+++ b/apps/gateway/src/policy.rs
@@ -3,6 +3,7 @@
 //! Policy rules control access to upstream endpoints:
 //! - **Block**: returns 403 Forbidden
 //! - **Rate limit**: allows up to N requests per time window, then 429
+//! - **Allow**: explicitly permits a request (used in deny-by-default mode)
 
 use crate::cache::CacheStore;
 use crate::inject::path_matches;
@@ -21,6 +22,7 @@ pub(crate) enum PolicyAction {
     ManualApproval {
         rule_id: String,
     },
+    Allow,
 }
 
 /// A resolved policy rule ready for evaluation.
@@ -50,6 +52,8 @@ pub(crate) enum PolicyDecision {
     },
     /// Request requires manual approval before proceeding.
     ManualApproval { rule_id: String },
+    /// Request blocked because no allow rule matched in deny-by-default mode.
+    BlockedByDefaultPolicy,
 }
 
 // ── Evaluation ──────────────────────────────────────────────────────────
@@ -58,6 +62,7 @@ pub(crate) enum PolicyDecision {
 ///
 /// Priority: Block > ManualApproval > RateLimit > Allow.
 /// Each pass checks only one action type to enforce strict ordering.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn evaluate(
     request_method: &str,
     request_path: &str,
@@ -65,6 +70,8 @@ pub(crate) async fn evaluate(
     rules: &[PolicyRule],
     agent_token: &str,
     cache: &dyn CacheStore,
+    policy_mode: &str,
+    has_injections: bool,
 ) -> PolicyDecision {
     // Pass 1: block rules (absolute deny, highest priority)
     for rule in rules {
@@ -127,6 +134,20 @@ pub(crate) async fn evaluate(
                 }
             }
             // If incr failed (cache unavailable), allow through — graceful fallback
+        }
+    }
+
+    // Pass 4: in deny mode with injections, require an explicit allow rule.
+    if policy_mode == "deny" && has_injections {
+        let has_allow = rules.iter().any(|rule| {
+            matches_request(rule, request_method, request_path, request_body)
+                && matches!(
+                    rule.action,
+                    PolicyAction::Allow | PolicyAction::RateLimit { .. }
+                )
+        });
+        if !has_allow {
+            return PolicyDecision::BlockedByDefaultPolicy;
         }
     }
 
@@ -305,7 +326,10 @@ mod tests {
     async fn rate_limit_allows_under_limit() {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![rate_rule("*", Some("POST"), 5, 3600)];
-        let decision = evaluate("POST", "/path", None, &rules, "agent1", &*store).await;
+        let decision = evaluate(
+            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+        )
+        .await;
         assert!(matches!(decision, PolicyDecision::Allow));
     }
 
@@ -315,13 +339,22 @@ mod tests {
         let rules = vec![rate_rule("*", Some("POST"), 2, 3600)];
 
         // First 2 requests allowed
-        let d1 = evaluate("POST", "/path", None, &rules, "agent1", &*store).await;
+        let d1 = evaluate(
+            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+        )
+        .await;
         assert!(matches!(d1, PolicyDecision::Allow));
-        let d2 = evaluate("POST", "/path", None, &rules, "agent1", &*store).await;
+        let d2 = evaluate(
+            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+        )
+        .await;
         assert!(matches!(d2, PolicyDecision::Allow));
 
         // Third request rate limited
-        let d3 = evaluate("POST", "/path", None, &rules, "agent1", &*store).await;
+        let d3 = evaluate(
+            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+        )
+        .await;
         assert!(matches!(d3, PolicyDecision::RateLimited { .. }));
     }
 
@@ -331,12 +364,21 @@ mod tests {
         let rules = vec![rate_rule("*", Some("POST"), 1, 3600)];
 
         // Agent1 hits limit
-        evaluate("POST", "/path", None, &rules, "agent1", &*store).await;
-        let d = evaluate("POST", "/path", None, &rules, "agent1", &*store).await;
+        evaluate(
+            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+        )
+        .await;
+        let d = evaluate(
+            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::RateLimited { .. }));
 
         // Agent2 is unaffected
-        let d = evaluate("POST", "/path", None, &rules, "agent2", &*store).await;
+        let d = evaluate(
+            "POST", "/path", None, &rules, "agent2", &*store, "allow", false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::Allow));
     }
 
@@ -347,7 +389,17 @@ mod tests {
             block_rule("/danger/*", Some("POST")),
             rate_rule("/danger/*", Some("POST"), 100, 3600),
         ];
-        let d = evaluate("POST", "/danger/path", None, &rules, "agent1", &*store).await;
+        let d = evaluate(
+            "POST",
+            "/danger/path",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "allow",
+            false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::Blocked { .. }));
     }
 
@@ -355,7 +407,17 @@ mod tests {
     async fn evaluate_allows_non_matching_rules() {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![block_rule("/blocked/*", Some("POST"))];
-        let d = evaluate("GET", "/safe/path", None, &rules, "agent1", &*store).await;
+        let d = evaluate(
+            "GET",
+            "/safe/path",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "allow",
+            false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::Allow));
     }
 
@@ -377,7 +439,17 @@ mod tests {
     async fn manual_approval_matches_path_and_method() {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![approval_rule("/send/*", Some("POST"))];
-        let d = evaluate("POST", "/send/email", None, &rules, "agent1", &*store).await;
+        let d = evaluate(
+            "POST",
+            "/send/email",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "allow",
+            false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::ManualApproval { .. }));
     }
 
@@ -385,7 +457,17 @@ mod tests {
     async fn manual_approval_no_match_different_method() {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![approval_rule("/send/*", Some("POST"))];
-        let d = evaluate("GET", "/send/email", None, &rules, "agent1", &*store).await;
+        let d = evaluate(
+            "GET",
+            "/send/email",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "allow",
+            false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::Allow));
     }
 
@@ -396,7 +478,17 @@ mod tests {
             approval_rule("/danger/*", Some("POST")),
             block_rule("/danger/*", Some("POST")),
         ];
-        let d = evaluate("POST", "/danger/path", None, &rules, "agent1", &*store).await;
+        let d = evaluate(
+            "POST",
+            "/danger/path",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "allow",
+            false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::Blocked { .. }));
     }
 
@@ -407,7 +499,10 @@ mod tests {
             rate_rule("/v1/*", Some("POST"), 100, 3600),
             approval_rule("/v1/*", Some("POST")),
         ];
-        let d = evaluate("POST", "/v1/send", None, &rules, "agent1", &*store).await;
+        let d = evaluate(
+            "POST", "/v1/send", None, &rules, "agent1", &*store, "allow", false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::ManualApproval { .. }));
     }
 
@@ -444,5 +539,172 @@ mod tests {
             None,
             &rules
         ));
+    }
+
+    // ── Deny-by-default mode tests ──────────────────────────────────
+
+    fn allow_rule(path: &str, method: Option<&str>) -> PolicyRule {
+        PolicyRule {
+            name: "Test allow rule".to_string(),
+            path_pattern: path.to_string(),
+            method: method.map(|m| m.to_string()),
+            action: PolicyAction::Allow,
+            conditions_raw: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn deny_mode_blocks_when_no_allow_rule() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules: Vec<PolicyRule> = vec![];
+        let d = evaluate(
+            "POST",
+            "/api/v1/messages",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "deny",
+            true,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::BlockedByDefaultPolicy));
+    }
+
+    #[tokio::test]
+    async fn deny_mode_allows_with_explicit_allow_rule() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules = vec![allow_rule("/api/*", Some("POST"))];
+        let d = evaluate(
+            "POST",
+            "/api/v1/messages",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "deny",
+            true,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::Allow));
+    }
+
+    #[tokio::test]
+    async fn deny_mode_block_overrides_allow() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules = vec![
+            allow_rule("/api/*", Some("POST")),
+            block_rule("/api/v1/danger", Some("POST")),
+        ];
+        let d = evaluate(
+            "POST",
+            "/api/v1/danger",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "deny",
+            true,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::Blocked { .. }));
+    }
+
+    #[tokio::test]
+    async fn deny_mode_rate_limit_implicit_allow() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules = vec![rate_rule("/api/*", Some("POST"), 100, 3600)];
+        let d = evaluate(
+            "POST",
+            "/api/v1/send",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "deny",
+            true,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::Allow));
+    }
+
+    #[tokio::test]
+    async fn deny_mode_manual_approval_implicit_allow() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules = vec![approval_rule("/send/*", Some("POST"))];
+        let d = evaluate(
+            "POST",
+            "/send/email",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "deny",
+            true,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::ManualApproval { .. }));
+    }
+
+    #[tokio::test]
+    async fn deny_mode_non_matching_allow_still_blocks() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules = vec![allow_rule("/api/*", Some("GET"))];
+        let d = evaluate(
+            "POST",
+            "/api/v1/send",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "deny",
+            true,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::BlockedByDefaultPolicy));
+    }
+
+    #[tokio::test]
+    async fn allow_mode_ignores_allow_rules() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules = vec![allow_rule("/api/*", Some("POST"))];
+        let d = evaluate(
+            "POST",
+            "/other/path",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "allow",
+            false,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::Allow));
+    }
+
+    #[tokio::test]
+    async fn deny_mode_allows_without_injections() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules: Vec<PolicyRule> = vec![];
+        let d = evaluate(
+            "POST",
+            "/api/v1/messages",
+            None,
+            &rules,
+            "agent1",
+            &*store,
+            "deny",
+            false,
+        )
+        .await;
+        assert!(matches!(d, PolicyDecision::Allow));
+    }
+
+    #[tokio::test]
+    async fn allow_mode_empty_string_same_as_allow() {
+        let store = crate::cache::create_store().await.unwrap();
+        let rules: Vec<PolicyRule> = vec![];
+        let d = evaluate("POST", "/path", None, &rules, "agent1", &*store, "", false).await;
+        assert!(matches!(d, PolicyDecision::Allow));
     }
 }

--- a/apps/gateway/src/telemetry_core.rs
+++ b/apps/gateway/src/telemetry_core.rs
@@ -37,6 +37,7 @@ pub(crate) enum RequestDecision {
         triggered_at: String,
         resolved_at: String,
     },
+    BlockedByDefaultPolicy,
 }
 
 pub(crate) struct RequestEvent {

--- a/apps/web/src/app/(dashboard)/activity/_components/activity-detail-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-detail-dialog.tsx
@@ -20,6 +20,7 @@ import { withProjectPrefix } from "@/lib/navigation";
 import { hasJsonData } from "@onecli/api/lib/format";
 import {
   isBlockedRequest,
+  isDefaultDenied,
   isRateLimitedRequest,
   getBlockedByRule,
   getConnectionLabel,
@@ -50,6 +51,7 @@ export const ActivityDetailDialog = ({
 }: ActivityDetailDialogProps) => {
   const pathname = usePathname();
   const blocked = log ? isBlockedRequest(log) : false;
+  const defaultDenied = log ? isDefaultDenied(log) : false;
   const rateLimited = log ? isRateLimitedRequest(log) : false;
   const blockedByRule = log ? getBlockedByRule(log) : null;
   const connectionLabel = log ? getConnectionLabel(log) : null;
@@ -99,9 +101,20 @@ export const ActivityDetailDialog = ({
               <StatusBadge
                 status={log.status}
                 blocked={blocked}
+                defaultDenied={defaultDenied}
                 rateLimited={rateLimited}
               />
             </Row>
+            {defaultDenied && (
+              <Row label="Reason">
+                <Link
+                  href={rulesUrl}
+                  className="text-destructive hover:text-destructive/80 underline underline-offset-4 transition-colors"
+                >
+                  No matching allow rule
+                </Link>
+              </Row>
+            )}
             {(blocked || rateLimited) && blockedByRule && (
               <Row label={rateLimited ? "Limited by" : "Blocked by"}>
                 <Link

--- a/apps/web/src/app/(dashboard)/activity/_components/activity-table.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-table.tsx
@@ -21,6 +21,7 @@ import { formatRelative, formatUTC } from "@onecli/api/lib/format";
 import { getProviderIcon } from "@onecli/api/apps/provider-icons";
 import {
   isBlockedRequest,
+  isDefaultDenied,
   isRateLimitedRequest,
   getApprovalDecision,
   type RequestLogEntry,
@@ -129,6 +130,7 @@ export const ActivityTable = ({ logs, onRowClick }: ActivityTableProps) => (
                   <StatusBadge
                     status={log.status}
                     blocked={isBlockedRequest(log)}
+                    defaultDenied={isDefaultDenied(log)}
                     rateLimited={isRateLimitedRequest(log)}
                   />
                 </TableCell>

--- a/apps/web/src/app/(dashboard)/activity/_components/status-badge.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/status-badge.tsx
@@ -1,16 +1,27 @@
-import { Ban, Timer } from "lucide-react";
+import { Ban, ShieldCheck, Timer } from "lucide-react";
 
 interface StatusBadgeProps {
   status: number;
   blocked?: boolean;
+  defaultDenied?: boolean;
   rateLimited?: boolean;
 }
 
 export const StatusBadge = ({
   status,
   blocked,
+  defaultDenied,
   rateLimited,
 }: StatusBadgeProps) => {
+  if (defaultDenied) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium text-destructive">
+        <ShieldCheck className="size-3 shrink-0" />
+        Not allowed
+      </span>
+    );
+  }
+
   if (blocked) {
     return (
       <span className="inline-flex items-center gap-1 text-xs font-medium text-destructive">

--- a/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-detail.tsx
@@ -65,6 +65,7 @@ interface AppDetailProps {
   permissionActions?: React.ComponentProps<typeof AppPermissions>["actions"];
   orgPermissionStates?: Record<string, AppPermissionLevel>;
   orgConditions?: Record<string, unknown[]>;
+  policyMode?: "allow" | "deny";
 }
 
 interface ConnectionData {
@@ -90,6 +91,7 @@ export const AppDetail = ({
   permissionActions,
   orgPermissionStates,
   orgConditions,
+  policyMode,
 }: AppDetailProps) => {
   const pathname = usePathname();
   const [connections, setConnections] = useState<ConnectionData[]>([]);
@@ -298,6 +300,7 @@ export const AppDetail = ({
               actions={permissionActions}
               orgStates={orgPermissionStates}
               orgConditions={orgConditions}
+              policyMode={policyMode}
             />
           ) : isConnected && app.permissions.length > 0 ? (
             <PermissionsList

--- a/apps/web/src/app/(dashboard)/connections/_components/app-permission-group.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-permission-group.tsx
@@ -32,6 +32,7 @@ interface AppPermissionGroupProps {
   disabled?: boolean;
   orgStates?: Record<string, AppPermissionLevel>;
   orgConditions?: Record<string, unknown[]>;
+  defaultPermission?: AppPermissionLevel;
 }
 
 const groupLabels: Record<string, string> = {
@@ -48,10 +49,11 @@ const permissionLabels: Record<string, string> = {
 const getGroupPermission = (
   tools: AppToolGroup["tools"],
   states: Record<string, AppPermissionState>,
+  fallback: AppPermissionLevel = "allow",
 ): AppPermissionLevel | "custom" => {
-  const permissions = tools.map((t) => states[t.id]?.permission ?? "allow");
+  const permissions = tools.map((t) => states[t.id]?.permission ?? fallback);
   const first = permissions[0];
-  if (first === undefined) return "allow";
+  if (first === undefined) return fallback;
   return permissions.every((p) => p === first) ? first : "custom";
 };
 
@@ -63,13 +65,18 @@ export const AppPermissionGroup = ({
   disabled,
   orgStates,
   orgConditions,
+  defaultPermission = "allow",
 }: AppPermissionGroupProps) => {
-  const groupPerm = getGroupPermission(group.tools, permissionStates);
+  const groupPerm = getGroupPermission(
+    group.tools,
+    permissionStates,
+    defaultPermission,
+  );
 
   const isGroupOptionDisabled = (opt: AppPermissionLevel) =>
     group.tools.some((t) =>
       resolveToolPermission(
-        permissionStates[t.id]?.permission ?? "allow",
+        permissionStates[t.id]?.permission ?? defaultPermission,
         [],
         orgStates?.[t.id],
         (orgConditions?.[t.id] ?? []) as RuleCondition[],
@@ -132,7 +139,7 @@ export const AppPermissionGroup = ({
         <div className="ml-6">
           {group.tools.map((tool) => {
             const state = permissionStates[tool.id];
-            const permission = state?.permission ?? "allow";
+            const permission = state?.permission ?? defaultPermission;
             const projectConditions = (state?.conditions ??
               []) as RuleCondition[];
             const toolOrgConditions = (orgConditions?.[tool.id] ??

--- a/apps/web/src/app/(dashboard)/connections/_components/app-permissions.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-permissions.tsx
@@ -49,6 +49,7 @@ interface AppPermissionsProps {
   actions?: AppPermissionActions;
   orgStates?: Record<string, AppPermissionLevel>;
   orgConditions?: Record<string, unknown[]>;
+  policyMode?: "allow" | "deny";
 }
 
 export const AppPermissions = ({
@@ -58,7 +59,10 @@ export const AppPermissions = ({
   actions,
   orgStates,
   orgConditions,
+  policyMode = "allow",
 }: AppPermissionsProps) => {
+  const defaultPermission: AppPermissionLevel =
+    policyMode === "deny" ? "block" : "allow";
   const pathname = usePathname();
   const [states, setStates] = useState<Record<string, AppPermissionState>>({});
   const [overlappingRuleCount, setOverlappingRuleCount] = useState(0);
@@ -155,8 +159,8 @@ export const AppPermissions = ({
     const allTools = groups.flatMap((g) => g.tools);
     const restrictedTools = allTools.filter((t) => {
       if (isLocked(t.id)) return false;
-      const perm = states[t.id]?.permission ?? "allow";
-      return perm !== "allow";
+      const perm = states[t.id]?.permission ?? defaultPermission;
+      return perm !== defaultPermission;
     });
 
     if (restrictedTools.length === 0) {
@@ -182,7 +186,9 @@ export const AppPermissions = ({
     .flatMap((g) => g.tools)
     .filter((t) => {
       if (isLocked(t.id)) return false;
-      return (states[t.id]?.permission ?? "allow") !== "allow";
+      return (
+        (states[t.id]?.permission ?? defaultPermission) !== defaultPermission
+      );
     }).length;
 
   if (loading) {
@@ -247,6 +253,7 @@ export const AppPermissions = ({
             disabled={saving}
             orgStates={orgStates}
             orgConditions={orgConditions}
+            defaultPermission={defaultPermission}
           />
         ))}
       </Accordion>

--- a/apps/web/src/app/(dashboard)/connections/_components/use-connect-param.ts
+++ b/apps/web/src/app/(dashboard)/connections/_components/use-connect-param.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { getApps } from "@onecli/api/apps/registry";
 import type { AppDefinition } from "@onecli/api/apps/types";
 import { safeDecode } from "./safe-decode";
@@ -38,6 +38,7 @@ export const useConnectParam = ({
   onRequestApp,
 }: UseConnectParamOptions) => {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const handled = useRef(false);
 
@@ -48,7 +49,7 @@ export const useConnectParam = ({
     if (requestHost) {
       handled.current = true;
       const appName = safeDecode(searchParams.get("request_name"));
-      router.replace("/connections");
+      router.replace(pathname);
       onRequestApp(requestHost, appName);
       return;
     }
@@ -59,7 +60,7 @@ export const useConnectParam = ({
     handled.current = true;
     const app = getApps().find((a) => a.id === provider);
     if (!app) {
-      router.replace("/connections");
+      router.replace(pathname);
       return;
     }
 
@@ -68,7 +69,7 @@ export const useConnectParam = ({
         ? (safeDecode(searchParams.get("agent_name")) ?? "your agent")
         : undefined;
 
-    router.replace("/connections");
+    router.replace(pathname);
 
     const hasCredentials =
       envDefaultProviders.has(app.id) || configuredProviders.has(app.id);
@@ -84,6 +85,7 @@ export const useConnectParam = ({
     }
   }, [
     loading,
+    pathname,
     searchParams,
     connectedProviders,
     configuredProviders,

--- a/apps/web/src/app/(dashboard)/rules/_components/app-permission-summary.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/app-permission-summary.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Ban, ChevronDown, Hand } from "lucide-react";
+import { Ban, ChevronDown, Hand, ShieldCheck } from "lucide-react";
 import { Badge } from "@onecli/ui/components/badge";
 import { Button } from "@onecli/ui/components/button";
 import {
@@ -129,12 +129,18 @@ const AppPermissionCard = ({
                   <TooltipTrigger asChild>
                     {tool.action === "block" ? (
                       <Ban className="size-3 text-destructive shrink-0 mt-0.5" />
+                    ) : tool.action === "allow" ? (
+                      <ShieldCheck className="size-3 text-emerald-500 shrink-0 mt-0.5" />
                     ) : (
                       <Hand className="size-3 text-blue-500 shrink-0 mt-0.5" />
                     )}
                   </TooltipTrigger>
                   <TooltipContent side="left" className="text-xs">
-                    {tool.action === "block" ? "Blocked" : "Needs approval"}
+                    {tool.action === "block"
+                      ? "Blocked"
+                      : tool.action === "allow"
+                        ? "Allowed"
+                        : "Needs approval"}
                   </TooltipContent>
                 </Tooltip>
                 <div className="min-w-0">

--- a/apps/web/src/app/(dashboard)/rules/_components/application-rule-form.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/application-rule-form.tsx
@@ -29,7 +29,10 @@ import {
   getAppPermissionDefinition,
   type AppPermissionLevel,
 } from "@onecli/api/apps/app-permissions";
-import type { RuleCondition } from "@onecli/api/validations/policy-rule";
+import type {
+  RuleCondition,
+  PolicyMode,
+} from "@onecli/api/validations/policy-rule";
 import { setAppPermissions as defaultSetAppPermissions } from "@/lib/actions/rules";
 import { ConditionBuilder } from "@/lib/components/condition-builder";
 import type { RuleActions } from "./types";
@@ -76,6 +79,7 @@ interface ApplicationRuleFormProps {
   onClose: () => void;
   ruleActions?: RuleActions;
   connectedProviders?: Map<string, string[]>;
+  policyMode?: PolicyMode;
 }
 
 export const ApplicationRuleForm = ({
@@ -83,13 +87,17 @@ export const ApplicationRuleForm = ({
   onClose,
   ruleActions,
   connectedProviders,
+  policyMode = "allow",
 }: ApplicationRuleFormProps) => {
+  const isDenyMode = policyMode === "deny";
   const invalidateCache = useInvalidateGatewayCache();
   const [step, setStep] = useState<Step>("app");
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [scope, setScope] = useState<Scope>("all");
   const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
-  const [policy, setPolicy] = useState<AppPermissionLevel>("allow");
+  const [policy, setPolicy] = useState<AppPermissionLevel>(
+    isDenyMode ? "block" : "allow",
+  );
   const [conditions, setConditions] = useState<RuleCondition[]>([]);
   const [saving, setSaving] = useState(false);
 

--- a/apps/web/src/app/(dashboard)/rules/_components/custom-endpoint-form.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/custom-endpoint-form.tsx
@@ -3,7 +3,14 @@
 import { useState, useEffect, useMemo } from "react";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { toast } from "sonner";
-import { ShieldBan, Gauge, Hand, Check, Settings2 } from "lucide-react";
+import {
+  ShieldBan,
+  ShieldCheck,
+  Gauge,
+  Hand,
+  Check,
+  Settings2,
+} from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
 import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
@@ -24,6 +31,7 @@ import {
   SelectValue,
 } from "@onecli/ui/components/select";
 import { DialogFooter } from "@onecli/ui/components/dialog";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
 import { updateRule as defaultUpdateRule } from "@/lib/actions/rules";
 import { useQueryClient } from "@tanstack/react-query";
 import { rules } from "@/lib/api";
@@ -66,6 +74,7 @@ interface CustomEndpointFormProps {
   rule?: PolicyRuleItem;
   showAgentField?: boolean;
   ruleActions?: RuleActions;
+  policyMode?: PolicyMode;
 }
 
 export const CustomEndpointForm = ({
@@ -75,7 +84,9 @@ export const CustomEndpointForm = ({
   rule,
   showAgentField = true,
   ruleActions,
+  policyMode = "allow",
 }: CustomEndpointFormProps) => {
+  const isDenyMode = policyMode === "deny";
   const isEdit = !!rule;
   const invalidateCache = useInvalidateGatewayCache();
   const queryClient = useQueryClient();
@@ -88,8 +99,8 @@ export const CustomEndpointForm = ({
   const [method, setMethod] = useState("");
   const [agentId, setAgentId] = useState("");
   const [action, setAction] = useState<
-    "block" | "rate_limit" | "manual_approval"
-  >("block");
+    "block" | "rate_limit" | "manual_approval" | "allow"
+  >(isDenyMode ? "allow" : "block");
   const [rateLimit, setRateLimit] = useState(100);
   const [rateLimitWindow, setRateLimitWindow] = useState<
     "minute" | "hour" | "day"
@@ -106,7 +117,8 @@ export const CustomEndpointForm = ({
     setMethod(rule?.method ?? "");
     setAgentId(rule?.agentId ?? "");
     setAction(
-      (rule?.action as "block" | "rate_limit" | "manual_approval") ?? "block",
+      (rule?.action as "block" | "rate_limit" | "manual_approval" | "allow") ??
+        (isDenyMode ? "allow" : "block"),
     );
     setRateLimit(rule?.rateLimit ?? 100);
     setRateLimitWindow(
@@ -114,7 +126,7 @@ export const CustomEndpointForm = ({
     );
     setEnabled(rule?.enabled ?? true);
     setConditions((rule?.conditions as RuleCondition[]) ?? []);
-  }, [rule]);
+  }, [rule, isDenyMode]);
 
   const nameError = useMemo(() => validateDisplayName(name), [name]);
   const showNameError = nameTouched && nameError !== null;
@@ -378,29 +390,55 @@ export const CustomEndpointForm = ({
       {step === "action" && (
         <div className="space-y-4 pt-5">
           <div className="grid grid-cols-3 gap-2">
-            <button
-              type="button"
-              onClick={() => setAction("block")}
-              className={cn(
-                "flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors",
-                action === "block"
-                  ? "border-destructive bg-destructive/5"
-                  : "hover:bg-muted/50 hover:border-foreground/20",
-              )}
-            >
-              <span className="flex items-center gap-2 text-sm font-medium">
-                <ShieldBan
-                  className={cn(
-                    "size-4",
-                    action === "block" && "text-destructive",
-                  )}
-                />
-                Block
-              </span>
-              <span className="text-muted-foreground text-xs">
-                Deny the request entirely
-              </span>
-            </button>
+            {isDenyMode ? (
+              <button
+                type="button"
+                onClick={() => setAction("allow")}
+                className={cn(
+                  "flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors",
+                  action === "allow"
+                    ? "border-emerald-500 bg-emerald-500/5"
+                    : "hover:bg-muted/50 hover:border-foreground/20",
+                )}
+              >
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <ShieldCheck
+                    className={cn(
+                      "size-4",
+                      action === "allow" && "text-emerald-500",
+                    )}
+                  />
+                  Allow
+                </span>
+                <span className="text-muted-foreground text-xs">
+                  Permit the request through
+                </span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setAction("block")}
+                className={cn(
+                  "flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors",
+                  action === "block"
+                    ? "border-destructive bg-destructive/5"
+                    : "hover:bg-muted/50 hover:border-foreground/20",
+                )}
+              >
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <ShieldBan
+                    className={cn(
+                      "size-4",
+                      action === "block" && "text-destructive",
+                    )}
+                  />
+                  Block
+                </span>
+                <span className="text-muted-foreground text-xs">
+                  Deny the request entirely
+                </span>
+              </button>
+            )}
             <button
               type="button"
               onClick={() => setAction("rate_limit")}

--- a/apps/web/src/app/(dashboard)/rules/_components/rule-card.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/rule-card.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/actions/rules";
 import { cn } from "@onecli/ui/lib/utils";
 import { RuleDialog } from "./rule-dialog";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
 import type { AgentOption, PolicyRuleItem, RuleActions } from "./types";
 
 interface RuleCardProps {
@@ -36,6 +37,7 @@ interface RuleCardProps {
   readOnly?: boolean;
   badge?: string;
   ruleActions?: RuleActions;
+  policyMode?: PolicyMode;
 }
 
 export const RuleCard = ({
@@ -45,6 +47,7 @@ export const RuleCard = ({
   readOnly,
   badge,
   ruleActions,
+  policyMode,
 }: RuleCardProps) => {
   const deleteRule = ruleActions?.deleteRule ?? defaultDeleteRule;
   const updateRule = ruleActions?.updateRule ?? defaultUpdateRule;
@@ -123,11 +126,12 @@ export const RuleCard = ({
               <Badge
                 variant={
                   rule.action === "rate_limit" ||
-                  rule.action === "manual_approval"
+                  rule.action === "manual_approval" ||
+                  rule.action === "allow"
                     ? "secondary"
                     : "destructive"
                 }
-                className={`text-xs ${rule.action === "rate_limit" ? "bg-amber-500/15 text-amber-600 dark:text-amber-400" : rule.action === "manual_approval" ? "bg-blue-500/15 text-blue-600 dark:text-blue-400" : ""}`}
+                className={`text-xs ${rule.action === "rate_limit" ? "bg-amber-500/15 text-amber-600 dark:text-amber-400" : rule.action === "manual_approval" ? "bg-blue-500/15 text-blue-600 dark:text-blue-400" : rule.action === "allow" ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" : ""}`}
               >
                 {actionLabel}
               </Badge>
@@ -247,6 +251,7 @@ export const RuleCard = ({
           agents={agents}
           onSaved={onUpdate}
           ruleActions={ruleActions}
+          policyMode={policyMode}
         />
       )}
     </>

--- a/apps/web/src/app/(dashboard)/rules/_components/rule-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/rule-dialog.tsx
@@ -13,6 +13,7 @@ import {
   AnimatedTabTrigger,
   AnimatedTabContent,
 } from "@onecli/ui/components/animated-tabs";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
 import type { AgentOption, PolicyRuleItem, RuleActions } from "./types";
 import { ApplicationRuleForm } from "./application-rule-form";
 import { CustomEndpointForm } from "./custom-endpoint-form";
@@ -26,6 +27,7 @@ interface RuleDialogProps {
   showAgentField?: boolean;
   ruleActions?: RuleActions;
   connectedProviders?: Map<string, string[]>;
+  policyMode?: PolicyMode;
 }
 
 export const RuleDialog = ({
@@ -37,6 +39,7 @@ export const RuleDialog = ({
   showAgentField = true,
   ruleActions,
   connectedProviders,
+  policyMode,
 }: RuleDialogProps) => {
   const isEdit = !!rule;
   const handleClose = () => onOpenChange(false);
@@ -62,6 +65,7 @@ export const RuleDialog = ({
               rule={rule}
               showAgentField={showAgentField}
               ruleActions={ruleActions}
+              policyMode={policyMode}
             />
           </div>
         ) : (
@@ -86,6 +90,7 @@ export const RuleDialog = ({
                 onClose={handleClose}
                 ruleActions={ruleActions}
                 connectedProviders={connectedProviders}
+                policyMode={policyMode}
               />
             </AnimatedTabContent>
             <AnimatedTabContent
@@ -98,6 +103,7 @@ export const RuleDialog = ({
                 agents={agents}
                 showAgentField={showAgentField}
                 ruleActions={ruleActions}
+                policyMode={policyMode}
               />
             </AnimatedTabContent>
           </AnimatedTabs>

--- a/apps/web/src/app/(dashboard)/rules/_components/rules-content.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/rules-content.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { Plus, ShieldOff } from "lucide-react";
+import { Plus, Settings2, Shield, ShieldOff } from "lucide-react";
 import { rules as rulesApi } from "@/lib/api";
 import { queryKeys } from "@/lib/api/keys";
 import { useAgents } from "@/hooks/use-agents";
@@ -14,6 +15,7 @@ import { Separator } from "@onecli/ui/components/separator";
 import { RuleCard } from "./rule-card";
 import { RuleDialog } from "./rule-dialog";
 import { AppPermissionSummary } from "./app-permission-summary";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
 import type { AgentOption, PolicyRuleItem, RuleActions } from "./types";
 export type { PolicyRuleItem, AgentOption, RuleActions } from "./types";
 
@@ -22,6 +24,8 @@ interface RulesContentProps {
   ruleActions?: RuleActions;
   pageScope?: "project" | "organization";
   showAgentField?: boolean;
+  policyMode?: PolicyMode;
+  settingsHref?: string;
 }
 
 const isAppPermissionRule = (rule: PolicyRuleItem) =>
@@ -35,7 +39,10 @@ export const RulesContent = ({
   ruleActions,
   pageScope = "project",
   showAgentField = true,
+  policyMode = "allow",
+  settingsHref,
 }: RulesContentProps) => {
+  const isDenyMode = policyMode === "deny";
   const { data: rules = [], isPending: loading } = useQuery<PolicyRuleItem[]>({
     queryKey: [...queryKeys.rules.list(), pageScope],
     queryFn: (getRules ?? rulesApi.list) as () => Promise<PolicyRuleItem[]>,
@@ -110,14 +117,38 @@ export const RulesContent = ({
 
       {customRules.length === 0 && appPermRules.length === 0 ? (
         <Card className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-amber-500/10">
-            <ShieldOff className="size-6 text-amber-500" />
-          </div>
-          <p className="text-sm font-medium">YOLO mode</p>
-          <p className="text-muted-foreground mt-1 max-w-xs text-xs">
-            Your agents have unrestricted access to all assigned secrets. Add a
-            rule to block specific endpoints or set boundaries.
-          </p>
+          {isDenyMode ? (
+            <>
+              <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-blue-500/10">
+                <Shield className="size-6 text-blue-500" />
+              </div>
+              <p className="text-sm font-medium">Lockdown mode</p>
+              <p className="text-muted-foreground mt-1 max-w-xs text-xs">
+                All traffic is blocked by default. Add an allow rule to permit
+                specific endpoints your agents need.
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-amber-500/10">
+                <ShieldOff className="size-6 text-amber-500" />
+              </div>
+              <p className="text-sm font-medium">YOLO mode</p>
+              <p className="text-muted-foreground mt-1 max-w-xs text-xs">
+                Your agents have unrestricted access to all assigned secrets.
+                Add a rule to block specific endpoints or set boundaries.
+              </p>
+            </>
+          )}
+          {settingsHref && (
+            <Link
+              href={settingsHref}
+              className="text-muted-foreground hover:text-foreground mt-4 inline-flex items-center gap-1.5 text-xs transition-colors"
+            >
+              <Settings2 className="size-3" />
+              Change policy mode
+            </Link>
+          )}
         </Card>
       ) : (
         <>
@@ -131,6 +162,7 @@ export const RulesContent = ({
                   readOnly={isInherited(rule)}
                   badge={isInherited(rule) ? "Organization" : undefined}
                   ruleActions={ruleActions}
+                  policyMode={policyMode}
                 />
               ))}
             </div>
@@ -164,6 +196,7 @@ export const RulesContent = ({
         showAgentField={showAgentField}
         ruleActions={ruleActions}
         connectedProviders={connectedProviders}
+        policyMode={policyMode}
       />
     </div>
   );

--- a/apps/web/src/app/(dashboard)/rules/page.tsx
+++ b/apps/web/src/app/(dashboard)/rules/page.tsx
@@ -1,13 +1,17 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
 import { PageHeader } from "@dashboard/page-header";
+import { getPolicyMode } from "@/lib/actions/policy-mode";
 import { RulesContent } from "./_components/rules-content";
 
 export const metadata: Metadata = {
   title: "Rules",
 };
 
-export default function RulesPage() {
+export default async function RulesPage() {
+  const policyMode = await getPolicyMode();
+
   return (
     <div className="flex flex-1 flex-col gap-6">
       <PageHeader
@@ -15,7 +19,10 @@ export default function RulesPage() {
         description="Control what your agents can and cannot access."
       />
       <Suspense>
-        <RulesContent />
+        <RulesContent
+          policyMode={policyMode as PolicyMode}
+          settingsHref="/settings/policy"
+        />
       </Suspense>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/settings/policy/_components/policy-mode-toggle.tsx
+++ b/apps/web/src/app/(dashboard)/settings/policy/_components/policy-mode-toggle.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Shield, ShieldOff } from "lucide-react";
+import { Card, CardContent } from "@onecli/ui/components/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@onecli/ui/components/alert-dialog";
+import { cn } from "@onecli/ui/lib/utils";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
+import { updatePolicyMode } from "@/lib/actions/policy-mode";
+
+const modes: {
+  value: PolicyMode;
+  label: string;
+  description: string;
+  icon: typeof Shield;
+}[] = [
+  {
+    value: "allow",
+    label: "Allow by default",
+    description:
+      "All traffic is allowed by default. Rules define what to block.",
+    icon: ShieldOff,
+  },
+  {
+    value: "deny",
+    label: "Deny by default",
+    description:
+      "All traffic is blocked by default. Rules define what to allow.",
+    icon: Shield,
+  },
+];
+
+interface PolicyModeToggleProps {
+  policyMode: PolicyMode;
+}
+
+export const PolicyModeToggle = ({ policyMode }: PolicyModeToggleProps) => {
+  const [mode, setMode] = useState(policyMode);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const handleSelect = (newMode: PolicyMode) => {
+    if (pending || newMode === mode) return;
+
+    if (newMode === "deny") {
+      setConfirmOpen(true);
+      return;
+    }
+
+    doSave(newMode);
+  };
+
+  const doSave = (newMode: PolicyMode) => {
+    setMode(newMode);
+    startTransition(async () => {
+      try {
+        await updatePolicyMode(newMode);
+        toast.success(
+          newMode === "deny"
+            ? "Default-deny mode enabled"
+            : "Default-allow mode restored",
+        );
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to update policy mode",
+        );
+        setMode(policyMode);
+      }
+    });
+  };
+
+  return (
+    <>
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <div className="grid grid-cols-2 gap-3">
+            {modes.map((opt) => {
+              const isSelected = mode === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => handleSelect(opt.value)}
+                  disabled={pending}
+                  className={cn(
+                    "flex flex-col gap-2 rounded-lg border p-4 text-left transition-colors",
+                    isSelected
+                      ? "border-brand bg-brand/5"
+                      : "hover:bg-muted/50 hover:border-foreground/20",
+                    pending && "cursor-not-allowed opacity-60",
+                  )}
+                >
+                  <span className="flex items-center gap-2 text-sm font-medium">
+                    <opt.icon
+                      className={cn(
+                        "size-4",
+                        isSelected ? "text-brand" : "text-muted-foreground",
+                      )}
+                    />
+                    {opt.label}
+                  </span>
+                  <span className="text-muted-foreground text-xs leading-relaxed">
+                    {opt.description}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Enable deny-by-default mode?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3">
+                <p>
+                  Switching to deny-by-default will{" "}
+                  <strong>immediately block all agent traffic</strong> that
+                  doesn&apos;t have an explicit allow rule.
+                </p>
+                <p>
+                  This includes all API calls, app integrations, and secret
+                  injections. You will need to create allow rules for every
+                  endpoint your agents use.
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => doSave("deny")}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              I understand, enable deny mode
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+};

--- a/apps/web/src/app/(dashboard)/settings/policy/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/policy/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
+import { PageHeader } from "@dashboard/page-header";
+import { getPolicyMode } from "@/lib/actions/policy-mode";
+import { PolicyModeToggle } from "./_components/policy-mode-toggle";
+
+export const metadata: Metadata = {
+  title: "Policy",
+};
+
+export default async function PolicyPage() {
+  const policyMode = await getPolicyMode();
+
+  return (
+    <div className="flex flex-1 flex-col gap-4">
+      <PageHeader
+        title="Default Policy"
+        description="Control how traffic is handled when no rules match."
+      />
+      <PolicyModeToggle policyMode={policyMode as PolicyMode} />
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -19,7 +19,7 @@ export default function Home() {
 
     resolveHomeRedirect()
       .then((url) => router.replace(url))
-      .catch(() => router.replace("/overview"));
+      .catch(() => router.replace("/auth/login"));
   }, [isLoading, isAuthenticated, router]);
 
   return (

--- a/apps/web/src/lib/actions/policy-mode.ts
+++ b/apps/web/src/lib/actions/policy-mode.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { db } from "@onecli/db";
+import { revalidatePath } from "next/cache";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
+import { resolveProjectContext } from "@/lib/actions/resolve-user";
+import { invalidateGatewayCacheForOrg } from "@onecli/api/lib/gateway-invalidate";
+
+export const getPolicyMode = async (): Promise<PolicyMode> => {
+  const { organizationId } = await resolveProjectContext();
+  const org = await db.organization.findUniqueOrThrow({
+    where: { id: organizationId },
+    select: { policyMode: true },
+  });
+  return org.policyMode as PolicyMode;
+};
+
+export const updatePolicyMode = async (
+  policyMode: PolicyMode,
+): Promise<void> => {
+  const { organizationId } = await resolveProjectContext();
+  await db.organization.update({
+    where: { id: organizationId },
+    data: { policyMode },
+  });
+  invalidateGatewayCacheForOrg(organizationId);
+  revalidatePath("/", "layout");
+};

--- a/apps/web/src/lib/actions/rules.ts
+++ b/apps/web/src/lib/actions/rules.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { db } from "@onecli/db";
+import type { PolicyMode } from "@onecli/api/validations/policy-rule";
 import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import {
   listPolicyRules,
@@ -19,6 +21,7 @@ import {
 } from "@onecli/api/services/audit-service";
 import {
   getAppPermissionDefinition,
+  mapRuleActionToPermission,
   type AppPermissionLevel,
 } from "@onecli/api/apps/app-permissions";
 import type { RuleCondition } from "@onecli/api/validations/policy-rule";
@@ -92,7 +95,7 @@ export const getAppPermissionStates = async (
     const meta = rule.metadata as { toolId?: string } | null;
     if (meta?.toolId) {
       states[meta.toolId] = {
-        permission: rule.action === "block" ? "block" : "manual_approval",
+        permission: mapRuleActionToPermission(rule.action),
         conditions: Array.isArray(rule.conditions) ? rule.conditions : [],
       };
     }
@@ -105,7 +108,8 @@ export const setAppPermissions = async (
   changes: { toolId: string; permission: AppPermissionLevel }[],
   conditions?: RuleCondition[],
 ): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveProjectContext();
+  const { userId, userEmail, projectId, organizationId } =
+    await resolveProjectContext();
   const def = getAppPermissionDefinition(provider);
   if (!def)
     throw new Error(`No permission definition for provider: ${provider}`);
@@ -122,6 +126,11 @@ export const setAppPermissions = async (
   const appName =
     provider.charAt(0).toUpperCase() + provider.slice(1).replace(/-/g, " ");
 
+  const org = await db.organization.findUniqueOrThrow({
+    where: { id: organizationId },
+    select: { policyMode: true },
+  });
+
   await withAudit(
     () =>
       setAppPermissionsService(
@@ -130,6 +139,7 @@ export const setAppPermissions = async (
         appName,
         resolvedChanges,
         conditions,
+        org.policyMode as PolicyMode,
       ),
     (result) => ({
       projectId,

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -51,6 +51,7 @@ export const getSettingsSections = (
   {
     label: "Security",
     items: [
+      { title: "Policy", url: "/settings/policy", icon: Shield },
       { title: "Encryption", url: "/settings/encryption", icon: ShieldCheck },
     ],
   },

--- a/packages/api/src/apps/app-permissions/index.ts
+++ b/packages/api/src/apps/app-permissions/index.ts
@@ -4,6 +4,7 @@ export type {
   AppPermissionLevel,
   AppPermissionDefinition,
 } from "./types";
+export { mapRuleActionToPermission } from "./types";
 
 import type { AppPermissionDefinition } from "./types";
 import { awsPermissions } from "./aws";

--- a/packages/api/src/apps/app-permissions/types.ts
+++ b/packages/api/src/apps/app-permissions/types.ts
@@ -15,6 +15,15 @@ export interface AppToolGroup {
 
 export type AppPermissionLevel = "allow" | "manual_approval" | "block";
 
+export const mapRuleActionToPermission = (
+  action: string,
+): AppPermissionLevel =>
+  action === "block"
+    ? "block"
+    : action === "allow"
+      ? "allow"
+      : "manual_approval";
+
 export interface AppPermissionDefinition {
   provider: string;
   groups: AppToolGroup[];

--- a/packages/api/src/services/audit-service.ts
+++ b/packages/api/src/services/audit-service.ts
@@ -25,6 +25,7 @@ export const AUDIT_SERVICES = {
   APP_CONFIG: "app-config",
   DEPLOYMENT: "deployment",
   PROJECT: "project",
+  ORGANIZATION: "organization",
 } as const;
 
 export const AUDIT_STATUS = {

--- a/packages/api/src/services/policy-rule-service.ts
+++ b/packages/api/src/services/policy-rule-service.ts
@@ -11,6 +11,7 @@ import {
   type CreatePolicyRuleInput,
   type UpdatePolicyRuleInput,
   type RuleCondition,
+  type PolicyMode,
 } from "../validations/policy-rule";
 import type { AppTool, AppPermissionLevel } from "../apps/app-permissions";
 
@@ -206,7 +207,9 @@ export const setAppPermissionsService = async (
   appName: string,
   changes: AppPermissionChange[],
   conditions?: RuleCondition[],
+  policyMode?: PolicyMode,
 ) => {
+  const isDenyMode = policyMode === "deny";
   const existing = await listAppPermissionRules(scope, provider);
 
   const existingByToolId = new Map<string, typeof existing>();
@@ -236,6 +239,35 @@ export const setAppPermissionsService = async (
     const existingRules = existingByToolId.get(change.toolId) ?? [];
 
     if (change.permission === "allow") {
+      if (isDenyMode) {
+        // Deny mode: "allow" = create an explicit allow rule
+        if (existingRules.length > 0) {
+          for (const rule of existingRules) {
+            if (rule.action !== "allow" || conditionsProvided) {
+              toUpdate.push({ ruleId: rule.id, action: "allow" });
+            }
+          }
+          const existingPatterns = new Set(
+            existingRules.map((r) => r.pathPattern),
+          );
+          for (const pattern of allPatterns(change.tool)) {
+            if (!existingPatterns.has(pattern)) {
+              toCreateRules.push({ change, pathPattern: pattern });
+            }
+          }
+        } else {
+          for (const pattern of allPatterns(change.tool)) {
+            toCreateRules.push({ change, pathPattern: pattern });
+          }
+        }
+      } else {
+        // Allow mode: "allow" = delete the restriction rule (default = allowed)
+        for (const rule of existingRules) {
+          toDelete.push(rule.id);
+        }
+      }
+    } else if (change.permission === "block" && isDenyMode) {
+      // Deny mode: "block" = delete the allow rule (default = blocked)
       for (const rule of existingRules) {
         toDelete.push(rule.id);
       }

--- a/packages/api/src/services/request-log-service.ts
+++ b/packages/api/src/services/request-log-service.ts
@@ -29,6 +29,11 @@ export const isRateLimitedRequest = (log: RequestLogEntry): boolean => {
   return data?.decision === DECISION_RATE_LIMITED;
 };
 
+export const isDefaultDenied = (log: RequestLogEntry): boolean => {
+  const data = log.extraData as Record<string, unknown> | null;
+  return data?.decision === "blocked_by_default_policy";
+};
+
 export const getBlockedByRule = (log: RequestLogEntry): string | null => {
   const data = log.extraData as Record<string, unknown> | null;
   if (typeof data?.[BLOCKED_BY_RULE_KEY] === "string") {

--- a/packages/api/src/validations/policy-rule.ts
+++ b/packages/api/src/validations/policy-rule.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const policyModeSchema = z.enum(["allow", "deny"]);
+export type PolicyMode = z.infer<typeof policyModeSchema>;
+
 export const ruleConditionSchema = z.object({
   target: z.enum(["body"]),
   operator: z.enum(["contains"]),
@@ -15,7 +18,7 @@ export const createPolicyRuleSchema = z
     hostPattern: z.string().min(1).max(1000),
     pathPattern: z.string().max(1000).optional(),
     method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).optional(),
-    action: z.enum(["block", "rate_limit", "manual_approval"]),
+    action: z.enum(["block", "rate_limit", "manual_approval", "allow"]),
     enabled: z.boolean(),
     agentId: z.string().optional(),
     rateLimit: z.number().int().min(1).max(1_000_000).optional(),
@@ -48,7 +51,9 @@ export const updatePolicyRuleSchema = z
       .enum(["GET", "POST", "PUT", "PATCH", "DELETE"])
       .nullable()
       .optional(),
-    action: z.enum(["block", "rate_limit", "manual_approval"]).optional(),
+    action: z
+      .enum(["block", "rate_limit", "manual_approval", "allow"])
+      .optional(),
     enabled: z.boolean().optional(),
     agentId: z.string().nullable().optional(),
     rateLimit: z.number().int().min(1).max(1_000_000).nullable().optional(),

--- a/packages/db/prisma/migrations/20260525165914_add_org_policy_mode/migration.sql
+++ b/packages/db/prisma/migrations/20260525165914_add_org_policy_mode/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "policy_mode" TEXT NOT NULL DEFAULT 'allow';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Organization {
   stripeCustomerId   String?  @unique @map("stripe_customer_id")
   subscriptionStatus String   @default("free") @map("subscription_status")
   awsExternalId      String?  @map("aws_external_id")
+  policyMode         String   @default("allow") @map("policy_mode") // "allow" | "deny"
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 


### PR DESCRIPTION
## Summary

### Policy mode
- Add organization-level policy mode (allow/deny-by-default) with settings UI toggle and gateway enforcement
- New DB migration adds `policy_mode` field to organizations table
- Gateway evaluates policy mode and returns `blocked_by_default_policy` response when no allow rule matches

### Scoped gateway URLs
- `blocked_by_default_policy` response now includes project-scoped dashboard URL (`/p/<id>/rules?create=allow&host=...`)

### Connect param fix
- `useConnectParam` hook now uses `pathname` instead of hardcoded `/connections` when stripping query params, preserving project URL prefix

### Other fixes
- Home page error fallback redirects to `/auth/login` instead of flat `/overview`
- App permission conditions support for rules
- Activity detail dialog shows policy decision
- Custom endpoint wildcard path support in rule forms

## Changed files (37)
- Gateway: policy.rs, response.rs, forward.rs, websocket.rs, connect.rs, db.rs, telemetry_core.rs
- Web: use-connect-param.ts, page.tsx, nav-config.ts, rules components, activity components, policy settings page
- API: policy-rule service/validation, audit-service, app-permissions
- DB: migration + schema