### PR TITLE
fix: comprehensive logging overhaul with span-based context

### DIFF
--- a/apps/gateway/src/approval.rs
+++ b/apps/gateway/src/approval.rs
@@ -34,6 +34,7 @@ const BROADCAST_CAPACITY: usize = 16;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct PendingApproval {
     pub id: String,
+    pub organization_id: String,
     pub project_id: String,
     pub agent_id: String,
     pub agent_name: String,
@@ -104,15 +105,24 @@ impl DecisionReceiver {
 /// (approve, deny, or timeout) to prevent double-cleanup.
 pub(crate) struct ApprovalGuard {
     approval_id: Option<String>,
+    org_id: String,
+    project_id: String,
     store: Arc<dyn ApprovalStore>,
     log_id: Option<String>,
     pool: Option<sqlx::PgPool>,
 }
 
 impl ApprovalGuard {
-    pub fn new(id: String, store: Arc<dyn ApprovalStore>) -> Self {
+    pub fn new(
+        id: String,
+        org_id: String,
+        project_id: String,
+        store: Arc<dyn ApprovalStore>,
+    ) -> Self {
         Self {
             approval_id: Some(id),
+            org_id,
+            project_id,
             store,
             log_id: None,
             pool: None,
@@ -136,10 +146,12 @@ impl Drop for ApprovalGuard {
     fn drop(&mut self) {
         if let Some(id) = self.approval_id.take() {
             let store = Arc::clone(&self.store);
+            let org_id = self.org_id.clone();
+            let project_id = self.project_id.clone();
             let log_id = self.log_id.take();
             let pool = self.pool.take();
             tokio::spawn(async move {
-                store.remove(&id).await;
+                store.remove(&org_id, &project_id, &id).await;
                 if let (Some(log_id), Some(pool)) = (log_id, pool) {
                     if let Err(e) = sqlx::query(
                         "UPDATE request_logs \
@@ -169,7 +181,7 @@ pub(crate) trait ApprovalStore: Send + Sync {
     ///
     /// **Must be called before `store()`** to prevent a race condition where
     /// the SDK submits a decision before the gateway starts listening.
-    async fn prepare_wait(&self, id: &str) -> DecisionReceiver;
+    async fn prepare_wait(&self, org_id: &str, project_id: &str, id: &str) -> DecisionReceiver;
 
     /// Store a pending approval and notify long-polling waiters.
     ///
@@ -178,21 +190,32 @@ pub(crate) trait ApprovalStore: Send + Sync {
     async fn store(&self, approval: &PendingApproval) -> anyhow::Result<()>;
 
     /// Get a single pending approval by ID. O(1) lookup.
-    async fn get_pending(&self, id: &str) -> Option<PendingApproval>;
+    async fn get_pending(
+        &self,
+        org_id: &str,
+        project_id: &str,
+        id: &str,
+    ) -> Option<PendingApproval>;
 
     /// List all non-expired pending approvals for a project.
-    async fn list_pending(&self, project_id: &str) -> Vec<PendingApproval>;
+    async fn list_pending(&self, org_id: &str, project_id: &str) -> Vec<PendingApproval>;
 
     /// Remove a pending approval (after decision or expiry).
-    async fn remove(&self, id: &str);
+    async fn remove(&self, org_id: &str, project_id: &str, id: &str);
 
     /// Block until a new approval arrives for this project, or timeout.
     /// Returns `true` if notified, `false` on timeout.
-    async fn wait_for_new(&self, project_id: &str, timeout: Duration) -> bool;
+    async fn wait_for_new(&self, org_id: &str, project_id: &str, timeout: Duration) -> bool;
 
     /// Submit a decision for a pending approval. Wakes the held request.
     /// Returns `true` if the approval was found and decision delivered.
-    async fn submit_decision(&self, id: &str, decision: ApprovalDecision) -> bool;
+    async fn submit_decision(
+        &self,
+        org_id: &str,
+        project_id: &str,
+        id: &str,
+        decision: ApprovalDecision,
+    ) -> bool;
 }
 
 // ── In-memory implementation ───────────────────────────────────────────
@@ -220,7 +243,7 @@ impl InMemoryApprovalStore {
 
 #[async_trait]
 impl ApprovalStore for InMemoryApprovalStore {
-    async fn prepare_wait(&self, id: &str) -> DecisionReceiver {
+    async fn prepare_wait(&self, _org_id: &str, _project_id: &str, id: &str) -> DecisionReceiver {
         let (tx, rx) = watch::channel(None);
         self.decisions.insert(id.to_string(), tx);
         DecisionReceiver { rx }
@@ -230,14 +253,20 @@ impl ApprovalStore for InMemoryApprovalStore {
         self.pending.insert(approval.id.clone(), approval.clone());
 
         // Notify any long-pollers for this project.
-        if let Some(sender) = self.new_notify.get(&approval.project_id) {
+        let notify_key = format!("{}:{}", approval.organization_id, approval.project_id);
+        if let Some(sender) = self.new_notify.get(&notify_key) {
             let _ = sender.send(()); // ok if no receivers
         }
 
         Ok(())
     }
 
-    async fn get_pending(&self, id: &str) -> Option<PendingApproval> {
+    async fn get_pending(
+        &self,
+        _org_id: &str,
+        _project_id: &str,
+        id: &str,
+    ) -> Option<PendingApproval> {
         let entry = self.pending.get(id)?;
         if entry.expires_at > unix_now() {
             Some(entry.value().clone())
@@ -248,7 +277,7 @@ impl ApprovalStore for InMemoryApprovalStore {
         }
     }
 
-    async fn list_pending(&self, project_id: &str) -> Vec<PendingApproval> {
+    async fn list_pending(&self, _org_id: &str, project_id: &str) -> Vec<PendingApproval> {
         let now = unix_now();
         self.pending
             .iter()
@@ -257,18 +286,19 @@ impl ApprovalStore for InMemoryApprovalStore {
             .collect()
     }
 
-    async fn remove(&self, id: &str) {
+    async fn remove(&self, _org_id: &str, _project_id: &str, id: &str) {
         self.pending.remove(id);
         self.decisions.remove(id);
     }
 
-    async fn wait_for_new(&self, project_id: &str, timeout: Duration) -> bool {
+    async fn wait_for_new(&self, org_id: &str, project_id: &str, timeout: Duration) -> bool {
+        let notify_key = format!("{org_id}:{project_id}");
         // Get or create broadcast sender, subscribe, then drop the guard
         // before awaiting (critical: never hold DashMap guard across .await).
         let mut rx = {
             let sender = self
                 .new_notify
-                .entry(project_id.to_string())
+                .entry(notify_key)
                 .or_insert_with(|| broadcast::channel(BROADCAST_CAPACITY).0);
             sender.subscribe()
         }; // guard dropped here — safe to await
@@ -276,7 +306,13 @@ impl ApprovalStore for InMemoryApprovalStore {
         tokio::time::timeout(timeout, rx.recv()).await.is_ok()
     }
 
-    async fn submit_decision(&self, id: &str, decision: ApprovalDecision) -> bool {
+    async fn submit_decision(
+        &self,
+        _org_id: &str,
+        _project_id: &str,
+        id: &str,
+        decision: ApprovalDecision,
+    ) -> bool {
         if let Some((_, tx)) = self.decisions.remove(id) {
             let _ = tx.send(Some(decision));
             self.pending.remove(id);
@@ -348,10 +384,13 @@ mod tests {
         Arc::new(InMemoryApprovalStore::new())
     }
 
+    const TEST_ORG: &str = "org-1";
+
     fn make_approval(id: &str, project_id: &str) -> PendingApproval {
         let now = unix_now();
         PendingApproval {
             id: id.to_string(),
+            organization_id: TEST_ORG.to_string(),
             project_id: project_id.to_string(),
             agent_id: "agent-1".to_string(),
             agent_name: "Test Agent".to_string(),
@@ -370,6 +409,7 @@ mod tests {
     fn make_expired_approval(id: &str, project_id: &str) -> PendingApproval {
         PendingApproval {
             id: id.to_string(),
+            organization_id: TEST_ORG.to_string(),
             project_id: project_id.to_string(),
             agent_id: "agent-1".to_string(),
             agent_name: "Test Agent".to_string(),
@@ -390,10 +430,10 @@ mod tests {
         let store = new_store().await;
         let approval = make_approval("a1", "acc-1");
 
-        let _ = store.prepare_wait("a1").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&approval).await.unwrap();
 
-        let pending = store.list_pending("acc-1").await;
+        let pending = store.list_pending(TEST_ORG, "acc-1").await;
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].id, "a1");
     }
@@ -404,12 +444,12 @@ mod tests {
         let valid = make_approval("a1", "acc-1");
         let expired = make_expired_approval("a2", "acc-1");
 
-        let _ = store.prepare_wait("a1").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&valid).await.unwrap();
-        let _ = store.prepare_wait("a2").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a2").await;
         store.store(&expired).await.unwrap();
 
-        let pending = store.list_pending("acc-1").await;
+        let pending = store.list_pending(TEST_ORG, "acc-1").await;
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].id, "a1");
     }
@@ -419,11 +459,14 @@ mod tests {
         let store = new_store().await;
         let approval = make_approval("a1", "acc-1");
 
-        let _ = store.prepare_wait("a1").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&approval).await.unwrap();
 
-        assert!(store.get_pending("a1").await.is_some());
-        assert!(store.get_pending("nonexistent").await.is_none());
+        assert!(store.get_pending(TEST_ORG, "acc-1", "a1").await.is_some());
+        assert!(store
+            .get_pending(TEST_ORG, "acc-1", "nonexistent")
+            .await
+            .is_none());
     }
 
     #[tokio::test]
@@ -431,10 +474,10 @@ mod tests {
         let store = new_store().await;
         let expired = make_expired_approval("a1", "acc-1");
 
-        let _ = store.prepare_wait("a1").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&expired).await.unwrap();
 
-        assert!(store.get_pending("a1").await.is_none());
+        assert!(store.get_pending(TEST_ORG, "acc-1", "a1").await.is_none());
     }
 
     #[tokio::test]
@@ -442,7 +485,7 @@ mod tests {
         let store = new_store().await;
         let approval = make_approval("a1", "acc-1");
 
-        let rx = store.prepare_wait("a1").await;
+        let rx = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&approval).await.unwrap();
 
         // Submit decision from another task
@@ -450,7 +493,7 @@ mod tests {
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             store2
-                .submit_decision("a1", ApprovalDecision::Approve)
+                .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Approve)
                 .await;
         });
 
@@ -463,13 +506,15 @@ mod tests {
         let store = new_store().await;
         let approval = make_approval("a1", "acc-1");
 
-        let rx = store.prepare_wait("a1").await;
+        let rx = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&approval).await.unwrap();
 
         let store2 = Arc::clone(&store);
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
-            store2.submit_decision("a1", ApprovalDecision::Deny).await;
+            store2
+                .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Deny)
+                .await;
         });
 
         let decision = rx.wait(Duration::from_secs(5)).await;
@@ -481,7 +526,7 @@ mod tests {
         let store = new_store().await;
         let approval = make_approval("a1", "acc-1");
 
-        let rx = store.prepare_wait("a1").await;
+        let rx = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&approval).await.unwrap();
 
         // No decision submitted — should timeout
@@ -495,16 +540,16 @@ mod tests {
         let a1 = make_approval("a1", "acc-1");
         let a2 = make_approval("a2", "acc-2");
 
-        let _ = store.prepare_wait("a1").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&a1).await.unwrap();
-        let _ = store.prepare_wait("a2").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-2", "a2").await;
         store.store(&a2).await.unwrap();
 
-        let pending_1 = store.list_pending("acc-1").await;
+        let pending_1 = store.list_pending(TEST_ORG, "acc-1").await;
         assert_eq!(pending_1.len(), 1);
         assert_eq!(pending_1[0].id, "a1");
 
-        let pending_2 = store.list_pending("acc-2").await;
+        let pending_2 = store.list_pending(TEST_ORG, "acc-2").await;
         assert_eq!(pending_2.len(), 1);
         assert_eq!(pending_2[0].id, "a2");
     }
@@ -514,13 +559,13 @@ mod tests {
         let store = new_store().await;
         let approval = make_approval("a1", "acc-1");
 
-        let _ = store.prepare_wait("a1").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&approval).await.unwrap();
 
-        store.remove("a1").await;
+        store.remove(TEST_ORG, "acc-1", "a1").await;
 
-        assert!(store.get_pending("a1").await.is_none());
-        assert!(store.list_pending("acc-1").await.is_empty());
+        assert!(store.get_pending(TEST_ORG, "acc-1", "a1").await.is_none());
+        assert!(store.list_pending(TEST_ORG, "acc-1").await.is_empty());
     }
 
     #[tokio::test]
@@ -528,19 +573,21 @@ mod tests {
         let store = new_store().await;
         let approval = make_approval("a1", "acc-1");
 
-        let _ = store.prepare_wait("a1").await;
+        let _ = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
         store.store(&approval).await.unwrap();
 
-        store.submit_decision("a1", ApprovalDecision::Approve).await;
+        store
+            .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Approve)
+            .await;
 
-        assert!(store.get_pending("a1").await.is_none());
+        assert!(store.get_pending(TEST_ORG, "acc-1", "a1").await.is_none());
     }
 
     #[tokio::test]
     async fn submit_decision_nonexistent_returns_false() {
         let store = new_store().await;
         let result = store
-            .submit_decision("nonexistent", ApprovalDecision::Approve)
+            .submit_decision(TEST_ORG, "acc-1", "nonexistent", ApprovalDecision::Approve)
             .await;
         assert!(!result);
     }
@@ -553,11 +600,13 @@ mod tests {
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             let approval = make_approval("a1", "acc-1");
-            let _ = store2.prepare_wait("a1").await;
+            let _ = store2.prepare_wait(TEST_ORG, "acc-1", "a1").await;
             store2.store(&approval).await.unwrap();
         });
 
-        let got_new = store.wait_for_new("acc-1", Duration::from_secs(5)).await;
+        let got_new = store
+            .wait_for_new(TEST_ORG, "acc-1", Duration::from_secs(5))
+            .await;
         assert!(got_new);
     }
 
@@ -565,7 +614,7 @@ mod tests {
     async fn wait_for_new_timeout() {
         let store = new_store().await;
         let got_new = store
-            .wait_for_new("acc-1", Duration::from_millis(100))
+            .wait_for_new(TEST_ORG, "acc-1", Duration::from_millis(100))
             .await;
         assert!(!got_new);
     }

--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -65,14 +65,17 @@ pub(crate) struct HostRule {
     pub(crate) intercept: bool,
 }
 
-/// Check whether a `HostRule` matches a given hostname.
-/// Suffix rules match any hostname that ends with the suffix and is strictly longer
-/// (so the bare suffix itself never matches). Exact rules compare the host directly.
-fn host_rule_matches(rule: &HostRule, hostname: &str) -> bool {
-    match rule.pattern {
-        HostPattern::Exact(host) => host == hostname,
-        HostPattern::Suffix(suffix) => hostname.ends_with(suffix) && hostname.len() > suffix.len(),
+impl HostPattern {
+    pub(crate) fn matches(&self, hostname: &str) -> bool {
+        match self {
+            Self::Exact(host) => *host == hostname,
+            Self::Suffix(suffix) => hostname.ends_with(suffix) && hostname.len() > suffix.len(),
+        }
     }
+}
+
+fn host_rule_matches(rule: &HostRule, hostname: &str) -> bool {
+    rule.pattern.matches(hostname)
 }
 
 /// Body format for token refresh requests.
@@ -584,12 +587,6 @@ static APP_PROVIDERS: &[AppProvider] = &[
                 strategy: AuthStrategy::Bearer,
                 intercept: false,
             },
-            HostRule {
-                pattern: HostPattern::Suffix(".atlassian.net"),
-                path_prefix: None,
-                strategy: AuthStrategy::Bearer,
-                intercept: false,
-            },
         ],
         refresh: Some(&ATLASSIAN_REFRESH),
         metadata_headers: &[],
@@ -612,12 +609,6 @@ static APP_PROVIDERS: &[AppProvider] = &[
             HostRule {
                 pattern: HostPattern::Exact("api.atlassian.com"),
                 path_prefix: Some("/oauth/token/accessible-resources"),
-                strategy: AuthStrategy::Bearer,
-                intercept: false,
-            },
-            HostRule {
-                pattern: HostPattern::Suffix(".atlassian.net"),
-                path_prefix: None,
                 strategy: AuthStrategy::Bearer,
                 intercept: false,
             },
@@ -1508,6 +1499,7 @@ pub(crate) async fn refresh_github_app_token(
     private_key_pem: &str,
     app_id: &str,
     installation_id: &str,
+    repositories: Option<&[String]>,
 ) -> anyhow::Result<(String, i64)> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -1537,14 +1529,24 @@ pub(crate) async fn refresh_github_app_token(
     )
     .map_err(|e| anyhow::anyhow!("GitHub App JWT signing failed: {e}"))?;
 
-    let resp = reqwest::Client::new()
+    let mut req = reqwest::Client::new()
         .post(format!(
             "https://api.github.com/app/installations/{installation_id}/access_tokens"
         ))
         .header("Authorization", format!("Bearer {jwt}"))
         .header("Accept", "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28")
-        .header("User-Agent", "onecli-gateway")
+        .header("User-Agent", "onecli-gateway");
+
+    if let Some(repos) = repositories {
+        let bare_names: Vec<&str> = repos
+            .iter()
+            .map(|r| r.rsplit('/').next().unwrap_or(r.as_str()))
+            .collect();
+        req = req.json(&serde_json::json!({ "repositories": bare_names }));
+    }
+
+    let resp = req
         .send()
         .await
         .map_err(|e| anyhow::anyhow!("GitHub App token request failed: {e}"))?;
@@ -1588,6 +1590,7 @@ pub(crate) async fn refresh_github_app_token(
 pub(crate) async fn try_refresh_credentials(
     cred_type: &str,
     creds: &serde_json::Value,
+    _session_policy: Option<&serde_json::Value>,
 ) -> Option<anyhow::Result<(String, i64)>> {
     match cred_type {
         "github_app" => {
@@ -1599,7 +1602,7 @@ pub(crate) async fn try_refresh_credentials(
                     "GitHub App credentials incomplete, cannot refresh"
                 )));
             };
-            Some(refresh_github_app_token(pk, aid, iid).await)
+            Some(refresh_github_app_token(pk, aid, iid, None).await)
         }
         "service_account" => {
             let pk = creds.get("private_key").and_then(|v| v.as_str());
@@ -2004,21 +2007,20 @@ mod tests {
     }
 
     #[test]
-    fn jira_tenant_host_matches() {
+    fn atlassian_net_tenant_host_no_longer_matches() {
         let providers = providers_for_host("mysite.atlassian.net");
-        assert!(providers.contains(&"jira"));
+        assert!(
+            providers.is_empty(),
+            "*.atlassian.net should not match any provider (deprecated)"
+        );
     }
 
     #[test]
-    fn jira_tenant_host_uses_bearer() {
+    fn atlassian_net_tenant_host_produces_no_injections() {
         let injections = build_app_injections("jira", "mysite.atlassian.net", "eyJ0eXAi.test");
-        assert_eq!(injections.len(), 1);
-        assert_eq!(
-            injections[0],
-            Injection::SetHeader {
-                name: "authorization".to_string(),
-                value: "Bearer eyJ0eXAi.test".to_string(),
-            }
+        assert!(
+            injections.is_empty(),
+            "*.atlassian.net should produce no injections (deprecated)"
         );
     }
 

--- a/apps/gateway/src/auth.rs
+++ b/apps/gateway/src/auth.rs
@@ -69,6 +69,7 @@ fn nextauth_secret() -> Option<&'static str> {
 pub(crate) struct AuthUser {
     pub user_id: String,
     pub project_id: String,
+    pub auth_method: String,
 }
 
 impl FromRequestParts<GatewayState> for AuthUser {
@@ -103,6 +104,7 @@ impl FromRequestParts<GatewayState> for AuthUser {
         Ok(Self {
             user_id,
             project_id,
+            auth_method: "session".to_string(),
         })
     }
 }
@@ -126,9 +128,11 @@ async fn validate_api_key(pool: &PgPool, headers: &HeaderMap) -> Option<AuthUser
         .map_err(|e| warn!(error = %e, "api key auth: db error"))
         .ok()??;
 
+    let prefix = token.get(..12).unwrap_or(token);
     Some(AuthUser {
         user_id: api_key.user_id,
         project_id: api_key.project_id,
+        auth_method: format!("api_key:{prefix}"),
     })
 }
 

--- a/apps/gateway/src/cloud_apps.rs
+++ b/apps/gateway/src/cloud_apps.rs
@@ -12,6 +12,7 @@ pub(crate) fn providers() -> &'static [AppProvider] {
 pub(crate) async fn try_refresh_credentials(
     _cred_type: &str,
     _creds: &serde_json::Value,
+    _session_policy: Option<&serde_json::Value>,
 ) -> Option<anyhow::Result<(String, i64)>> {
     None
 }

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -473,8 +473,13 @@ impl PolicyEngine {
         project_id: &str,
         cache: &dyn CacheStore,
     ) -> Result<AppConnectionResult, ConnectError> {
+        let policy_suffix = conn
+            .session_policy
+            .as_ref()
+            .map(|sp| format!(":{sp}"))
+            .unwrap_or_default();
         let cache_key = format!(
-            "app_injection:{organization_id}:{project_id}:{}:{hostname}",
+            "app_injection:{organization_id}:{project_id}:{}:{hostname}{policy_suffix}",
             conn.id
         );
 
@@ -511,7 +516,13 @@ impl PolicyEngine {
         let needs_token = apps::needs_access_token(&conn.provider);
         let (token, expires_at) = if needs_token {
             let Some(resolved) = self
-                .resolve_access_token(&decrypted_json, &conn.provider, project_id, &conn.id)
+                .resolve_access_token(
+                    &decrypted_json,
+                    &conn.provider,
+                    project_id,
+                    &conn.id,
+                    conn.session_policy.as_ref(),
+                )
                 .await
             else {
                 return Ok(AppConnectionResult::NoConnections);
@@ -560,7 +571,11 @@ impl PolicyEngine {
         }
 
         // Parse credentials once for credential headers and host rewrite
-        let creds: Option<serde_json::Value> = serde_json::from_str(&decrypted_json).ok();
+        let creds: Option<serde_json::Value> = serde_json::from_str(&decrypted_json)
+            .map_err(|e| {
+                warn!(provider = %conn.provider, error = %e, "failed to parse app connection credentials JSON");
+            })
+            .ok();
 
         // Inject credential-driven headers (e.g., DD-API-KEY from credentials.apiKey)
         if let Some(ref creds) = creds {
@@ -764,8 +779,13 @@ impl PolicyEngine {
         provider: &str,
         project_id: &str,
         connection_id: &str,
+        session_policy: Option<&serde_json::Value>,
     ) -> Option<(String, Option<i64>)> {
-        let mut creds: serde_json::Value = serde_json::from_str(json).ok()?;
+        let mut creds: serde_json::Value = serde_json::from_str(json)
+            .map_err(|e| {
+                warn!(provider = %provider, error = %e, "failed to parse access token credentials JSON");
+            })
+            .ok()?;
 
         let mut token = creds
             .get("access_token")
@@ -774,6 +794,13 @@ impl PolicyEngine {
 
         let mut effective_expires_at = creds.get("expires_at").and_then(|v| v.as_i64());
 
+        // Any non-empty session policy means scoped access is required.
+        // Provider-specific interpretation (e.g. GitHub repos) is handled by
+        // cloud_apps::try_refresh_credentials, not here.
+        let needs_scoped_token = session_policy
+            .and_then(|sp| sp.as_object())
+            .is_some_and(|obj| !obj.is_empty());
+
         // Check if token is expired and needs refresh
         if let Some(expires_at) = effective_expires_at {
             let now = std::time::SystemTime::now()
@@ -781,16 +808,17 @@ impl PolicyEngine {
                 .expect("system clock before UNIX epoch")
                 .as_secs() as i64;
 
-            if expires_at < now {
+            if expires_at < now || needs_scoped_token {
                 let cred_type = creds.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
                 // Try cloud-specific refresh first, then shared credential types
                 let refresh_result = if let Some(r) =
-                    crate::cloud_apps::try_refresh_credentials(cred_type, &creds).await
+                    crate::cloud_apps::try_refresh_credentials(cred_type, &creds, session_policy)
+                        .await
                 {
                     Some(r)
                 } else {
-                    apps::try_refresh_credentials(cred_type, &creds).await
+                    apps::try_refresh_credentials(cred_type, &creds, session_policy).await
                 };
 
                 if let Some(result) = refresh_result {
@@ -800,10 +828,14 @@ impl PolicyEngine {
                             token = Some(new_token.clone());
                             effective_expires_at = Some(new_expires_at);
 
-                            creds["access_token"] = serde_json::Value::String(new_token);
-                            creds["expires_at"] = serde_json::json!(new_expires_at);
-                            self.persist_refreshed_credentials(connection_id, provider, &creds)
-                                .await;
+                            if needs_scoped_token {
+                                debug!(provider = %provider, "scoped token generated, skipping persist");
+                            } else {
+                                creds["access_token"] = serde_json::Value::String(new_token);
+                                creds["expires_at"] = serde_json::json!(new_expires_at);
+                                self.persist_refreshed_credentials(connection_id, provider, &creds)
+                                    .await;
+                            }
                         }
                         Err(e) => {
                             debug!(provider = %provider, cred_type, error = ?e, "credential refresh failed");
@@ -907,8 +939,15 @@ impl PolicyEngine {
 
         // clientSecret is in credentials (encrypted)
         let encrypted = config.credentials.as_deref()?;
-        let decrypted = self.crypto.decrypt(encrypted).await.ok()?;
-        let secrets: serde_json::Value = serde_json::from_str(&decrypted).ok()?;
+        let decrypted = self
+            .crypto
+            .decrypt(encrypted)
+            .await
+            .map_err(|e| warn!(error = %e, "failed to decrypt BYOC credentials"))
+            .ok()?;
+        let secrets: serde_json::Value = serde_json::from_str(&decrypted)
+            .map_err(|e| warn!(error = %e, "failed to parse BYOC credentials JSON"))
+            .ok()?;
         let client_secret = secrets
             .get("clientSecret")
             .and_then(|v| v.as_str())

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -65,11 +65,19 @@ pub(crate) struct UserRow {
     pub id: String,
 }
 
-/// An API key row from the `api_keys` table.
+/// An API key row from the `api_keys` table (project-scoped).
 #[derive(Debug, FromRow)]
 pub(crate) struct ApiKeyRow {
     pub user_id: String,
     pub project_id: String,
+}
+
+/// An org-scoped API key row from the `api_keys` table.
+#[cfg(feature = "cloud")]
+#[derive(Debug, FromRow)]
+pub(crate) struct OrgApiKeyRow {
+    pub user_id: String,
+    pub organization_id: String,
 }
 
 /// A vault connection row from the `vault_connections` table.
@@ -130,6 +138,38 @@ pub(crate) async fn find_api_key(pool: &PgPool, key: &str) -> Result<Option<ApiK
     .fetch_optional(pool)
     .await
     .context("querying api_keys by key")
+}
+
+/// Look up an org-scoped API key (`oc_org_...`) and return its user_id and organization_id.
+#[cfg(feature = "cloud")]
+pub(crate) async fn find_org_api_key(pool: &PgPool, key: &str) -> Result<Option<OrgApiKeyRow>> {
+    sqlx::query_as::<_, OrgApiKeyRow>(
+        r#"SELECT user_id, organization_id
+           FROM api_keys
+           WHERE key = $1 AND scope = 'organization' AND organization_id IS NOT NULL
+           LIMIT 1"#,
+    )
+    .bind(key)
+    .fetch_optional(pool)
+    .await
+    .context("querying org api_keys by key")
+}
+
+/// Verify that a project belongs to the given organization.
+#[cfg(feature = "cloud")]
+pub(crate) async fn verify_project_in_org(
+    pool: &PgPool,
+    project_id: &str,
+    organization_id: &str,
+) -> Result<bool> {
+    let row: Option<(String,)> =
+        sqlx::query_as(r#"SELECT id FROM projects WHERE id = $1 AND organization_id = $2 LIMIT 1"#)
+            .bind(project_id)
+            .bind(organization_id)
+            .fetch_optional(pool)
+            .await
+            .context("verifying project belongs to organization")?;
+    Ok(row.is_some())
 }
 
 /// Look up an agent by its access token.
@@ -282,6 +322,7 @@ pub(crate) struct AppConnectionRow {
     pub credentials: Option<String>,
     pub label: Option<String>,
     pub metadata: Option<serde_json::Value>,
+    pub session_policy: Option<serde_json::Value>,
 }
 
 /// Find all connected app connections for a given project.
@@ -290,7 +331,7 @@ pub(crate) async fn find_app_connections_by_project(
     project_id: &str,
 ) -> Result<Vec<AppConnectionRow>> {
     sqlx::query_as::<_, AppConnectionRow>(
-        r#"SELECT id, provider, credentials, label, metadata FROM app_connections WHERE project_id = $1 AND status = 'connected'"#,
+        r#"SELECT id, provider, credentials, label, metadata, NULL::jsonb AS session_policy FROM app_connections WHERE project_id = $1 AND status = 'connected'"#,
     )
     .bind(project_id)
     .fetch_all(pool)
@@ -304,7 +345,7 @@ pub(crate) async fn find_app_connections_by_agent(
     agent_id: &str,
 ) -> Result<Vec<AppConnectionRow>> {
     sqlx::query_as::<_, AppConnectionRow>(
-        r#"SELECT ac.id, ac.provider, ac.credentials, ac.label, ac.metadata
+        r#"SELECT ac.id, ac.provider, ac.credentials, ac.label, ac.metadata, aac.session_policy
            FROM app_connections ac
            INNER JOIN agent_app_connections aac ON ac.id = aac.app_connection_id
            WHERE aac.agent_id = $1 AND ac.status = 'connected'"#,
@@ -321,7 +362,7 @@ pub(crate) async fn find_app_connections_by_org(
     organization_id: &str,
 ) -> Result<Vec<AppConnectionRow>> {
     sqlx::query_as::<_, AppConnectionRow>(
-        r#"SELECT id, provider, credentials, label, metadata
+        r#"SELECT id, provider, credentials, label, metadata, NULL::jsonb AS session_policy
            FROM app_connections
            WHERE organization_id = $1 AND scope = 'organization' AND status = 'connected'"#,
     )

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -19,6 +19,7 @@ mod body;
 mod cloud_response;
 mod finalizers;
 pub(crate) mod forward;
+mod hints;
 #[cfg(not(feature = "cloud"))]
 mod hooks;
 #[cfg(feature = "cloud")]
@@ -44,7 +45,7 @@ use hyper_util::rt::TokioIo;
 use tokio::net::{TcpListener, TcpStream};
 use tower::ServiceExt;
 use tower_http::cors::CorsLayer;
-use tracing::{info, warn};
+use tracing::{info, info_span, warn, Instrument};
 
 use crate::approval::{ApprovalDecision, ApprovalStore, APPROVAL_TIMEOUT_SECS};
 use crate::auth::AuthUser;
@@ -293,39 +294,42 @@ async fn invalidate_cache(
     auth: AuthUser,
     State(state): State<GatewayState>,
 ) -> impl axum::response::IntoResponse {
-    // Clear injection cache first, then connect cache. This ordering ensures
-    // a concurrent request that re-resolves the connect cache also re-resolves
-    // injections (since injection cache is already cleared).
-    // Cache keys include org_id — look it up once for both prefixes
-    let org_id = match db::find_organization_id_by_project(
-        &state.policy_engine.pool,
-        &auth.project_id,
-    )
-    .await
-    {
-        Ok(Some(oid)) => oid,
-        other => {
-            warn!(
-                project_id = %auth.project_id,
-                error = ?other.err(),
-                "cache invalidation: failed to resolve org_id; using broad prefix"
-            );
-            String::new()
-        }
-    };
+    let span = info_span!("cache_invalidate",
+        project_id = %auth.project_id,
+        user_id = %auth.user_id,
+        auth_method = %auth.auth_method,
+    );
+    async move {
+        let org_id =
+            match db::find_organization_id_by_project(&state.policy_engine.pool, &auth.project_id)
+                .await
+            {
+                Ok(Some(oid)) => oid,
+                other => {
+                    warn!(
+                        error = ?other.err(),
+                        "cache invalidation: failed to resolve org_id; using broad prefix"
+                    );
+                    String::new()
+                }
+            };
 
-    state
-        .cache
-        .del_by_prefix(&format!("app_injection:{org_id}:{}:", auth.project_id))
-        .await;
-    state
-        .cache
-        .del_by_prefix(&format!("connect:{org_id}:{}:", auth.project_id))
-        .await;
-    (
-        StatusCode::OK,
-        axum::Json(serde_json::json!({ "invalidated": true })),
-    )
+        state
+            .cache
+            .del_by_prefix(&format!("app_injection:{org_id}:{}:", auth.project_id))
+            .await;
+        state
+            .cache
+            .del_by_prefix(&format!("connect:{org_id}:{}:", auth.project_id))
+            .await;
+        info!("cache invalidated");
+        (
+            StatusCode::OK,
+            axum::Json(serde_json::json!({ "invalidated": true })),
+        )
+    }
+    .instrument(span)
+    .await
 }
 
 /// Query parameters for the pending approvals endpoint.
@@ -344,43 +348,64 @@ async fn get_pending_approvals(
     State(state): State<GatewayState>,
     axum::extract::Query(params): axum::extract::Query<PendingParams>,
 ) -> impl axum::response::IntoResponse {
-    let exclude: std::collections::HashSet<&str> = params
-        .exclude
-        .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let span = info_span!("approval_poll",
+        project_id = %auth.project_id,
+        user_id = %auth.user_id,
+        auth_method = %auth.auth_method,
+    );
+    async move {
+        let org_id = db::find_organization_id_by_project(&state.policy_engine.pool, &auth.project_id)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default();
 
-    let mut pending = state.approval_store.list_pending(&auth.project_id).await;
-    pending.retain(|a| !exclude.contains(a.id.as_str()));
+        let exclude: std::collections::HashSet<&str> = params
+            .exclude
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
 
-    if pending.is_empty() {
-        let got_new = state
-            .approval_store
-            .wait_for_new(&auth.project_id, std::time::Duration::from_secs(30))
-            .await;
-        if got_new {
-            let mut fresh = state.approval_store.list_pending(&auth.project_id).await;
-            fresh.retain(|a| !exclude.contains(a.id.as_str()));
-            pending = fresh;
+        info!(exclude_count = exclude.len(), "approval poll started");
+
+        let mut pending = state.approval_store.list_pending(&org_id, &auth.project_id).await;
+        pending.retain(|a| !exclude.contains(a.id.as_str()));
+
+        let mut long_polled = false;
+        if pending.is_empty() {
+            long_polled = true;
+            let got_new = state
+                .approval_store
+                .wait_for_new(&org_id, &auth.project_id, std::time::Duration::from_secs(30))
+                .await;
+            if got_new {
+                let mut fresh = state.approval_store.list_pending(&org_id, &auth.project_id).await;
+                fresh.retain(|a| !exclude.contains(a.id.as_str()));
+                pending = fresh;
+            }
         }
-    }
 
-    axum::Json(serde_json::json!({
-        "requests": pending.iter().map(|a| serde_json::json!({
-            "id": a.id,
-            "method": a.method,
-            "url": format!("{}://{}{}", a.scheme, a.host, a.path),
-            "host": a.host,
-            "path": a.path,
-            "headers": a.headers,
-            "bodyPreview": a.body_preview,
-            "agent": { "id": a.agent_id, "name": a.agent_name, "externalId": a.agent_identifier },
-            "createdAt": format_unix_ts(a.created_at),
-            "expiresAt": format_unix_ts(a.expires_at),
-        })).collect::<Vec<_>>(),
-        "timeoutSeconds": APPROVAL_TIMEOUT_SECS,
-    }))
+        info!(count = pending.len(), long_polled, "approval poll completed");
+
+        axum::Json(serde_json::json!({
+            "requests": pending.iter().map(|a| serde_json::json!({
+                "id": a.id,
+                "method": a.method,
+                "url": format!("{}://{}{}", a.scheme, a.host, a.path),
+                "host": a.host,
+                "path": a.path,
+                "headers": a.headers,
+                "bodyPreview": a.body_preview,
+                "agent": { "id": a.agent_id, "name": a.agent_name, "externalId": a.agent_identifier },
+                "createdAt": format_unix_ts(a.created_at),
+                "expiresAt": format_unix_ts(a.expires_at),
+            })).collect::<Vec<_>>(),
+            "timeoutSeconds": APPROVAL_TIMEOUT_SECS,
+        }))
+    }
+    .instrument(span)
+    .await
 }
 
 /// Submit a decision for a pending manual approval request.
@@ -390,50 +415,66 @@ async fn submit_approval_decision(
     axum::extract::Path(approval_id): axum::extract::Path<String>,
     axum::Json(body): axum::Json<DecisionBody>,
 ) -> impl axum::response::IntoResponse {
-    // O(1) lookup — verify approval exists and belongs to this project.
-    match state.approval_store.get_pending(&approval_id).await {
-        Some(a) if a.project_id == auth.project_id => {}
-        _ => {
-            return (
-                StatusCode::NOT_FOUND,
-                axum::Json(serde_json::json!({ "error": "approval_not_found" })),
+    let span = info_span!("approval_decision",
+        project_id = %auth.project_id,
+        user_id = %auth.user_id,
+        auth_method = %auth.auth_method,
+        approval_id = %approval_id,
+    );
+    async move {
+        let org_id =
+            db::find_organization_id_by_project(&state.policy_engine.pool, &auth.project_id)
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+
+        // O(1) lookup — verify approval exists and belongs to this project.
+        match state
+            .approval_store
+            .get_pending(&org_id, &auth.project_id, &approval_id)
+            .await
+        {
+            Some(a) if a.project_id == auth.project_id => {}
+            _ => {
+                warn!("approval decision rejected: not found or wrong project");
+                return (
+                    StatusCode::NOT_FOUND,
+                    axum::Json(serde_json::json!({ "error": "approval_not_found" })),
+                );
+            }
+        }
+
+        let decision_str = match body.decision {
+            ApprovalDecision::Approve => "approve",
+            ApprovalDecision::Deny => "deny",
+        };
+
+        info!(decision = decision_str, "approval decision submitted");
+
+        let delivered = state
+            .approval_store
+            .submit_decision(&org_id, &auth.project_id, &approval_id, body.decision)
+            .await;
+
+        if delivered {
+            (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({ "success": true })),
+            )
+        } else {
+            warn!(
+                decision = decision_str,
+                "approval decision submitted but approval already expired"
             );
+            (
+                StatusCode::GONE,
+                axum::Json(serde_json::json!({ "error": "approval_expired" })),
+            )
         }
     }
-
-    let decision_str = match body.decision {
-        ApprovalDecision::Approve => "approve",
-        ApprovalDecision::Deny => "deny",
-    };
-
-    info!(
-        approval_id = %approval_id,
-        decision = decision_str,
-        project_id = %auth.project_id,
-        "approval decision submitted"
-    );
-
-    let delivered = state
-        .approval_store
-        .submit_decision(&approval_id, body.decision)
-        .await;
-
-    if delivered {
-        (
-            StatusCode::OK,
-            axum::Json(serde_json::json!({ "success": true })),
-        )
-    } else {
-        warn!(
-            approval_id = %approval_id,
-            decision = decision_str,
-            "approval decision submitted but approval already expired"
-        );
-        (
-            StatusCode::GONE,
-            axum::Json(serde_json::json!({ "error": "approval_expired" })),
-        )
-    }
+    .instrument(span)
+    .await
 }
 
 /// Request body for the approval decision endpoint.
@@ -575,9 +616,17 @@ async fn handle_connect(
         intercept = true;
     }
 
-    info!(
+    let session_span = info_span!("session",
         peer = %peer_addr,
         host = %host,
+        project_id = project_id.as_deref().unwrap_or("-"),
+        org_id = organization_id.as_deref().unwrap_or("-"),
+        agent = agent_name.as_deref().unwrap_or("-"),
+        agent_id = agent_id.as_deref().unwrap_or("-"),
+    );
+
+    info!(
+        parent: &session_span,
         mode = if intercept { "mitm" } else { "tunnel" },
         "CONNECT"
     );
@@ -585,7 +634,7 @@ async fn handle_connect(
     let ca = Arc::clone(&state.ca);
     let skip_verify = host_matches_skip_verify(&hostname, &state.skip_verify_hosts);
     let http_client = if skip_verify {
-        info!(host = %hostname, "TLS verification skipped (GATEWAY_SKIP_VERIFY_HOSTS)");
+        info!(parent: &session_span, "TLS verification skipped (GATEWAY_SKIP_VERIFY_HOSTS)");
         state.http_client_no_verify.clone()
     } else {
         state.http_client.clone()
@@ -601,34 +650,37 @@ async fn handle_connect(
         agent_token: agent_token.clone(),
     });
 
-    tokio::spawn(async move {
-        match hyper::upgrade::on(req).await {
-            Ok(upgraded) => {
-                let result = if intercept {
-                    mitm::mitm(
-                        upgraded,
-                        &host,
-                        &ca,
-                        http_client,
-                        vault_injection_rules,
-                        cache,
-                        proxy_ctx,
-                        approval_store,
-                        Arc::clone(&state.policy_engine),
-                    )
-                    .await
-                } else {
-                    tunnel::tunnel(upgraded, &host).await
-                };
-                if let Err(e) = result {
-                    warn!(host = %host, error = ?e, "connection error");
+    tokio::spawn(
+        async move {
+            match hyper::upgrade::on(req).await {
+                Ok(upgraded) => {
+                    let result = if intercept {
+                        mitm::mitm(
+                            upgraded,
+                            &host,
+                            &ca,
+                            http_client,
+                            vault_injection_rules,
+                            cache,
+                            proxy_ctx,
+                            approval_store,
+                            Arc::clone(&state.policy_engine),
+                        )
+                        .await
+                    } else {
+                        tunnel::tunnel(upgraded, &host).await
+                    };
+                    if let Err(e) = result {
+                        warn!(host = %host, error = ?e, "connection error");
+                    }
+                }
+                Err(e) => {
+                    warn!(host = %host, error = %e, "upgrade failed");
                 }
             }
-            Err(e) => {
-                warn!(host = %host, error = %e, "upgrade failed");
-            }
         }
-    });
+        .instrument(session_span),
+    );
 
     // 200 tells the client the tunnel is established.
     Ok(Response::new(axum::body::Body::empty()))
@@ -739,9 +791,17 @@ async fn handle_http_proxy(
         }
     }
 
-    info!(
+    let session_span = info_span!("session",
         peer = %peer_addr,
         host = %authority,
+        project_id = resolved.project_id.as_deref().unwrap_or("-"),
+        org_id = resolved.organization_id.as_deref().unwrap_or("-"),
+        agent = resolved.agent_name.as_deref().unwrap_or("-"),
+        agent_id = resolved.agent_id.as_deref().unwrap_or("-"),
+    );
+
+    info!(
+        parent: &session_span,
         scheme = %scheme,
         injection_count = resolved.injection_rules.len(),
         policy_count = resolved.policy_rules.len(),
@@ -777,17 +837,21 @@ async fn handle_http_proxy(
             state.http_client.clone()
         };
 
-    let mut resp = forward::forward_request(
-        req,
-        &authority,
-        scheme,
-        http_client,
-        &rules,
-        &*state.cache,
-        &proxy_ctx,
-        &state.approval_store,
-        &state.policy_engine.pool,
-    )
+    let mut resp = async {
+        forward::forward_request(
+            req,
+            &authority,
+            scheme,
+            http_client,
+            &rules,
+            &*state.cache,
+            &proxy_ctx,
+            &state.approval_store,
+            &state.policy_engine.pool,
+        )
+        .await
+    }
+    .instrument(session_span)
     .await?;
 
     connect::inject_connections_header(&mut resp, &resolved.app_connections);

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -152,7 +152,12 @@ pub(crate) async fn forward_request(
     let has_injections = !rules.injection_rules.is_empty();
     let enforce_deny = has_injections && !policy::is_llm_host(host);
 
+    let org_id = proxy_ctx.organization_id.as_deref().unwrap_or("");
+    let pid = proxy_ctx.project_id.as_deref().unwrap_or("");
+
     let decision = policy::evaluate(
+        org_id,
+        pid,
         method.as_str(),
         &path,
         condition_buffer.as_deref(),
@@ -262,7 +267,7 @@ pub(crate) async fn forward_request(
         inject::apply_injections(&mut headers, &mut upstream_path, &rules.injection_rules);
     let upstream_url = format!("{scheme}://{host}{upstream_path}");
 
-    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, cache, injection_count).await {
+    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, cache, injection_count, host).await {
         return Ok(resp);
     }
 
@@ -281,6 +286,7 @@ pub(crate) async fn forward_request(
                     return Ok(response::approval_store_unavailable());
                 }
             };
+            let org_id = proxy_ctx.organization_id.as_deref().unwrap_or("");
             let agent_id = proxy_ctx.agent_id.as_deref().unwrap_or("unknown");
             let agent_name = proxy_ctx.agent_name.as_deref().unwrap_or("Unknown Agent");
 
@@ -354,6 +360,7 @@ pub(crate) async fn forward_request(
 
             let approval = PendingApproval {
                 id: approval_id.clone(),
+                organization_id: org_id.to_string(),
                 project_id: project_id.to_string(),
                 agent_id: agent_id.to_string(),
                 agent_name: agent_name.to_string(),
@@ -368,16 +375,25 @@ pub(crate) async fn forward_request(
                 expires_at: now + APPROVAL_TIMEOUT_SECS,
             };
 
-            let decision_rx = approval_store.prepare_wait(&approval_id).await;
+            let decision_rx = approval_store
+                .prepare_wait(org_id, project_id, &approval_id)
+                .await;
 
             // Guard cleans up the approval if the agent disconnects (future cancelled).
             // Created BEFORE store() so there's no window where cancellation misses cleanup.
-            let mut guard = ApprovalGuard::new(approval_id.clone(), Arc::clone(approval_store));
+            let mut guard = ApprovalGuard::new(
+                approval_id.clone(),
+                org_id.to_string(),
+                project_id.to_string(),
+                Arc::clone(approval_store),
+            );
 
             if let Err(e) = approval_store.store(&approval).await {
                 warn!(url = %url, error = ?e, "failed to store pending approval");
                 guard.defuse();
-                approval_store.remove(&approval_id).await;
+                approval_store
+                    .remove(org_id, project_id, &approval_id)
+                    .await;
                 return Ok(response::approval_store_unavailable());
             }
 
@@ -421,7 +437,9 @@ pub(crate) async fn forward_request(
             match approval_decision {
                 Some(ApprovalDecision::Approve) => {
                     info!(url = %url, approval_id = %approval_id, "APPROVED — forwarding request");
-                    approval_store.remove(&approval_id).await;
+                    approval_store
+                        .remove(org_id, project_id, &approval_id)
+                        .await;
                     (
                         fwd_body,
                         Some(log_id),
@@ -435,7 +453,9 @@ pub(crate) async fn forward_request(
                         _ => "timed out",
                     };
                     warn!(url = %url, approval_id = %approval_id, reason, "MANUAL APPROVAL rejected");
-                    approval_store.remove(&approval_id).await;
+                    approval_store
+                        .remove(org_id, project_id, &approval_id)
+                        .await;
                     let resolved_at = time::OffsetDateTime::now_utc()
                         .format(&time::format_description::well_known::Iso8601::DEFAULT)
                         .unwrap_or_default();
@@ -532,6 +552,23 @@ pub(crate) async fn forward_request(
 
     let status = upstream_resp.status();
     let resp_headers = upstream_resp.headers().clone();
+
+    // Response hints: intercept known-deprecated host error responses.
+    if proxy_ctx.agent_token.is_some() {
+        let hostname = super::strip_port(host);
+        if let Some(hint) =
+            super::hints::find_hint(hostname, &path, status.as_u16(), injection_count)
+        {
+            info!(
+                method = %method,
+                url = %url,
+                status = %status.as_u16(),
+                hint = %hint.error_code,
+                "deprecated host — returning response hint"
+            );
+            return Ok(super::hints::hint_response(hint, hostname, &path));
+        }
+    }
 
     // If no credentials were injected and upstream returned 401/403,
     // guide the agent to connect/configure credentials in OneCLI.
@@ -709,6 +746,11 @@ pub(crate) async fn forward_request(
         };
 
         let meta = hooks::RequestMeta {
+            org_id: proxy_ctx
+                .organization_id
+                .as_deref()
+                .unwrap_or("")
+                .to_string(),
             project_id: aid.to_string(),
             agent_id: gid.to_string(),
             agent_name: proxy_ctx
@@ -772,6 +814,11 @@ fn emit_policy_telemetry(
         .unwrap_or_default();
     let telemetry_path = path.split('?').next().unwrap_or(path);
     crate::telemetry::on_request(crate::telemetry::RequestEvent {
+        org_id: proxy_ctx
+            .organization_id
+            .as_deref()
+            .unwrap_or("")
+            .to_string(),
         project_id: pid.to_string(),
         agent_id: aid.to_string(),
         agent_name: proxy_ctx
@@ -821,6 +868,11 @@ fn emit_approval_telemetry(
         .format(&time::format_description::well_known::Iso8601::DEFAULT)
         .unwrap_or_default();
     crate::telemetry::on_request(crate::telemetry::RequestEvent {
+        org_id: proxy_ctx
+            .organization_id
+            .as_deref()
+            .unwrap_or("")
+            .to_string(),
         project_id: pid.to_string(),
         agent_id: aid.to_string(),
         agent_name: proxy_ctx

--- a/apps/gateway/src/gateway/hints.rs
+++ b/apps/gateway/src/gateway/hints.rs
@@ -1,0 +1,179 @@
+//! Response hints — synthetic responses for requests to known-deprecated hosts.
+//!
+//! When an agent calls a deprecated API endpoint and the upstream returns an
+//! error matching a configured trigger status, the gateway replaces the response
+//! with actionable guidance telling the agent which API to use instead.
+
+use hyper::{Response, StatusCode};
+
+use crate::apps::HostPattern;
+
+use super::response::{self, ForwardBody};
+
+// ── Hint definition ────────────────────────────────────────────────────
+
+pub(super) struct ResponseHint {
+    pattern: HostPattern,
+    path_prefix: Option<&'static str>,
+    trigger_statuses: &'static [u16],
+    skip_with_injections: bool,
+    pub(super) response_status: StatusCode,
+    pub(super) error_code: &'static str,
+    pub(super) provider: &'static str,
+    pub(super) correct_host: &'static str,
+    message: &'static str,
+}
+
+// ── Hint registry ──────────────────────────────────────────────────────
+
+static RESPONSE_HINTS: &[ResponseHint] = &[ResponseHint {
+    pattern: HostPattern::Suffix(".atlassian.net"),
+    path_prefix: None,
+    trigger_statuses: &[401, 403],
+    skip_with_injections: true,
+    response_status: StatusCode::MISDIRECTED_REQUEST,
+    error_code: "deprecated_api",
+    provider: "atlassian",
+    correct_host: "api.atlassian.com",
+    message: "The Atlassian tenant REST API at {hostname} is deprecated. \
+              Use the Atlassian cloud REST API at api.atlassian.com instead.\n\n\
+              For Jira: https://api.atlassian.com/ex/jira/<cloudId>/rest/api/3/...\n\
+              For Confluence: https://api.atlassian.com/ex/confluence/<cloudId>/rest/api/...\n\n\
+              To discover your cloudId, call: \
+              GET https://api.atlassian.com/oauth/token/accessible-resources\n\n\
+              Your credentials are already configured for api.atlassian.com \
+              through the OneCLI gateway — just update the URL and retry.",
+}];
+
+// ── Lookup ─────────────────────────────────────────────────────────────
+
+#[must_use]
+pub(super) fn find_hint(
+    hostname: &str,
+    path: &str,
+    status: u16,
+    injection_count: usize,
+) -> Option<&'static ResponseHint> {
+    RESPONSE_HINTS.iter().find(|hint| {
+        hint.pattern.matches(hostname)
+            && hint.path_prefix.is_none_or(|pfx| path.starts_with(pfx))
+            && hint.trigger_statuses.contains(&status)
+            && !(hint.skip_with_injections && injection_count > 0)
+    })
+}
+
+// ── Response builder ───────────────────────────────────────────────────
+
+#[must_use]
+pub(super) fn hint_response<S>(
+    hint: &ResponseHint,
+    hostname: &str,
+    path: &str,
+) -> Response<ForwardBody<S>> {
+    let message = hint.message.replace("{hostname}", hostname);
+    response::with_no_retry(response::json_error(
+        hint.response_status,
+        serde_json::json!({
+            "error": hint.error_code,
+            "message": message,
+            "deprecated_host": hostname,
+            "correct_host": hint.correct_host,
+            "provider": hint.provider,
+            "requested_path": path,
+        }),
+    ))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use http_body_util::Either;
+    use hyper::body::Bytes;
+
+    use super::*;
+
+    type TestBody =
+        ForwardBody<futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>>;
+
+    #[test]
+    fn atlassian_tenant_host_triggers_hint() {
+        let hint = find_hint("mysite.atlassian.net", "/rest/api/3/issue", 401, 0);
+        assert!(hint.is_some(), "*.atlassian.net with 401 should match");
+        let h = hint.unwrap();
+        assert_eq!(h.error_code, "deprecated_api");
+        assert_eq!(h.correct_host, "api.atlassian.com");
+        assert_eq!(h.provider, "atlassian");
+    }
+
+    #[test]
+    fn atlassian_tenant_host_triggers_on_403() {
+        assert!(find_hint("mysite.atlassian.net", "/rest/api/3/issue", 403, 0).is_some());
+    }
+
+    #[test]
+    fn atlassian_tenant_host_skips_on_200() {
+        assert!(find_hint("mysite.atlassian.net", "/rest/api/3/issue", 200, 0).is_none());
+    }
+
+    #[test]
+    fn atlassian_tenant_host_skips_with_injections() {
+        assert!(find_hint("mysite.atlassian.net", "/rest/api/3/issue", 401, 1).is_none());
+    }
+
+    #[test]
+    fn atlassian_api_host_does_not_trigger_hint() {
+        assert!(find_hint("api.atlassian.com", "/ex/jira/123/rest/api/3/issue", 401, 0).is_none());
+    }
+
+    #[test]
+    fn bare_suffix_does_not_match() {
+        assert!(find_hint(".atlassian.net", "/any", 401, 0).is_none());
+        assert!(find_hint("atlassian.net", "/any", 401, 0).is_none());
+    }
+
+    #[test]
+    fn unrelated_host_does_not_trigger_hint() {
+        assert!(find_hint("api.github.com", "/repos", 401, 0).is_none());
+        assert!(find_hint("example.com", "/", 403, 0).is_none());
+    }
+
+    #[test]
+    fn hint_response_has_correct_status_and_headers() {
+        let hint = find_hint("mysite.atlassian.net", "/rest/api/3/issue", 401, 0).unwrap();
+        let resp: Response<TestBody> =
+            hint_response(hint, "mysite.atlassian.net", "/rest/api/3/issue");
+        assert_eq!(resp.status(), StatusCode::MISDIRECTED_REQUEST);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+        assert_eq!(resp.headers().get("x-should-retry").unwrap(), "false");
+    }
+
+    #[tokio::test]
+    async fn hint_response_body_contains_fields() {
+        use http_body_util::BodyExt;
+        let hint = find_hint("mysite.atlassian.net", "/rest/api/3/issue", 401, 0).unwrap();
+        let resp: Response<TestBody> =
+            hint_response(hint, "mysite.atlassian.net", "/rest/api/3/issue");
+        let body = match resp.into_body() {
+            Either::Left(full) => full.collect().await.expect("collect").to_bytes(),
+            Either::Right(_) => panic!("expected Left"),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert_eq!(json["error"], "deprecated_api");
+        assert_eq!(json["deprecated_host"], "mysite.atlassian.net");
+        assert_eq!(json["correct_host"], "api.atlassian.com");
+        assert_eq!(json["provider"], "atlassian");
+        assert_eq!(json["requested_path"], "/rest/api/3/issue");
+        assert!(json["message"]
+            .as_str()
+            .unwrap()
+            .contains("mysite.atlassian.net"));
+        assert!(json["message"]
+            .as_str()
+            .unwrap()
+            .contains("api.atlassian.com"));
+    }
+}

--- a/apps/gateway/src/gateway/hooks.rs
+++ b/apps/gateway/src/gateway/hooks.rs
@@ -22,6 +22,7 @@ pub(crate) type ForwardResponseBody = Either<Full<Bytes>, StreamBody<BodyStream>
 
 /// Common telemetry fields for a proxied request, passed from forward to hooks.
 pub(crate) struct RequestMeta {
+    pub org_id: String,
     pub project_id: String,
     pub agent_id: String,
     pub agent_name: String,
@@ -54,6 +55,7 @@ pub(crate) async fn pre_forward(
     _proxy_ctx: &ProxyContext,
     _cache: &dyn crate::cache::CacheStore,
     _injection_count: usize,
+    _host: &str,
 ) -> Option<Response<ForwardResponseBody>> {
     None
 }
@@ -65,6 +67,7 @@ pub(crate) fn track_and_wrap(
     stream: impl futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 ) -> BodyStream {
     crate::telemetry::on_request(crate::telemetry::RequestEvent {
+        org_id: meta.org_id,
         project_id: meta.project_id,
         agent_id: meta.agent_id,
         agent_name: meta.agent_name,

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -13,7 +13,7 @@ use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use std::fmt;
 use tokio_rustls::TlsAcceptor;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::approval::ApprovalStore;
 use crate::ca::CertificateAuthority;
@@ -62,6 +62,7 @@ pub(super) async fn mitm(
         .accept(client_io)
         .await
         .context(TlsHandshakeWithClient)?;
+    debug!(host = %hostname, "TLS handshake with client succeeded");
 
     let host_owned = host.to_string();
     let vault_injection_rules = Arc::new(vault_injection_rules);

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -22,7 +22,7 @@ pub(crate) type ForwardBody<S> = Either<Full<Bytes>, S>;
 
 /// Resolve the OneCLI dashboard base URL from `APP_URL`,
 /// falling back to `http://localhost:10254`. Cached after first call.
-fn dashboard_url() -> &'static str {
+pub(crate) fn dashboard_url() -> &'static str {
     static URL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
     URL.get_or_init(|| {
         std::env::var("APP_URL")
@@ -41,7 +41,10 @@ fn scoped_url(base: &str, path: &str, project_id: Option<&str>) -> String {
 
 /// Build a JSON error response with the given status code and body.
 /// Used by `forward_request` (MITM and HTTP proxy forwarding path).
-fn json_error<S>(status: StatusCode, body: serde_json::Value) -> Response<ForwardBody<S>> {
+pub(super) fn json_error<S>(
+    status: StatusCode,
+    body: serde_json::Value,
+) -> Response<ForwardBody<S>> {
     let json = body.to_string();
     let mut response = Response::new(Either::Left(Full::new(Bytes::from(json))));
     *response.status_mut() = status;
@@ -64,7 +67,7 @@ fn json_error_axum(status: StatusCode, body: serde_json::Value) -> Response<axum
 }
 
 /// Mark a response as non-transient so clients know not to retry.
-fn with_no_retry<B>(mut resp: Response<B>) -> Response<B> {
+pub(super) fn with_no_retry<B>(mut resp: Response<B>) -> Response<B> {
     resp.headers_mut()
         .insert("x-should-retry", HeaderValue::from_static("false"));
     resp

--- a/apps/gateway/src/gateway/tunnel.rs
+++ b/apps/gateway/src/gateway/tunnel.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpStream;
-use tracing::info;
+use tracing::{debug, info};
 
 /// Connect to the target server and splice bytes in both directions
 /// until either side closes the connection. Used for non-intercepted domains.
@@ -11,6 +11,7 @@ pub(super) async fn tunnel(upgraded: hyper::upgrade::Upgraded, host: &str) -> Re
     let mut server = TcpStream::connect(host)
         .await
         .with_context(|| format!("connecting to upstream {host}"))?;
+    debug!(host = %host, "tunnel established");
 
     let mut client = TokioIo::new(upgraded);
 

--- a/apps/gateway/src/gateway/websocket.rs
+++ b/apps/gateway/src/gateway/websocket.rs
@@ -103,7 +103,12 @@ pub(super) async fn handle_websocket(
     let has_injections = !rules.injection_rules.is_empty();
     let enforce_deny = has_injections && !policy::is_llm_host(host);
 
+    let org_id = proxy_ctx.organization_id.as_deref().unwrap_or("");
+    let pid = proxy_ctx.project_id.as_deref().unwrap_or("");
+
     let decision = policy::evaluate(
+        org_id,
+        pid,
         "GET",
         &path,
         None,
@@ -373,6 +378,11 @@ fn emit_telemetry(
             crate::apps::provider_for_host_and_path(hostname, path).unwrap_or((hostname, hostname));
 
         crate::telemetry::on_request(crate::telemetry::RequestEvent {
+            org_id: proxy_ctx
+                .organization_id
+                .as_deref()
+                .unwrap_or("")
+                .to_string(),
             project_id: pid.to_string(),
             agent_id: aid.to_string(),
             agent_name: proxy_ctx

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -101,9 +101,13 @@ fn default_data_dir() -> &'static str {
 #[tokio::main]
 async fn main() -> Result<()> {
     // Install ring as the default rustls CryptoProvider (required by reqwest)
-    rustls::crypto::ring::default_provider()
+    if rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("failed to install rustls CryptoProvider");
+        .is_err()
+    {
+        eprintln!("fatal: failed to install rustls CryptoProvider");
+        std::process::exit(1);
+    }
 
     // Initialize logging — JSON for production (CloudWatch), text for dev
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
@@ -128,6 +132,7 @@ async fn main() -> Result<()> {
 
     // Load or generate CA
     let ca = CertificateAuthority::load_or_generate(&data_dir).await?;
+    info!("CA certificate loaded");
 
     // Connect to PostgreSQL
     // Support both DATABASE_URL (OSS) and individual DB_* vars (cloud ECS from Secrets Manager)
@@ -144,12 +149,14 @@ async fn main() -> Result<()> {
         }
     };
     let pool = db::create_pool(&database_url).await?;
+    info!("database pool created");
     let telemetry_pool = pool.clone();
 
     // Load crypto service for secret decryption
     // OSS: AES-256-GCM with local key from SECRET_ENCRYPTION_KEY
     // Cloud: KMS envelope decryption (calls KMS Decrypt for each data key)
     let crypto = Arc::new(crypto::CryptoService::from_env().await?);
+    info!("crypto service initialized");
 
     let policy_engine = Arc::new(PolicyEngine {
         pool,
@@ -168,16 +175,20 @@ async fn main() -> Result<()> {
         vec![Box::new(bitwarden)],
         policy_engine.pool.clone(),
     ));
+    info!("vault service initialized");
 
     // Initialize cache store
     // OSS: in-memory DashMap. Cloud: Redis (ElastiCache with TLS + AUTH).
     let cache = cache::create_store().await?;
+    info!("cache store created");
 
     // Initialize approval store for manual approval policy action
     // OSS: in-memory DashMap + tokio channels. Cloud: Redis + BLPOP.
     let approval_store = approval::create_store().await?;
+    info!("approval store created");
 
     telemetry::init(telemetry_pool, Arc::clone(&cache));
+    info!("telemetry initialized");
 
     info!(port = cli.port, "gateway ready");
 

--- a/apps/gateway/src/policy.rs
+++ b/apps/gateway/src/policy.rs
@@ -5,6 +5,8 @@
 //! - **Rate limit**: allows up to N requests per time window, then 429
 //! - **Allow**: explicitly permits a request (used in deny-by-default mode)
 
+use tracing::{debug, warn};
+
 use crate::cache::CacheStore;
 use crate::inject::path_matches;
 
@@ -64,6 +66,8 @@ pub(crate) enum PolicyDecision {
 /// Each pass checks only one action type to enforce strict ordering.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn evaluate(
+    org_id: &str,
+    project_id: &str,
     request_method: &str,
     request_path: &str,
     request_body: Option<&[u8]>,
@@ -79,6 +83,7 @@ pub(crate) async fn evaluate(
             continue;
         }
         if matches!(rule.action, PolicyAction::Block) {
+            debug!(rule = %rule.name, method = request_method, path = request_path, "policy: block rule matched");
             return PolicyDecision::Blocked {
                 rule_name: rule.name.clone(),
             };
@@ -91,6 +96,7 @@ pub(crate) async fn evaluate(
             continue;
         }
         if let PolicyAction::ManualApproval { rule_id } = &rule.action {
+            debug!(rule = %rule.name, rule_id = %rule_id, method = request_method, path = request_path, "policy: manual approval rule matched");
             return PolicyDecision::ManualApproval {
                 rule_id: rule_id.clone(),
             };
@@ -113,7 +119,7 @@ pub(crate) async fn evaluate(
                 .unwrap_or_default()
                 .as_secs();
             let window_id = now / (*window_secs).max(1);
-            let key = format!("rate:{rule_id}:{agent_token}:{window_id}");
+            let key = format!("rate:{org_id}:{project_id}:{rule_id}:{agent_token}:{window_id}");
 
             if let Some(count) = cache.incr(&key, *window_secs).await {
                 if count > *max_requests {
@@ -132,8 +138,9 @@ pub(crate) async fn evaluate(
                         retry_after_secs: retry_after,
                     };
                 }
+            } else {
+                warn!(rule = %rule.name, "policy: rate limit cache unavailable, allowing through");
             }
-            // If incr failed (cache unavailable), allow through — graceful fallback
         }
     }
 
@@ -147,6 +154,11 @@ pub(crate) async fn evaluate(
                 )
         });
         if !has_allow {
+            debug!(
+                method = request_method,
+                path = request_path,
+                "policy: no allow rule matched in deny-by-default mode"
+            );
             return PolicyDecision::BlockedByDefaultPolicy;
         }
     }
@@ -340,7 +352,7 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![rate_rule("*", Some("POST"), 5, 3600)];
         let decision = evaluate(
-            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+            "org1", "proj1", "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
         )
         .await;
         assert!(matches!(decision, PolicyDecision::Allow));
@@ -353,19 +365,19 @@ mod tests {
 
         // First 2 requests allowed
         let d1 = evaluate(
-            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+            "org1", "proj1", "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
         )
         .await;
         assert!(matches!(d1, PolicyDecision::Allow));
         let d2 = evaluate(
-            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+            "org1", "proj1", "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
         )
         .await;
         assert!(matches!(d2, PolicyDecision::Allow));
 
         // Third request rate limited
         let d3 = evaluate(
-            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+            "org1", "proj1", "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
         )
         .await;
         assert!(matches!(d3, PolicyDecision::RateLimited { .. }));
@@ -378,18 +390,18 @@ mod tests {
 
         // Agent1 hits limit
         evaluate(
-            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+            "org1", "proj1", "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
         )
         .await;
         let d = evaluate(
-            "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
+            "org1", "proj1", "POST", "/path", None, &rules, "agent1", &*store, "allow", false,
         )
         .await;
         assert!(matches!(d, PolicyDecision::RateLimited { .. }));
 
         // Agent2 is unaffected
         let d = evaluate(
-            "POST", "/path", None, &rules, "agent2", &*store, "allow", false,
+            "org1", "proj1", "POST", "/path", None, &rules, "agent2", &*store, "allow", false,
         )
         .await;
         assert!(matches!(d, PolicyDecision::Allow));
@@ -403,6 +415,8 @@ mod tests {
             rate_rule("/danger/*", Some("POST"), 100, 3600),
         ];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/danger/path",
             None,
@@ -421,6 +435,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![block_rule("/blocked/*", Some("POST"))];
         let d = evaluate(
+            "org1",
+            "proj1",
             "GET",
             "/safe/path",
             None,
@@ -453,6 +469,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![approval_rule("/send/*", Some("POST"))];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/send/email",
             None,
@@ -471,6 +489,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![approval_rule("/send/*", Some("POST"))];
         let d = evaluate(
+            "org1",
+            "proj1",
             "GET",
             "/send/email",
             None,
@@ -492,6 +512,8 @@ mod tests {
             block_rule("/danger/*", Some("POST")),
         ];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/danger/path",
             None,
@@ -513,7 +535,7 @@ mod tests {
             approval_rule("/v1/*", Some("POST")),
         ];
         let d = evaluate(
-            "POST", "/v1/send", None, &rules, "agent1", &*store, "allow", false,
+            "org1", "proj1", "POST", "/v1/send", None, &rules, "agent1", &*store, "allow", false,
         )
         .await;
         assert!(matches!(d, PolicyDecision::ManualApproval { .. }));
@@ -571,6 +593,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules: Vec<PolicyRule> = vec![];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/api/v1/messages",
             None,
@@ -589,6 +613,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![allow_rule("/api/*", Some("POST"))];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/api/v1/messages",
             None,
@@ -610,6 +636,8 @@ mod tests {
             block_rule("/api/v1/danger", Some("POST")),
         ];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/api/v1/danger",
             None,
@@ -628,6 +656,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![rate_rule("/api/*", Some("POST"), 100, 3600)];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/api/v1/send",
             None,
@@ -646,6 +676,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![approval_rule("/send/*", Some("POST"))];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/send/email",
             None,
@@ -664,6 +696,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![allow_rule("/api/*", Some("GET"))];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/api/v1/send",
             None,
@@ -682,6 +716,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules = vec![allow_rule("/api/*", Some("POST"))];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/other/path",
             None,
@@ -700,6 +736,8 @@ mod tests {
         let store = crate::cache::create_store().await.unwrap();
         let rules: Vec<PolicyRule> = vec![];
         let d = evaluate(
+            "org1",
+            "proj1",
             "POST",
             "/api/v1/messages",
             None,
@@ -717,7 +755,10 @@ mod tests {
     async fn allow_mode_empty_string_same_as_allow() {
         let store = crate::cache::create_store().await.unwrap();
         let rules: Vec<PolicyRule> = vec![];
-        let d = evaluate("POST", "/path", None, &rules, "agent1", &*store, "", false).await;
+        let d = evaluate(
+            "org1", "proj1", "POST", "/path", None, &rules, "agent1", &*store, "", false,
+        )
+        .await;
         assert!(matches!(d, PolicyDecision::Allow));
     }
 

--- a/apps/gateway/src/telemetry_core.rs
+++ b/apps/gateway/src/telemetry_core.rs
@@ -41,6 +41,8 @@ pub(crate) enum RequestDecision {
 }
 
 pub(crate) struct RequestEvent {
+    #[allow(dead_code)] // read by cloud telemetry (Redis counters), unused in OSS
+    pub org_id: String,
     pub project_id: String,
     pub agent_id: String,
     #[allow(dead_code)] // read by cloud telemetry (PostHog), unused in OSS
@@ -148,6 +150,7 @@ mod tests {
 
     fn base_event() -> RequestEvent {
         RequestEvent {
+            org_id: "org1".into(),
             project_id: "p1".into(),
             agent_id: "a1".into(),
             agent_name: "test".into(),

--- a/apps/gateway/src/vault/api.rs
+++ b/apps/gateway/src/vault/api.rs
@@ -7,6 +7,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use tracing::{info_span, warn, Instrument};
 
 use crate::auth::AuthUser;
 use crate::gateway::GatewayState;
@@ -19,23 +20,31 @@ pub(crate) async fn vault_pair(
     Path(provider): Path<String>,
     Json(params): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    match state
-        .vault_service
-        .pair(&auth.project_id, &provider, &params)
-        .await
-    {
-        Ok(result) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "status": "paired",
-                "display_name": result.display_name,
-            })),
-        ),
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": e.to_string()})),
-        ),
+    let span = info_span!("vault_pair", project_id = %auth.project_id, provider = %provider);
+    async move {
+        match state
+            .vault_service
+            .pair(&auth.project_id, &provider, &params)
+            .await
+        {
+            Ok(result) => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": "paired",
+                    "display_name": result.display_name,
+                })),
+            ),
+            Err(e) => {
+                warn!(error = %e, "vault pair failed");
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": e.to_string()})),
+                )
+            }
+        }
     }
+    .instrument(span)
+    .await
 }
 
 /// GET /v1/vault/:provider/status
@@ -44,28 +53,33 @@ pub(crate) async fn vault_status(
     State(state): State<GatewayState>,
     Path(provider): Path<String>,
 ) -> impl IntoResponse {
-    match state
-        .vault_service
-        .status(&auth.project_id, &provider)
-        .await
-    {
-        Some(status) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "connected": status.connected,
-                "name": status.name,
-                "status_data": status.status_data,
-            })),
-        ),
-        None => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "connected": false,
-                "name": null,
-                "status_data": null,
-            })),
-        ),
+    let span = info_span!("vault_status", project_id = %auth.project_id, provider = %provider);
+    async move {
+        match state
+            .vault_service
+            .status(&auth.project_id, &provider)
+            .await
+        {
+            Some(status) => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "connected": status.connected,
+                    "name": status.name,
+                    "status_data": status.status_data,
+                })),
+            ),
+            None => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "connected": false,
+                    "name": null,
+                    "status_data": null,
+                })),
+            ),
+        }
     }
+    .instrument(span)
+    .await
 }
 
 /// DELETE /v1/vault/:provider/pair
@@ -74,18 +88,26 @@ pub(crate) async fn vault_disconnect(
     State(state): State<GatewayState>,
     Path(provider): Path<String>,
 ) -> impl IntoResponse {
-    match state
-        .vault_service
-        .disconnect(&auth.project_id, &provider)
-        .await
-    {
-        Ok(()) => (
-            StatusCode::OK,
-            Json(serde_json::json!({"status": "disconnected"})),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e.to_string()})),
-        ),
+    let span = info_span!("vault_disconnect", project_id = %auth.project_id, provider = %provider);
+    async move {
+        match state
+            .vault_service
+            .disconnect(&auth.project_id, &provider)
+            .await
+        {
+            Ok(()) => (
+                StatusCode::OK,
+                Json(serde_json::json!({"status": "disconnected"})),
+            ),
+            Err(e) => {
+                warn!(error = %e, "vault disconnect failed");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": e.to_string()})),
+                )
+            }
+        }
     }
+    .instrument(span)
+    .await
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -34,6 +34,7 @@ const nextConfig = {
             "@/cloud/components/condition-builder",
           "@/lib/dashboard/session-redirect":
             "@/cloud/dashboard/session-redirect",
+          "@/lib/granular-access": "@/cloud/granular-access",
 
           // Cloud initialization (api, server actions, client)
           "@/lib/init/api": "@/cloud/init/api",

--- a/apps/web/src/app/(dashboard)/agents/_components/manage-access-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/manage-access-dialog.tsx
@@ -42,6 +42,8 @@ import {
 import { getApp } from "@onecli/api/apps/registry";
 import { extractLabel } from "@onecli/api/services/connection-service";
 import type { SecretMode } from "@onecli/api/services/agent-service";
+import { granularAccessConfigs } from "@/lib/granular-access";
+import { ProAppDialog } from "@/lib/components/pro-app-dialog";
 
 interface ManageAccessDialogProps {
   agent: {
@@ -72,17 +74,25 @@ export const ManageAccessDialog = ({
   const [selectedSecretIds, setSelectedSecretIds] = useState<Set<string>>(
     () => new Set(),
   );
-  const [selectedConnectionIds, setSelectedConnectionIds] = useState<
-    Set<string>
-  >(() => new Set());
+  const [connectionPolicies, setConnectionPolicies] = useState<
+    Map<string, Record<string, unknown> | null>
+  >(() => new Map());
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [search, setSearch] = useState("");
 
+  const [granularDialogConnId, setGranularDialogConnId] = useState<
+    string | null
+  >(null);
+  const [editingPolicy, setEditingPolicy] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const [allSecrets, assignedSecretIds, allConnections, assignedAppIds] =
+      const [allSecrets, assignedSecretIds, allConnections, assignedConns] =
         await Promise.all([
           secretsApi.list(),
           getAgentSecrets(agent.id),
@@ -105,7 +115,14 @@ export const ManageAccessDialog = ({
       }
       setConnections(projectConns);
       setOrgConnections(orgConns);
-      setSelectedConnectionIds(new Set(assignedAppIds));
+      const policies = new Map<string, Record<string, unknown> | null>();
+      for (const ac of assignedConns) {
+        policies.set(
+          ac.appConnectionId,
+          ac.sessionPolicy as Record<string, unknown> | null,
+        );
+      }
+      setConnectionPolicies(policies);
     } catch {
       toast.error("Failed to load credentials");
     } finally {
@@ -117,6 +134,7 @@ export const ManageAccessDialog = ({
     if (open) {
       setMode(agent.secretMode === "selective" ? "selective" : "all");
       setSearch("");
+      setGranularDialogConnId(null);
       fetchData();
     }
   }, [open, agent.secretMode, fetchData]);
@@ -198,10 +216,10 @@ export const ManageAccessDialog = ({
   };
 
   const toggleConnection = (connectionId: string) => {
-    setSelectedConnectionIds((prev) => {
-      const next = new Set(prev);
+    setConnectionPolicies((prev) => {
+      const next = new Map(prev);
       if (next.has(connectionId)) next.delete(connectionId);
-      else next.add(connectionId);
+      else next.set(connectionId, null);
       return next;
     });
   };
@@ -211,18 +229,20 @@ export const ManageAccessDialog = ({
     orgSecrets.length +
     appConnections.length +
     orgConnections.length;
-  const totalSelected = selectedSecretIds.size + selectedConnectionIds.size;
+  const totalSelected = selectedSecretIds.size + connectionPolicies.size;
 
   const selectAll = () => {
     setSelectedSecretIds(new Set([...secrets, ...orgSecrets].map((s) => s.id)));
-    setSelectedConnectionIds(
-      new Set([...appConnections, ...orgConnections].map((c) => c.id)),
-    );
+    const allPolicies = new Map<string, Record<string, unknown> | null>();
+    for (const c of [...appConnections, ...orgConnections]) {
+      allPolicies.set(c.id, connectionPolicies.get(c.id) ?? null);
+    }
+    setConnectionPolicies(allPolicies);
   };
 
   const clearAll = () => {
     setSelectedSecretIds(new Set());
-    setSelectedConnectionIds(new Set());
+    setConnectionPolicies(new Map());
   };
 
   const handleSave = async () => {
@@ -230,12 +250,15 @@ export const ManageAccessDialog = ({
     try {
       await updateAgentSecretMode(agent.id, mode);
       if (mode === "selective") {
+        const connPayload = Array.from(connectionPolicies.entries()).map(
+          ([id, policy]) => ({
+            appConnectionId: id,
+            sessionPolicy: policy,
+          }),
+        );
         await Promise.all([
           updateAgentSecrets(agent.id, Array.from(selectedSecretIds)),
-          updateAgentAppConnections(
-            agent.id,
-            Array.from(selectedConnectionIds),
-          ),
+          updateAgentAppConnections(agent.id, connPayload),
         ]);
       }
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all() });
@@ -252,6 +275,40 @@ export const ManageAccessDialog = ({
 
   const isSelective = mode === "selective";
   const hasItems = totalItems > 0;
+
+  const granularDialogConn = useMemo(
+    () =>
+      granularDialogConnId
+        ? [...appConnections, ...orgConnections].find(
+            (c) => c.id === granularDialogConnId,
+          )
+        : undefined,
+    [granularDialogConnId, appConnections, orgConnections],
+  );
+  const granularDialogConfig = granularDialogConn
+    ? granularAccessConfigs.get(granularDialogConn.provider)
+    : undefined;
+  const granularDialogApp = granularDialogConn
+    ? getApp(granularDialogConn.provider)
+    : undefined;
+  const granularDialogMeta =
+    (granularDialogConn?.metadata as Record<string, unknown>) ?? {};
+
+  const openGranularDialog = (connId: string) => {
+    setGranularDialogConnId(connId);
+    setEditingPolicy(connectionPolicies.get(connId) ?? null);
+  };
+
+  const saveGranularPolicy = () => {
+    if (granularDialogConnId) {
+      setConnectionPolicies((prev) => {
+        const next = new Map(prev);
+        next.set(granularDialogConnId, editingPolicy);
+        return next;
+      });
+    }
+    setGranularDialogConnId(null);
+  };
 
   const renderSecretSection = (title: string, items: Secret[]) => {
     if (items.length === 0) return null;
@@ -301,37 +358,117 @@ export const ManageAccessDialog = ({
           const hasMultiple = (providerCounts.get(conn.provider) ?? 0) > 1;
           const displayName =
             hasMultiple && label ? `${baseName} - ${label}` : baseName;
+          const isSelected = connectionPolicies.has(conn.id);
+          const config = granularAccessConfigs.get(conn.provider);
+          const hasGranularAccess =
+            config && isSelected && config.isSupported(meta ?? {});
+          const policy = connectionPolicies.get(conn.id);
+
+          const policyItems = hasGranularAccess
+            ? config.getItems(meta ?? {})
+            : [];
+          const selectedItemIds = new Set(
+            policy && hasGranularAccess ? config.getSelectedItems(policy) : [],
+          );
+          const isAllItems = !policy || Object.keys(policy).length === 0;
+
           return (
-            <label
-              key={conn.id}
-              className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors"
-            >
-              <Checkbox
-                checked={selectedConnectionIds.has(conn.id)}
-                onCheckedChange={() => toggleConnection(conn.id)}
-              />
-              <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                {app?.icon && (
-                  <AppIcon
-                    icon={app.icon}
-                    darkIcon={app.darkIcon}
-                    name={baseName}
-                    size={16}
-                  />
-                )}
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium">{displayName}</p>
-                  {!hasMultiple && label && (
-                    <p className="text-muted-foreground truncate text-xs">
-                      {label}
-                    </p>
+            <div key={conn.id}>
+              <label className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors">
+                <Checkbox
+                  checked={isSelected}
+                  onCheckedChange={() => toggleConnection(conn.id)}
+                />
+                <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                  {app?.icon && (
+                    <AppIcon
+                      icon={app.icon}
+                      darkIcon={app.darkIcon}
+                      name={baseName}
+                      size={16}
+                    />
                   )}
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">
+                      {displayName}
+                    </p>
+                    {!hasMultiple && label && (
+                      <p className="text-muted-foreground truncate text-xs">
+                        {label}
+                      </p>
+                    )}
+                  </div>
                 </div>
-              </div>
-              <Badge variant="secondary" className="shrink-0 text-xs">
-                {app?.name ?? conn.provider}
-              </Badge>
-            </label>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  {hasGranularAccess &&
+                    config.PolicyDialogContent &&
+                    !isAllItems && (
+                      <Badge variant="outline" className="text-xs">
+                        {selectedItemIds.size}{" "}
+                        {selectedItemIds.size !== 1
+                          ? config.itemLabel.plural
+                          : config.itemLabel.singular}
+                      </Badge>
+                    )}
+                  <Badge variant="secondary" className="text-xs">
+                    {app?.name ?? conn.provider}
+                  </Badge>
+                </div>
+              </label>
+
+              {hasGranularAccess && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openGranularDialog(conn.id);
+                  }}
+                  className="hover:bg-muted/50 ml-9 mr-3 mb-2 flex items-center gap-1.5 rounded-md px-2 py-1 transition-colors"
+                >
+                  <config.Icon className="text-muted-foreground size-3" />
+                  <span className="text-muted-foreground text-xs">
+                    {isAllItems
+                      ? `All ${config.itemLabel.plural}`
+                      : `${selectedItemIds.size} of ${policyItems.length} ${config.itemLabel.plural}`}
+                  </span>
+                  <span className="text-muted-foreground/30 text-xs">·</span>
+                  <span className="text-muted-foreground text-xs font-medium">
+                    Manage
+                  </span>
+                  {!config.PolicyDialogContent && (
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-brand/20 bg-brand/5 px-2 py-px">
+                      <svg
+                        width="11"
+                        height="9"
+                        viewBox="0 0 44 36"
+                        fill="none"
+                        className="-mt-px shrink-0"
+                      >
+                        <path
+                          d="M2 2L16 18L2 34"
+                          stroke="currentColor"
+                          strokeWidth="5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="text-brand"
+                        />
+                        <path
+                          d="M22 2L36 18L22 34"
+                          stroke="currentColor"
+                          strokeWidth="5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="text-brand"
+                        />
+                      </svg>
+                      <span className="text-[10px] font-semibold tracking-wide text-brand">
+                        Team
+                      </span>
+                    </span>
+                  )}
+                </button>
+              )}
+            </div>
           );
         })}
       </>
@@ -339,172 +476,226 @@ export const ManageAccessDialog = ({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 p-0 sm:max-w-lg">
-        <DialogHeader className="p-6 pb-4">
-          <DialogTitle>Credential access for {agent.name}</DialogTitle>
-          <p className="text-muted-foreground text-xs leading-relaxed">
-            Secrets and app connections are injected by the gateway at request
-            time. The agent never sees raw values.
-          </p>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="gap-0 p-0 sm:max-w-lg">
+          <DialogHeader className="p-6 pb-4">
+            <DialogTitle>Credential access for {agent.name}</DialogTitle>
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              Secrets and app connections are injected by the gateway at request
+              time. The agent never sees raw values.
+            </p>
+          </DialogHeader>
 
-        {/* Mode selection */}
-        <div className="space-y-2 px-6 pb-2">
-          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-            Access mode
-          </p>
-          <div className="grid grid-cols-2 gap-2">
-            {(
-              [
-                {
-                  value: "all",
-                  icon: Globe,
-                  label: "All credentials",
-                  desc: "Every secret and app connection",
-                },
-                {
-                  value: "selective",
-                  icon: ListChecks,
-                  label: "Selective",
-                  desc: "Choose specific secrets and apps",
-                },
-              ] as const
-            ).map(({ value, icon: Icon, label, desc }) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setMode(value)}
-                className={cn(
-                  "flex flex-col gap-2 rounded-lg border p-3 text-left transition-colors",
-                  mode === value
-                    ? "border-foreground/30 bg-muted/60"
-                    : "border-border hover:bg-muted/30",
-                )}
-              >
-                <div className="flex items-center gap-2">
-                  <Icon
-                    className={cn(
-                      "size-3.5",
-                      mode === value
-                        ? "text-foreground"
-                        : "text-muted-foreground/60",
-                    )}
-                  />
-                  <p
-                    className={cn(
-                      "text-sm font-medium",
-                      mode !== value && "text-muted-foreground",
-                    )}
-                  >
-                    {label}
-                  </p>
-                </div>
-                <p className="text-muted-foreground text-xs">{desc}</p>
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Credential lists — revealed when selective */}
-        {isSelective && (
-          <div className="px-6 pt-2 pb-1">
-            {loading ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="text-muted-foreground size-4 animate-spin" />
-              </div>
-            ) : !hasItems ? (
-              <div className="flex flex-col items-center justify-center py-8 text-center">
-                <div className="bg-muted mb-3 flex size-10 items-center justify-center rounded-full">
-                  <KeyRound className="text-muted-foreground size-4" />
-                </div>
-                <p className="text-sm font-medium">No credentials yet</p>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  Add secrets or connect apps first.
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {/* Search */}
-                <div className="relative">
-                  <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
-                  <Input
-                    placeholder="Filter credentials..."
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    className="h-8 pl-8 text-sm"
-                  />
-                </div>
-
-                {/* Toolbar: count + actions */}
-                <div className="flex items-center justify-between">
-                  <p className="text-muted-foreground text-xs">
-                    <span className="text-foreground font-medium">
-                      {totalSelected}
-                    </span>{" "}
-                    of {totalItems} selected
-                  </p>
-                  <div className="flex gap-1">
-                    <button
-                      type="button"
-                      onClick={selectAll}
-                      className="text-muted-foreground hover:text-foreground text-xs transition-colors"
-                    >
-                      Select all
-                    </button>
-                    <span className="text-muted-foreground/40 text-xs">/</span>
-                    <button
-                      type="button"
-                      onClick={clearAll}
-                      className="text-muted-foreground hover:text-foreground text-xs transition-colors"
-                    >
-                      Clear
-                    </button>
-                  </div>
-                </div>
-
-                {/* List */}
-                <ScrollArea className="h-[280px] overflow-hidden rounded-md border">
-                  <div className="divide-border divide-y">
-                    {renderSecretSection("Secrets", filteredSecrets)}
-                    {renderConnectionSection(
-                      "App connections",
-                      filteredConnections,
-                    )}
-                    {renderSecretSection(
-                      "Organization secrets",
-                      filteredOrgSecrets,
-                    )}
-                    {renderConnectionSection(
-                      "Organization app connections",
-                      filteredOrgConnections,
-                    )}
-
-                    {filteredSecrets.length === 0 &&
-                      filteredOrgSecrets.length === 0 &&
-                      filteredConnections.length === 0 &&
-                      filteredOrgConnections.length === 0 && (
-                        <p className="text-muted-foreground py-6 text-center text-xs">
-                          No credentials match &ldquo;{search}&rdquo;
-                        </p>
+          {/* Mode selection */}
+          <div className="space-y-2 px-6 pb-2">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+              Access mode
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {(
+                [
+                  {
+                    value: "all",
+                    icon: Globe,
+                    label: "All credentials",
+                    desc: "Every secret and app connection",
+                  },
+                  {
+                    value: "selective",
+                    icon: ListChecks,
+                    label: "Selective",
+                    desc: "Choose specific secrets and apps",
+                  },
+                ] as const
+              ).map(({ value, icon: Icon, label, desc }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setMode(value)}
+                  className={cn(
+                    "flex flex-col gap-2 rounded-lg border p-3 text-left transition-colors",
+                    mode === value
+                      ? "border-foreground/30 bg-muted/60"
+                      : "border-border hover:bg-muted/30",
+                  )}
+                >
+                  <div className="flex items-center gap-2">
+                    <Icon
+                      className={cn(
+                        "size-3.5",
+                        mode === value
+                          ? "text-foreground"
+                          : "text-muted-foreground/60",
                       )}
+                    />
+                    <p
+                      className={cn(
+                        "text-sm font-medium",
+                        mode !== value && "text-muted-foreground",
+                      )}
+                    >
+                      {label}
+                    </p>
                   </div>
-                </ScrollArea>
-              </div>
-            )}
+                  <p className="text-muted-foreground text-xs">{desc}</p>
+                </button>
+              ))}
+            </div>
           </div>
-        )}
 
-        {/* Footer */}
-        <DialogFooter className="border-border/50 border-t px-6 py-4">
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleSave} loading={saving} disabled={loading}>
-            {saving ? "Saving..." : "Save"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          {/* Credential lists — revealed when selective */}
+          {isSelective && (
+            <div className="px-6 pt-2 pb-1">
+              {loading ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="text-muted-foreground size-4 animate-spin" />
+                </div>
+              ) : !hasItems ? (
+                <div className="flex flex-col items-center justify-center py-8 text-center">
+                  <div className="bg-muted mb-3 flex size-10 items-center justify-center rounded-full">
+                    <KeyRound className="text-muted-foreground size-4" />
+                  </div>
+                  <p className="text-sm font-medium">No credentials yet</p>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    Add secrets or connect apps first.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {/* Search */}
+                  <div className="relative">
+                    <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+                    <Input
+                      placeholder="Filter credentials..."
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      className="h-8 pl-8 text-sm"
+                    />
+                  </div>
+
+                  {/* Toolbar: count + actions */}
+                  <div className="flex items-center justify-between">
+                    <p className="text-muted-foreground text-xs">
+                      <span className="text-foreground font-medium">
+                        {totalSelected}
+                      </span>{" "}
+                      of {totalItems} selected
+                    </p>
+                    <div className="flex gap-1">
+                      <button
+                        type="button"
+                        onClick={selectAll}
+                        className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+                      >
+                        Select all
+                      </button>
+                      <span className="text-muted-foreground/40 text-xs">
+                        /
+                      </span>
+                      <button
+                        type="button"
+                        onClick={clearAll}
+                        className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* List */}
+                  <ScrollArea className="h-70 overflow-hidden rounded-md border">
+                    <div className="divide-border divide-y">
+                      {renderSecretSection("Secrets", filteredSecrets)}
+                      {renderConnectionSection(
+                        "App connections",
+                        filteredConnections,
+                      )}
+                      {renderSecretSection(
+                        "Organization secrets",
+                        filteredOrgSecrets,
+                      )}
+                      {renderConnectionSection(
+                        "Organization app connections",
+                        filteredOrgConnections,
+                      )}
+
+                      {filteredSecrets.length === 0 &&
+                        filteredOrgSecrets.length === 0 &&
+                        filteredConnections.length === 0 &&
+                        filteredOrgConnections.length === 0 && (
+                          <p className="text-muted-foreground py-6 text-center text-xs">
+                            No credentials match &ldquo;{search}&rdquo;
+                          </p>
+                        )}
+                    </div>
+                  </ScrollArea>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Footer */}
+          <DialogFooter className="border-border/50 border-t px-6 py-4">
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} loading={saving} disabled={loading}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Granular access policy dialog (cloud) */}
+      {granularDialogConnId && granularDialogConfig?.PolicyDialogContent && (
+        <Dialog open onOpenChange={() => setGranularDialogConnId(null)}>
+          <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-sm">
+            <DialogHeader className="border-border/50 border-b px-5 py-4">
+              <div className="flex items-center gap-3">
+                {granularDialogApp?.icon && (
+                  <AppIcon
+                    icon={granularDialogApp.icon}
+                    darkIcon={granularDialogApp.darkIcon}
+                    name={granularDialogApp.name}
+                    size={18}
+                  />
+                )}
+                <div>
+                  <DialogTitle className="text-sm">
+                    Manage {granularDialogConfig.itemLabel.singular} access
+                  </DialogTitle>
+                  <p className="text-muted-foreground text-xs">
+                    {granularDialogConn?.label ??
+                      extractLabel(granularDialogMeta ?? undefined) ??
+                      granularDialogApp?.name}
+                  </p>
+                </div>
+              </div>
+            </DialogHeader>
+
+            <granularDialogConfig.PolicyDialogContent
+              metadata={granularDialogMeta}
+              policy={editingPolicy}
+              onPolicyChange={setEditingPolicy}
+              onSave={saveGranularPolicy}
+              onCancel={() => setGranularDialogConnId(null)}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Granular access upsell (OSS) */}
+      {granularDialogConnId && !granularDialogConfig?.PolicyDialogContent && (
+        <ProAppDialog
+          appName="Granular access control"
+          appIcon={granularDialogApp?.icon ?? ""}
+          appDarkIcon={granularDialogApp?.darkIcon}
+          description="Control which resources each agent can access through your app connections."
+          open
+          onOpenChange={() => setGranularDialogConnId(null)}
+        />
+      )}
+    </>
   );
 };

--- a/apps/web/src/app/(dashboard)/overview/_components/recent-activity-card.tsx
+++ b/apps/web/src/app/(dashboard)/overview/_components/recent-activity-card.tsx
@@ -106,6 +106,15 @@ export const RecentActivityCard = () => {
                         {getProviderIcon(log.provider)?.name ?? log.provider}
                       </span>
                     </span>
+                    <span className="text-muted-foreground mx-0.5">·</span>
+                    <span className="shrink-0 text-sm font-medium">
+                      {log.host.replace(/:(?:443|80)$/, "")}
+                    </span>
+                    <span className="text-muted-foreground truncate font-mono text-xs">
+                      {log.path || "/"}
+                    </span>
+                  </div>
+                  <div className="flex w-5 shrink-0 items-center justify-center">
                     {isOwnKey(log) && (
                       <Tooltip>
                         <TooltipTrigger asChild>
@@ -116,15 +125,8 @@ export const RecentActivityCard = () => {
                         </TooltipContent>
                       </Tooltip>
                     )}
-                    <span className="text-muted-foreground mx-0.5">·</span>
-                    <span className="shrink-0 text-sm font-medium">
-                      {log.host.replace(/:(?:443|80)$/, "")}
-                    </span>
-                    <span className="text-muted-foreground truncate font-mono text-xs">
-                      {log.path || "/"}
-                    </span>
                   </div>
-                  <div className="flex items-center justify-end border-l pl-3 shrink-0 w-[140px]">
+                  <div className="flex items-center justify-end shrink-0 border-l pl-2">
                     <StatusBadge
                       status={log.status}
                       blocked={isBlockedRequest(log)}

--- a/apps/web/src/hooks/use-agents.ts
+++ b/apps/web/src/hooks/use-agents.ts
@@ -145,11 +145,14 @@ export const useUpdateAgentConnections = () => {
   return useMutation({
     mutationFn: ({
       agentId,
-      connectionIds,
+      connections,
     }: {
       agentId: string;
-      connectionIds: string[];
-    }) => updateAgentAppConnections(agentId, connectionIds),
+      connections: {
+        appConnectionId: string;
+        sessionPolicy?: Record<string, unknown> | null;
+      }[];
+    }) => updateAgentAppConnections(agentId, connections),
     onSuccess: (_data, { agentId }) => {
       qc.invalidateQueries({
         queryKey: queryKeys.agents.connections(agentId),

--- a/apps/web/src/lib/actions/agents.ts
+++ b/apps/web/src/lib/actions/agents.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { resolveProjectContext } from "@/lib/actions/resolve-user";
-import type { SecretMode } from "@onecli/api/services/agent-service";
+import type {
+  SecretMode,
+  AgentAppConnectionInput,
+} from "@onecli/api/services/agent-service";
 import {
   listAgents,
   getDefaultAgent as getDefaultAgentService,
@@ -158,19 +161,18 @@ export const getAgentAppConnections = async (agentId: string) => {
 
 export const updateAgentAppConnections = async (
   agentId: string,
-  appConnectionIds: string[],
+  connections: AgentAppConnectionInput[],
 ): Promise<void> => {
   const { userId, userEmail, projectId } = await resolveProjectContext();
   return withAudit(
-    () =>
-      updateAgentAppConnectionsService(projectId, agentId, appConnectionIds),
+    () => updateAgentAppConnectionsService(projectId, agentId, connections),
     () => ({
       projectId,
       userId,
       userEmail,
       action: AUDIT_ACTIONS.UPDATE,
       service: AUDIT_SERVICES.AGENT,
-      metadata: { agentId, appConnectionCount: appConnectionIds.length },
+      metadata: { agentId, appConnectionCount: connections.length },
     }),
   );
 };

--- a/apps/web/src/lib/granular-access/configs/github-app.ts
+++ b/apps/web/src/lib/granular-access/configs/github-app.ts
@@ -1,0 +1,15 @@
+import { GitBranch } from "lucide-react";
+import type { GranularAccessConfig } from "../types";
+
+export const githubAppConfig: GranularAccessConfig = {
+  isSupported: (meta) => Array.isArray(meta.repos) && meta.repos.length > 0,
+  getItems: (meta) =>
+    ((meta.repos as string[]) ?? []).map((repo) => ({
+      id: repo,
+      label: repo.split("/").pop() ?? repo,
+    })),
+  buildPolicy: (repos) => (repos.length > 0 ? { repositories: repos } : {}),
+  getSelectedItems: (policy) => (policy.repositories as string[]) ?? [],
+  itemLabel: { singular: "repository", plural: "repositories" },
+  Icon: GitBranch,
+};

--- a/apps/web/src/lib/granular-access/index.ts
+++ b/apps/web/src/lib/granular-access/index.ts
@@ -1,0 +1,12 @@
+import { githubAppConfig } from "./configs/github-app";
+import type { GranularAccessConfig } from "./types";
+
+export type {
+  GranularAccessConfig,
+  GranularAccessItem,
+  PolicyDialogContentProps,
+} from "./types";
+
+export const granularAccessConfigs = new Map<string, GranularAccessConfig>([
+  ["github-app", githubAppConfig],
+]);

--- a/apps/web/src/lib/granular-access/types.ts
+++ b/apps/web/src/lib/granular-access/types.ts
@@ -1,0 +1,24 @@
+import type { ComponentType } from "react";
+
+export interface GranularAccessItem {
+  id: string;
+  label: string;
+}
+
+export interface PolicyDialogContentProps {
+  metadata: Record<string, unknown>;
+  policy: Record<string, unknown> | null;
+  onPolicyChange: (policy: Record<string, unknown> | null) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export interface GranularAccessConfig {
+  isSupported: (metadata: Record<string, unknown>) => boolean;
+  getItems: (metadata: Record<string, unknown>) => GranularAccessItem[];
+  buildPolicy: (selectedItemIds: string[]) => Record<string, unknown>;
+  getSelectedItems: (policy: Record<string, unknown>) => string[];
+  itemLabel: { singular: string; plural: string };
+  Icon: ComponentType<{ className?: string }>;
+  PolicyDialogContent?: ComponentType<PolicyDialogContentProps>;
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,7 +21,8 @@
     "./cloud/notifications/*": "./src/cloud/notifications/*.ts",
     "./cloud/apps/*": "./src/cloud/apps/*.ts",
     "./cloud/apps/app-permissions/*": "./src/cloud/apps/app-permissions/*.ts",
-    "./cloud/auth/*": "./src/cloud/auth/*.ts"
+    "./cloud/auth/*": "./src/cloud/auth/*.ts",
+    "./cloud/granular-access": "./src/cloud/granular-access/index.ts"
   },
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -5,6 +5,7 @@ import type {
   ConnectionHooks,
   ResourceHooks,
   RoleResolver,
+  PolicyValidator,
 } from "./providers";
 import type { CryptoService } from "./lib/crypto-types";
 import type { AppDefinition } from "./apps/types";
@@ -19,6 +20,7 @@ import {
   initResourceHooks,
   initSelfUrl,
   initRoleResolver,
+  initPolicyValidator,
 } from "./providers";
 import { registerAppPermission } from "./apps/app-permissions";
 import { errorHandler, notFoundHandler } from "./middleware/error-handler";
@@ -49,6 +51,7 @@ export interface CreateApiAppOptions {
   resourceHooks?: ResourceHooks;
   selfUrl?: string;
   roleResolver?: RoleResolver;
+  policyValidator?: PolicyValidator;
   sessionHooks?: Partial<SessionHooks>;
   version?: string;
 }
@@ -70,6 +73,7 @@ export const createApiApp = (
   if (options?.resourceHooks) initResourceHooks(options.resourceHooks);
   if (options?.selfUrl) initSelfUrl(options.selfUrl);
   if (options?.roleResolver) initRoleResolver(options.roleResolver);
+  if (options?.policyValidator) initPolicyValidator(options.policyValidator);
   if (options?.sessionHooks) initSessionHooks(options.sessionHooks);
 
   const app = new Hono<ApiEnv>().basePath("/v1");

--- a/packages/api/src/providers/hooks/index.ts
+++ b/packages/api/src/providers/hooks/index.ts
@@ -8,3 +8,8 @@ export {
   initConnectionHooks,
   getConnectionHooks,
 } from "./connection-hooks";
+export {
+  type PolicyValidator,
+  initPolicyValidator,
+  getPolicyValidator,
+} from "./policy-validator";

--- a/packages/api/src/providers/hooks/policy-validator.ts
+++ b/packages/api/src/providers/hooks/policy-validator.ts
@@ -1,0 +1,20 @@
+export interface PolicyValidator {
+  validate(
+    organizationId: string,
+    provider: string,
+    metadata: Record<string, unknown> | null,
+    policy: Record<string, unknown>,
+  ): Promise<void>;
+}
+
+const defaultPolicyValidator: PolicyValidator = {
+  validate: async () => {},
+};
+
+let _policyValidator: PolicyValidator = defaultPolicyValidator;
+
+export const initPolicyValidator = (v: PolicyValidator) => {
+  _policyValidator = v;
+};
+
+export const getPolicyValidator = (): PolicyValidator => _policyValidator;

--- a/packages/api/src/providers/index.ts
+++ b/packages/api/src/providers/index.ts
@@ -23,4 +23,7 @@ export {
   type ConnectionHooks,
   initConnectionHooks,
   getConnectionHooks,
+  type PolicyValidator,
+  initPolicyValidator,
+  getPolicyValidator,
 } from "./hooks";

--- a/packages/api/src/routes/apps.ts
+++ b/packages/api/src/routes/apps.ts
@@ -11,7 +11,7 @@ import {
   verifyOAuthState,
   generateNonce,
 } from "../lib/oauth-state";
-import { NODE_ENV } from "../lib/env";
+import { APP_URL, NODE_ENV } from "../lib/env";
 import { dashboardUrl } from "../lib/dashboard-url";
 import { getRequestOrigin } from "../lib/request-origin";
 import { buildFragmentBridgeHtml } from "../lib/fragment-bridge";
@@ -310,7 +310,8 @@ export const appRoutes = () => {
   // ── GET /apps/:provider/callback ── OAuth callback ─────────────────────
   app.get("/:provider/callback", async (c) => {
     const provider = c.req.param("provider")!;
-    const origin = getRequestOrigin(c.req.raw);
+    const apiOrigin = getRequestOrigin(c.req.raw);
+    const appOrigin = APP_URL || apiOrigin;
 
     const appDef = getApp(provider);
     if (
@@ -318,7 +319,7 @@ export const appRoutes = () => {
       appDef.connectionMethod.fragmentCallback &&
       !c.req.query(appDef.connectionMethod.fragmentCallback.paramName)
     ) {
-      const errorUrl = `${origin}/app-connect/${provider}?status=error&message=${encodeURIComponent("No token received")}`;
+      const errorUrl = `${appOrigin}/app-connect/${provider}?status=error&message=${encodeURIComponent("No token received")}`;
       return c.html(
         buildFragmentBridgeHtml(
           appDef.connectionMethod.fragmentCallback.paramName,
@@ -335,7 +336,7 @@ export const appRoutes = () => {
 
     const errorRedirect = (msg: string) =>
       c.redirect(
-        `${origin}/app-connect/${provider}?status=error&message=${encodeURIComponent(msg)}`,
+        `${appOrigin}/app-connect/${provider}?status=error&message=${encodeURIComponent(msg)}`,
       );
 
     try {
@@ -386,7 +387,7 @@ export const appRoutes = () => {
             successParams.set("agent_name", state.agentName as string);
           }
           return c.redirect(
-            `${origin}/app-connect/${provider}?${successParams}`,
+            `${appOrigin}/app-connect/${provider}?${successParams}`,
           );
         }
       }
@@ -396,7 +397,7 @@ export const appRoutes = () => {
         return errorRedirect(`${appDef.name} is not configured`);
       }
 
-      const redirectUri = `${origin}/v1/apps/${provider}/callback`;
+      const redirectUri = `${apiOrigin}/v1/apps/${provider}/callback`;
 
       // Extract all query params as callback params
       const url = new URL(c.req.url);
@@ -462,7 +463,9 @@ export const appRoutes = () => {
         path: `/v1/apps/${provider}/callback`,
       });
 
-      return c.redirect(`${origin}/app-connect/${provider}?${successParams}`);
+      return c.redirect(
+        `${appOrigin}/app-connect/${provider}?${successParams}`,
+      );
     } catch (err) {
       logger.error({ err, provider }, "OAuth callback failed");
       const message =

--- a/packages/api/src/services/agent-service.ts
+++ b/packages/api/src/services/agent-service.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "crypto";
 import { db, Prisma } from "@onecli/db";
 import { ServiceError } from "./errors";
+import { getPolicyValidator } from "../providers/hooks/policy-validator";
 import { IDENTIFIER_REGEX } from "../validations/agent";
 
 export type SecretMode = "all" | "selective";
@@ -319,10 +320,17 @@ export const updateAgentSecrets = async (
   ]);
 };
 
+export type SessionPolicy = Record<string, unknown>;
+
+export interface AgentAppConnectionEntry {
+  appConnectionId: string;
+  sessionPolicy: SessionPolicy | null;
+}
+
 export const getAgentAppConnections = async (
   projectId: string,
   agentId: string,
-) => {
+): Promise<AgentAppConnectionEntry[]> => {
   const agent = await db.agent.findFirst({
     where: { id: agentId, projectId },
     select: { id: true },
@@ -332,16 +340,24 @@ export const getAgentAppConnections = async (
 
   const rows = await db.agentAppConnection.findMany({
     where: { agentId },
-    select: { appConnectionId: true },
+    select: { appConnectionId: true, sessionPolicy: true },
   });
 
-  return rows.map((r) => r.appConnectionId);
+  return rows.map((r) => ({
+    appConnectionId: r.appConnectionId,
+    sessionPolicy: r.sessionPolicy as SessionPolicy | null,
+  }));
 };
+
+export interface AgentAppConnectionInput {
+  appConnectionId: string;
+  sessionPolicy?: SessionPolicy | null;
+}
 
 export const updateAgentAppConnections = async (
   projectId: string,
   agentId: string,
-  appConnectionIds: string[],
+  connections: AgentAppConnectionInput[],
 ) => {
   const agent = await db.agent.findFirst({
     where: { id: agentId, projectId },
@@ -350,12 +366,14 @@ export const updateAgentAppConnections = async (
 
   if (!agent) throw new ServiceError("NOT_FOUND", "Agent not found");
 
+  const appConnectionIds = connections.map((c) => c.appConnectionId);
+
   const project = await db.project.findUnique({
     where: { id: projectId },
     select: { organizationId: true },
   });
 
-  const connections = await db.appConnection.findMany({
+  const dbConnections = await db.appConnection.findMany({
     where: {
       id: { in: appConnectionIds },
       OR: [
@@ -365,10 +383,10 @@ export const updateAgentAppConnections = async (
           : []),
       ],
     },
-    select: { id: true },
+    select: { id: true, provider: true, metadata: true },
   });
 
-  const validIds = new Set(connections.map((c) => c.id));
+  const validIds = new Set(dbConnections.map((c) => c.id));
   const invalid = appConnectionIds.filter((id) => !validIds.has(id));
   if (invalid.length > 0) {
     throw new ServiceError(
@@ -377,10 +395,34 @@ export const updateAgentAppConnections = async (
     );
   }
 
+  const dbConnectionMap = new Map(dbConnections.map((c) => [c.id, c]));
+  const validator = getPolicyValidator();
+  for (const conn of connections) {
+    if (!conn.sessionPolicy || Object.keys(conn.sessionPolicy).length === 0)
+      continue;
+    const dbConn = dbConnectionMap.get(conn.appConnectionId);
+    if (dbConn) {
+      await validator.validate(
+        project?.organizationId ?? "",
+        dbConn.provider,
+        dbConn.metadata as Record<string, unknown> | null,
+        conn.sessionPolicy,
+      );
+    }
+  }
+
   await db.$transaction([
     db.agentAppConnection.deleteMany({ where: { agentId } }),
-    ...appConnectionIds.map((appConnectionId) =>
-      db.agentAppConnection.create({ data: { agentId, appConnectionId } }),
+    ...connections.map((conn) =>
+      db.agentAppConnection.create({
+        data: {
+          agentId,
+          appConnectionId: conn.appConnectionId,
+          sessionPolicy: conn.sessionPolicy
+            ? (conn.sessionPolicy as unknown as Prisma.InputJsonValue)
+            : Prisma.DbNull,
+        },
+      }),
     ),
   ]);
 };

--- a/packages/db/prisma/migrations/20260526232448_session_policy_json/migration.sql
+++ b/packages/db/prisma/migrations/20260526232448_session_policy_json/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `session_policy` column on the `agent_app_connections` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "agent_app_connections" DROP COLUMN "session_policy",
+ADD COLUMN     "session_policy" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -344,7 +344,7 @@ model AppConnection {
 model AgentAppConnection {
   agentId         String        @map("agent_id")
   appConnectionId String        @map("app_connection_id")
-  sessionPolicy   String?       @map("session_policy")
+  sessionPolicy   Json?         @map("session_policy")
   createdAt       DateTime      @default(now()) @map("created_at")
   updatedAt       DateTime      @updatedAt @map("updated_at")
   agent           Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary

- Gateway: comprehensive logging overhaul with span-based context, response hints for deprecated API hosts, approval flow and request identity logging
- Gateway: support org API keys and optional project auth
- Web: granular GitHub app access control with policy dialog
- Web: manage-access-dialog improvements, recent-activity-card updates
- API: policy validator hook, session policy support in agent connections
- DB: add session_policy JSON column to agent_app_connection

## Test plan

- [ ] Verify gateway builds with `cargo build --release`
- [ ] Verify gateway builds without cloud feature
- [ ] Verify web app type checks pass
- [ ] Verify API package type checks pass
- [ ] Run `pnpm check` to validate all linting and types