### PR TITLE
fix: migrate export sends data to cloud instead of itself

### DIFF
--- a/packages/api/src/routes/migrate.ts
+++ b/packages/api/src/routes/migrate.ts
@@ -6,8 +6,11 @@ import { IS_CLOUD } from "../lib/env";
 import { exportToCloud } from "../services/migrate-export-service";
 import { logger } from "../lib/logger";
 
+const CLOUD_API_URL = "https://api.onecli.sh";
+
 const exportSchema = z.object({
   cloudApiKey: z.string().min(1, "Cloud API key is required"),
+  cloudUrl: z.string().url().optional(),
 });
 
 export const migrateRoutes = () => {
@@ -31,7 +34,12 @@ export const migrateRoutes = () => {
       );
     }
 
-    const result = await exportToCloud(projectId, parsed.data.cloudApiKey);
+    const cloudUrl = parsed.data.cloudUrl ?? CLOUD_API_URL;
+    const result = await exportToCloud(
+      projectId,
+      parsed.data.cloudApiKey,
+      cloudUrl,
+    );
 
     logger.info(
       { projectId, imported: result.imported },

--- a/packages/api/src/services/migrate-export-service.ts
+++ b/packages/api/src/services/migrate-export-service.ts
@@ -1,5 +1,5 @@
 import { db } from "@onecli/db";
-import { getCrypto, getSelfUrl } from "../providers";
+import { getCrypto } from "../providers";
 import { ServiceError } from "./errors";
 import { logger } from "../lib/logger";
 
@@ -29,6 +29,7 @@ interface MigrateResult {
 export const exportToCloud = async (
   projectId: string,
   cloudApiKey: string,
+  cloudUrl: string,
 ): Promise<MigrateResult> => {
   // ── Gather data ───────────────────────────────────────────────
 
@@ -150,7 +151,7 @@ export const exportToCloud = async (
 
   // ── Send to cloud ─────────────────────────────────────────────
 
-  const response = await fetch(`${getSelfUrl()}/v1/migrate/import`, {
+  const response = await fetch(`${cloudUrl}/v1/migrate/import`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

The migration export service used `getSelfUrl()` to determine where to POST the import payload, which returned the local server's own URL — causing the local instance to send data to itself (404) instead of to OneCLI Cloud.

- Accept optional `cloudUrl` in the export schema, defaulting to `https://api.onecli.sh`
- Use `cloudUrl` in the export service instead of `getSelfUrl()`

## Test plan

- [ ] `pnpm check` passes
- [ ] Run `onecli migrate --cloud-key <key>` and verify data exports to cloud successfully