### PR TITLE
fix: use spreadsheets scope to allow editing existing Google Sheets

### DIFF
--- a/packages/api/src/apps/google-sheets.ts
+++ b/packages/api/src/apps/google-sheets.ts
@@ -17,7 +17,7 @@ export const googleSheets: AppDefinition = {
       "email",
       "profile",
       "https://www.googleapis.com/auth/drive.readonly",
-      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/spreadsheets",
     ],
     permissions: [
       {
@@ -27,9 +27,9 @@ export const googleSheets: AppDefinition = {
         access: "read",
       },
       {
-        scope: "https://www.googleapis.com/auth/drive.file",
-        name: "Manage app spreadsheets",
-        description: "Create and edit spreadsheets opened or created by OneCLI",
+        scope: "https://www.googleapis.com/auth/spreadsheets",
+        name: "Edit spreadsheets",
+        description: "Create and edit any of your Google Sheets",
         access: "write",
       },
       {


### PR DESCRIPTION
Summary
- Replaces drive.file scope with spreadsheets scope for Google Sheets write access
- drive.file only allows editing files that OneCLI itself created/opened, which prevents agents from editing existing spreadsheets the user already has
- spreadsheets scope grants edit access to all of the user's Google Sheets, matching what agents actually need

Test plan
- Connect a Google account with the updated scopes
- Verify an agent can read an existing spreadsheet (via drive.readonly)
- Verify an agent can edit an existing spreadsheet the user already had (previously broken)
- Verify an agent can create a new spreadsheet
