### PR TITLE
feat: add Codex (OpenAI OAuth) secret type with auto-refresh

### DIFF
--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -7,6 +7,7 @@
 use base64::Engine;
 
 use crate::inject::Injection;
+use crate::util::parse_jwt_exp;
 
 // ── Host rule ──────────────────────────────────────────────────────────
 
@@ -1681,15 +1682,6 @@ async fn refresh_docker_hub_token(username: &str, password: &str) -> anyhow::Res
     Ok((token, expires_at))
 }
 
-fn parse_jwt_exp(token: &str) -> Option<i64> {
-    let payload = token.split('.').nth(1)?;
-    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(payload.trim_end_matches('='))
-        .ok()?;
-    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
-    json.get("exp")?.as_i64()
-}
-
 // ── Tests ──────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -2396,20 +2388,6 @@ mod tests {
         assert!(providers_for_host("docker.com").is_empty());
         assert!(providers_for_host("registry.docker.com").is_empty());
         assert!(providers_for_host("index.docker.io").is_empty());
-    }
-
-    #[test]
-    fn parse_jwt_exp_extracts_expiry() {
-        // JWT with payload {"exp": 1700000000}
-        let token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3MDAwMDAwMDB9.signature";
-        assert_eq!(parse_jwt_exp(token), Some(1700000000));
-    }
-
-    #[test]
-    fn parse_jwt_exp_returns_none_for_invalid_token() {
-        assert_eq!(parse_jwt_exp("not-a-jwt"), None);
-        assert_eq!(parse_jwt_exp(""), None);
-        assert_eq!(parse_jwt_exp("a.!!!.c"), None);
     }
 
     // ── Monday.com ────────────────────────────────────────────────────

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -14,6 +14,7 @@ use crate::crypto::CryptoService;
 use crate::db;
 use crate::inject::{Injection, InjectionRule};
 use crate::policy::{PolicyAction, PolicyRule};
+use crate::secret_inject;
 
 /// How long to cache resolved connect responses before re-checking.
 const CACHE_TTL_SECS: u64 = 60;
@@ -255,8 +256,27 @@ impl PolicyEngine {
                 }
             };
 
-            let injections =
-                build_injections(&secret.type_, &decrypted, secret.injection_config.as_ref());
+            let effective_value = if secret.type_ == "codex" {
+                match secret_inject::refresh_codex_if_expired(
+                    &self.crypto,
+                    &self.pool,
+                    &decrypted,
+                    &secret.id,
+                )
+                .await
+                {
+                    Some(refreshed) => refreshed,
+                    None => decrypted,
+                }
+            } else {
+                decrypted
+            };
+
+            let injections = secret_inject::build_injections(
+                &secret.type_,
+                &effective_value,
+                secret.injection_config.as_ref(),
+            );
 
             rules.push(InjectionRule {
                 path_pattern: secret
@@ -1046,100 +1066,6 @@ fn host_matches(request_host: &str, pattern: &str) -> bool {
     false
 }
 
-// ── Injection building ──────────────────────────────────────────────────
-
-/// Build injection instructions for a secret based on its type.
-/// Mirrors the logic in `apps/web/src/app/v1/gateway/connect/route.ts`.
-fn build_injections(
-    secret_type: &str,
-    decrypted_value: &str,
-    injection_config: Option<&serde_json::Value>,
-) -> Vec<Injection> {
-    match secret_type {
-        "anthropic" => {
-            let is_oauth = decrypted_value.starts_with("sk-ant-oat");
-            if is_oauth {
-                // OAuth: replace Authorization when the SDK sends the exchange
-                // request. The temp API key from the exchange passes through
-                // untouched on subsequent requests.
-                vec![Injection::ReplaceHeader {
-                    name: "authorization".to_string(),
-                    value: format!("Bearer {decrypted_value}"),
-                }]
-            } else {
-                vec![
-                    Injection::SetHeader {
-                        name: "x-api-key".to_string(),
-                        value: decrypted_value.to_string(),
-                    },
-                    Injection::RemoveHeader {
-                        name: "authorization".to_string(),
-                    },
-                ]
-            }
-        }
-
-        "openai" => vec![Injection::SetHeader {
-            name: "authorization".to_string(),
-            value: format!("Bearer {decrypted_value}"),
-        }],
-
-        "generic" => {
-            let config = injection_config.and_then(|v| v.as_object());
-
-            // Check for header injection
-            let header_name = config
-                .and_then(|c| c.get("headerName"))
-                .and_then(|v| v.as_str());
-
-            // Check for parameter injection
-            let param_name = config
-                .and_then(|c| c.get("paramName"))
-                .and_then(|v| v.as_str());
-
-            if header_name.is_some() && param_name.is_some() {
-                tracing::warn!(
-                    "generic secret has both headerName and paramName; using headerName"
-                );
-            }
-
-            if let Some(header_name) = header_name {
-                let value_format = config
-                    .and_then(|c| c.get("valueFormat"))
-                    .and_then(|v| v.as_str());
-
-                let value = match value_format {
-                    Some(fmt) => fmt.replace("{value}", decrypted_value),
-                    None => decrypted_value.to_string(),
-                };
-
-                vec![Injection::SetHeader {
-                    name: header_name.to_string(),
-                    value,
-                }]
-            } else if let Some(param_name) = param_name {
-                let param_format = config
-                    .and_then(|c| c.get("paramFormat"))
-                    .and_then(|v| v.as_str());
-
-                let value = match param_format {
-                    Some(fmt) => fmt.replace("{value}", decrypted_value),
-                    None => decrypted_value.to_string(),
-                };
-
-                vec![Injection::SetParam {
-                    name: param_name.to_string(),
-                    value,
-                }]
-            } else {
-                vec![]
-            }
-        }
-
-        _ => vec![],
-    }
-}
-
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1286,133 +1212,5 @@ mod tests {
     #[test]
     fn host_wildcard_no_match_without_dot() {
         assert!(!host_matches("notexample.com", "*.example.com"));
-    }
-
-    // ── build_injections ────────────────────────────────────────────────
-
-    #[test]
-    fn build_injections_anthropic_api_key() {
-        let injections = build_injections("anthropic", "sk-ant-api03-test", None);
-        assert_eq!(injections.len(), 2);
-        assert_eq!(
-            injections[0],
-            Injection::SetHeader {
-                name: "x-api-key".to_string(),
-                value: "sk-ant-api03-test".to_string(),
-            }
-        );
-        assert_eq!(
-            injections[1],
-            Injection::RemoveHeader {
-                name: "authorization".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn build_injections_anthropic_oauth() {
-        let injections = build_injections("anthropic", "sk-ant-oat-test-token", None);
-        assert_eq!(injections.len(), 1);
-        assert_eq!(
-            injections[0],
-            Injection::ReplaceHeader {
-                name: "authorization".to_string(),
-                value: "Bearer sk-ant-oat-test-token".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn build_injections_generic_with_format() {
-        let config = serde_json::json!({
-            "headerName": "authorization",
-            "valueFormat": "Bearer {value}"
-        });
-        let injections = build_injections("generic", "my-secret", Some(&config));
-        assert_eq!(injections.len(), 1);
-        assert_eq!(
-            injections[0],
-            Injection::SetHeader {
-                name: "authorization".to_string(),
-                value: "Bearer my-secret".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn build_injections_generic_without_format() {
-        let config = serde_json::json!({
-            "headerName": "x-custom-key"
-        });
-        let injections = build_injections("generic", "raw-value", Some(&config));
-        assert_eq!(injections.len(), 1);
-        assert_eq!(
-            injections[0],
-            Injection::SetHeader {
-                name: "x-custom-key".to_string(),
-                value: "raw-value".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn build_injections_generic_missing_header_name() {
-        let config = serde_json::json!({});
-        let injections = build_injections("generic", "value", Some(&config));
-        assert!(injections.is_empty());
-    }
-
-    #[test]
-    fn build_injections_generic_no_config() {
-        let injections = build_injections("generic", "value", None);
-        assert!(injections.is_empty());
-    }
-
-    #[test]
-    fn build_injections_unknown_type() {
-        let injections = build_injections("unknown", "value", None);
-        assert!(injections.is_empty());
-    }
-
-    // ── build_injections: paramName ─────────────────────────────────────
-
-    #[test]
-    fn build_injections_generic_param_name() {
-        let config = serde_json::json!({ "paramName": "api_key" });
-        let injections = build_injections("generic", "my-secret", Some(&config));
-        assert_eq!(injections.len(), 1);
-        assert_eq!(
-            injections[0],
-            Injection::SetParam {
-                name: "api_key".to_string(),
-                value: "my-secret".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn build_injections_generic_param_name_with_format() {
-        let config = serde_json::json!({ "paramName": "token", "paramFormat": "Bearer-{value}" });
-        let injections = build_injections("generic", "my-secret", Some(&config));
-        assert_eq!(injections.len(), 1);
-        assert_eq!(
-            injections[0],
-            Injection::SetParam {
-                name: "token".to_string(),
-                value: "Bearer-my-secret".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn build_injections_generic_header_takes_precedence_over_param() {
-        // If both headerName and paramName are present, headerName wins
-        let config = serde_json::json!({
-            "headerName": "Authorization",
-            "paramName": "api_key"
-        });
-        let injections = build_injections("generic", "my-secret", Some(&config));
-        assert_eq!(injections.len(), 1);
-        assert!(matches!(injections[0], Injection::SetHeader { .. }));
     }
 }

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -35,6 +35,7 @@ pub(crate) struct AgentRow {
 /// A secret row from the `secrets` table.
 #[derive(Debug, FromRow)]
 pub(crate) struct SecretRow {
+    pub id: String,
     #[sqlx(rename = "type")]
     pub type_: String,
     pub encrypted_value: String,
@@ -42,6 +43,8 @@ pub(crate) struct SecretRow {
     pub path_pattern: Option<String>,
     pub injection_config: Option<serde_json::Value>,
     pub is_platform: bool,
+    #[allow(dead_code)]
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// A policy rule row from the `policy_rules` table.
@@ -211,7 +214,7 @@ pub(crate) async fn find_secrets_by_project(
     project_id: &str,
 ) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform FROM secrets WHERE project_id = $1"#,
+        r#"SELECT id, type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform, metadata FROM secrets WHERE project_id = $1"#,
     )
     .bind(project_id)
     .fetch_all(pool)
@@ -222,7 +225,7 @@ pub(crate) async fn find_secrets_by_project(
 /// Find secrets assigned to a specific agent (selective mode).
 pub(crate) async fn find_secrets_by_agent(pool: &PgPool, agent_id: &str) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT s.type, s.encrypted_value, s.host_pattern, s.path_pattern, s.injection_config, s.is_platform
+        r#"SELECT s.id, s.type, s.encrypted_value, s.host_pattern, s.path_pattern, s.injection_config, s.is_platform, s.metadata
            FROM secrets s
            INNER JOIN agent_secrets as_ ON s.id = as_.secret_id
            WHERE as_.agent_id = $1"#,
@@ -239,7 +242,7 @@ pub(crate) async fn find_secrets_by_org(
     organization_id: &str,
 ) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform
+        r#"SELECT id, type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform, metadata
            FROM secrets
            WHERE organization_id = $1 AND scope = 'organization'"#,
     )
@@ -247,6 +250,21 @@ pub(crate) async fn find_secrets_by_org(
     .fetch_all(pool)
     .await
     .context("querying secrets by organization_id")
+}
+
+/// Update a secret's encrypted value (used for token refresh).
+pub(crate) async fn update_secret_value(
+    pool: &PgPool,
+    secret_id: &str,
+    encrypted_value: &str,
+) -> Result<()> {
+    sqlx::query(r#"UPDATE secrets SET encrypted_value = $1, updated_at = NOW() WHERE id = $2"#)
+        .bind(encrypted_value)
+        .bind(secret_id)
+        .execute(pool)
+        .await
+        .context("updating secret encrypted value")?;
+    Ok(())
 }
 
 /// Find all enabled policy rules for a given project.

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -50,7 +50,9 @@ mod db;
 mod gateway;
 mod inject;
 mod policy;
+mod secret_inject;
 mod telemetry_core;
+mod util;
 
 #[cfg(not(feature = "cloud"))]
 mod telemetry;

--- a/apps/gateway/src/secret_inject.rs
+++ b/apps/gateway/src/secret_inject.rs
@@ -1,0 +1,388 @@
+//! Secret-to-injection mapping and Codex OAuth token refresh.
+//!
+//! Converts decrypted secret values into injection instructions based on the
+//! secret type (anthropic, openai, codex, generic). Also handles Codex OAuth
+//! token refresh and credential persistence.
+
+use tracing::{debug, warn};
+
+use crate::crypto::CryptoService;
+use crate::db;
+use crate::inject::Injection;
+use crate::util;
+
+/// Build injection instructions for a secret based on its type.
+pub(crate) fn build_injections(
+    secret_type: &str,
+    decrypted_value: &str,
+    injection_config: Option<&serde_json::Value>,
+) -> Vec<Injection> {
+    match secret_type {
+        "anthropic" => {
+            let is_oauth = decrypted_value.starts_with("sk-ant-oat");
+            if is_oauth {
+                vec![Injection::ReplaceHeader {
+                    name: "authorization".to_string(),
+                    value: format!("Bearer {decrypted_value}"),
+                }]
+            } else {
+                vec![
+                    Injection::SetHeader {
+                        name: "x-api-key".to_string(),
+                        value: decrypted_value.to_string(),
+                    },
+                    Injection::RemoveHeader {
+                        name: "authorization".to_string(),
+                    },
+                ]
+            }
+        }
+
+        "openai" => vec![Injection::SetHeader {
+            name: "authorization".to_string(),
+            value: format!("Bearer {decrypted_value}"),
+        }],
+
+        "codex" => match serde_json::from_str::<serde_json::Value>(decrypted_value) {
+            Ok(auth) => {
+                let access_token = auth
+                    .get("tokens")
+                    .and_then(|t| t.get("access_token"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if access_token.is_empty() {
+                    warn!("codex secret: no access_token found in auth.json");
+                    vec![]
+                } else {
+                    vec![Injection::SetHeader {
+                        name: "authorization".to_string(),
+                        value: format!("Bearer {access_token}"),
+                    }]
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "codex secret: failed to parse auth.json");
+                vec![]
+            }
+        },
+
+        "generic" => {
+            let config = injection_config.and_then(|v| v.as_object());
+
+            let header_name = config
+                .and_then(|c| c.get("headerName"))
+                .and_then(|v| v.as_str());
+
+            let param_name = config
+                .and_then(|c| c.get("paramName"))
+                .and_then(|v| v.as_str());
+
+            if header_name.is_some() && param_name.is_some() {
+                warn!("generic secret has both headerName and paramName; using headerName");
+            }
+
+            if let Some(header_name) = header_name {
+                let value_format = config
+                    .and_then(|c| c.get("valueFormat"))
+                    .and_then(|v| v.as_str());
+
+                let value = match value_format {
+                    Some(fmt) => fmt.replace("{value}", decrypted_value),
+                    None => decrypted_value.to_string(),
+                };
+
+                vec![Injection::SetHeader {
+                    name: header_name.to_string(),
+                    value,
+                }]
+            } else if let Some(param_name) = param_name {
+                let param_format = config
+                    .and_then(|c| c.get("paramFormat"))
+                    .and_then(|v| v.as_str());
+
+                let value = match param_format {
+                    Some(fmt) => fmt.replace("{value}", decrypted_value),
+                    None => decrypted_value.to_string(),
+                };
+
+                vec![Injection::SetParam {
+                    name: param_name.to_string(),
+                    value,
+                }]
+            } else {
+                vec![]
+            }
+        }
+
+        _ => vec![],
+    }
+}
+
+/// If the codex access_token is expired, refresh it and persist the updated
+/// credentials. Returns `Some(updated_json)` on successful refresh, or
+/// `None` to fall through with the original (possibly expired) value.
+pub(crate) async fn refresh_codex_if_expired(
+    crypto: &CryptoService,
+    pool: &sqlx::PgPool,
+    decrypted_json: &str,
+    secret_id: &str,
+) -> Option<String> {
+    let mut auth: serde_json::Value = serde_json::from_str(decrypted_json).ok()?;
+    let access_token = auth.get("tokens")?.get("access_token")?.as_str()?;
+
+    let exp = util::parse_jwt_exp(access_token)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_secs() as i64;
+
+    if exp > now + 300 {
+        return None;
+    }
+
+    let refresh_token = auth.get("tokens")?.get("refresh_token")?.as_str()?;
+    debug!(secret_id, "codex access_token expired, refreshing");
+
+    match refresh_codex_token(refresh_token).await {
+        Ok((new_access, new_refresh)) => {
+            auth["tokens"]["access_token"] = serde_json::Value::String(new_access);
+            if let Some(rt) = new_refresh {
+                auth["tokens"]["refresh_token"] = serde_json::Value::String(rt);
+            }
+
+            let updated_json = serde_json::to_string(&auth).ok()?;
+
+            if let Ok(encrypted) = crypto.encrypt(&updated_json).await {
+                if let Err(e) = db::update_secret_value(pool, secret_id, &encrypted).await {
+                    warn!(error = ?e, "failed to persist refreshed codex token");
+                }
+            }
+
+            Some(updated_json)
+        }
+        Err(e) => {
+            warn!(error = ?e, "codex token refresh failed, using expired token");
+            None
+        }
+    }
+}
+
+/// Refresh a Codex OAuth access_token using the refresh_token.
+async fn refresh_codex_token(refresh_token: &str) -> anyhow::Result<(String, Option<String>)> {
+    let resp = reqwest::Client::new()
+        .post("https://auth.openai.com/oauth/token")
+        .timeout(std::time::Duration::from_secs(10))
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("codex token refresh request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow::anyhow!(
+            "codex token refresh failed ({status}): {body}"
+        ));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("codex token refresh response parse failed: {e}"))?;
+
+    let access_token = body
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("codex token refresh response missing access_token"))?
+        .to_string();
+
+    let refresh_token = body
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    Ok((access_token, refresh_token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── build_injections: anthropic ────────────────────────────────────
+
+    #[test]
+    fn build_injections_anthropic_api_key() {
+        let injections = build_injections("anthropic", "sk-ant-api03-test", None);
+        assert_eq!(injections.len(), 2);
+        assert_eq!(
+            injections[0],
+            Injection::SetHeader {
+                name: "x-api-key".to_string(),
+                value: "sk-ant-api03-test".to_string(),
+            }
+        );
+        assert_eq!(
+            injections[1],
+            Injection::RemoveHeader {
+                name: "authorization".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_anthropic_oauth() {
+        let injections = build_injections("anthropic", "sk-ant-oat-test-token", None);
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::ReplaceHeader {
+                name: "authorization".to_string(),
+                value: "Bearer sk-ant-oat-test-token".to_string(),
+            }
+        );
+    }
+
+    // ── build_injections: openai ───────────────────────────────────────
+
+    #[test]
+    fn build_injections_openai() {
+        let injections = build_injections("openai", "sk-proj-abc123", None);
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: "Bearer sk-proj-abc123".to_string(),
+            }
+        );
+    }
+
+    // ── build_injections: codex ────────────────────────────────────────
+
+    #[test]
+    fn build_injections_codex_valid() {
+        let auth_json = r#"{"auth_mode":"chatgpt","tokens":{"access_token":"eyJhbGciOiJ","refresh_token":"rt_abc","account_id":"acc_123"},"last_refresh":"2025-01-01T00:00:00Z"}"#;
+        let injections = build_injections("codex", auth_json, None);
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: "Bearer eyJhbGciOiJ".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_codex_missing_token() {
+        let auth_json = r#"{"auth_mode":"chatgpt","tokens":{}}"#;
+        let injections = build_injections("codex", auth_json, None);
+        assert!(injections.is_empty());
+    }
+
+    #[test]
+    fn build_injections_codex_invalid_json() {
+        let injections = build_injections("codex", "not-json", None);
+        assert!(injections.is_empty());
+    }
+
+    // ── build_injections: generic ──────────────────────────────────────
+
+    #[test]
+    fn build_injections_generic_with_format() {
+        let config = serde_json::json!({
+            "headerName": "authorization",
+            "valueFormat": "Bearer {value}"
+        });
+        let injections = build_injections("generic", "my-secret", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: "Bearer my-secret".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_generic_without_format() {
+        let config = serde_json::json!({
+            "headerName": "x-custom-key"
+        });
+        let injections = build_injections("generic", "raw-value", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetHeader {
+                name: "x-custom-key".to_string(),
+                value: "raw-value".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_generic_missing_header_name() {
+        let config = serde_json::json!({});
+        let injections = build_injections("generic", "value", Some(&config));
+        assert!(injections.is_empty());
+    }
+
+    #[test]
+    fn build_injections_generic_no_config() {
+        let injections = build_injections("generic", "value", None);
+        assert!(injections.is_empty());
+    }
+
+    // ── build_injections: paramName ────────────────────────────────────
+
+    #[test]
+    fn build_injections_generic_param_name() {
+        let config = serde_json::json!({ "paramName": "api_key" });
+        let injections = build_injections("generic", "my-secret", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetParam {
+                name: "api_key".to_string(),
+                value: "my-secret".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_generic_param_name_with_format() {
+        let config = serde_json::json!({ "paramName": "token", "paramFormat": "Bearer-{value}" });
+        let injections = build_injections("generic", "my-secret", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetParam {
+                name: "token".to_string(),
+                value: "Bearer-my-secret".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_generic_header_takes_precedence_over_param() {
+        let config = serde_json::json!({
+            "headerName": "Authorization",
+            "paramName": "api_key"
+        });
+        let injections = build_injections("generic", "my-secret", Some(&config));
+        assert_eq!(injections.len(), 1);
+        assert!(matches!(injections[0], Injection::SetHeader { .. }));
+    }
+
+    // ── build_injections: unknown ──────────────────────────────────────
+
+    #[test]
+    fn build_injections_unknown_type() {
+        let injections = build_injections("unknown", "value", None);
+        assert!(injections.is_empty());
+    }
+}

--- a/apps/gateway/src/util.rs
+++ b/apps/gateway/src/util.rs
@@ -1,0 +1,32 @@
+//! Shared utility functions.
+
+use base64::Engine;
+
+/// Parse the `exp` claim from a JWT token without full validation.
+pub(crate) fn parse_jwt_exp(token: &str) -> Option<i64> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload.trim_end_matches('='))
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    json.get("exp")?.as_i64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_jwt_exp_extracts_expiry() {
+        // JWT with payload {"exp": 1700000000}
+        let token = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3MDAwMDAwMDB9.signature";
+        assert_eq!(parse_jwt_exp(token), Some(1700000000));
+    }
+
+    #[test]
+    fn parse_jwt_exp_returns_none_for_invalid_token() {
+        assert_eq!(parse_jwt_exp("not-a-jwt"), None);
+        assert_eq!(parse_jwt_exp(""), None);
+        assert_eq!(parse_jwt_exp("a.!!!.c"), None);
+    }
+}

--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { toast } from "sonner";
-import { ArrowLeft, Key, Settings2 } from "lucide-react";
+import { ArrowLeft, Key, Settings2, Upload } from "lucide-react";
 import { cn } from "@onecli/ui/lib/utils";
 import {
   Dialog,
@@ -38,9 +38,10 @@ import {
   isParamInjection,
   looksLikeAnthropicKey,
   looksLikeOpenaiKey,
+  parseCodexAuthJson,
 } from "@onecli/api/validations/secret";
 
-type SecretType = "anthropic" | "openai" | "generic";
+type SecretType = "anthropic" | "openai" | "codex" | "generic";
 
 interface SecretTypeOption {
   value: SecretType;
@@ -85,8 +86,9 @@ const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
   },
   {
     value: "openai",
-    label: "OpenAI API Key",
-    description: "Inject your OpenAI key into requests to api.openai.com",
+    label: "OpenAI",
+    description:
+      "Inject an API key or Codex OAuth credentials into requests to api.openai.com",
     icon: <OpenAIIcon className="size-5" />,
     hostDefault: "api.openai.com",
     nameDefault: "OpenAI Token",
@@ -156,6 +158,8 @@ export const SecretDialog = ({
   const [saving, setSaving] = useState(false);
 
   const [type, setType] = useState<SecretType>("anthropic");
+  const [openaiMode, setOpenaiMode] = useState<"api-key" | "codex">("api-key");
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState("");
   const [nameTouched, setNameTouched] = useState(false);
   const [value, setValue] = useState("");
@@ -169,6 +173,9 @@ export const SecretDialog = ({
   const [paramName, setParamName] = useState("");
   const [paramFormat, setParamFormat] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState("");
+
+  const effectiveType =
+    type === "openai" && openaiMode === "codex" ? "codex" : type;
 
   const nameError = useMemo(() => validateDisplayName(name), [name]);
   const showNameError = nameTouched && nameError !== null;
@@ -191,10 +198,13 @@ export const SecretDialog = ({
     if (open) {
       setNameTouched(false);
       setAdvancedOpen("");
+      setOpenaiMode("api-key");
       if (secret) {
         const config = secret.injectionConfig as InjectionConfig | null;
         setStep("form");
-        setType(secret.type as SecretType);
+        const secretType = secret.type === "codex" ? "openai" : secret.type;
+        setType(secretType as SecretType);
+        if (secret.type === "codex") setOpenaiMode("codex");
         setName(secret.name);
         setValue("");
         setHostPattern(secret.hostPattern);
@@ -221,7 +231,9 @@ export const SecretDialog = ({
       } else if (prefill) {
         const isParam = !!prefill.paramName;
         setStep("form");
-        setType(prefill.type);
+        const prefillType = prefill.type === "codex" ? "openai" : prefill.type;
+        setType(prefillType as SecretType);
+        if (prefill.type === "codex") setOpenaiMode("codex");
         setName(prefill.name);
         setValue("");
         setHostPattern(prefill.hostPattern);
@@ -270,7 +282,7 @@ export const SecretDialog = ({
   };
 
   const hasInjectionTarget =
-    type !== "generic" ||
+    effectiveType !== "generic" ||
     (injectionTarget === "header" ? headerName.trim() : paramName.trim());
 
   const isPlatformEdit = isEdit && secret?.isPlatform;
@@ -289,7 +301,7 @@ export const SecretDialog = ({
     setSaving(true);
     try {
       const buildInjectionConfig = () => {
-        if (type !== "generic") return undefined;
+        if (effectiveType !== "generic") return undefined;
         if (injectionTarget === "param") {
           return { paramName, paramFormat: paramFormat || "{value}" };
         }
@@ -318,7 +330,7 @@ export const SecretDialog = ({
       } else {
         await createSecret({
           name,
-          type,
+          type: effectiveType,
           value,
           hostPattern,
           pathPattern: pathPattern || undefined,
@@ -345,6 +357,26 @@ export const SecretDialog = ({
   };
 
   const typeOption = SECRET_TYPE_OPTIONS.find((o) => o.value === type)!;
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const contents = (ev.target?.result as string)?.trim();
+      if (!contents) return;
+      if (!parseCodexAuthJson(contents)) {
+        toast.error(
+          "Invalid auth.json — must contain tokens.access_token and tokens.refresh_token",
+        );
+        return;
+      }
+      setValue(contents);
+      if (!name.trim()) setName("Codex Token");
+    };
+    reader.readAsText(file);
+    e.target.value = "";
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -373,10 +405,10 @@ export const SecretDialog = ({
                   : type === "anthropic"
                     ? "Your key will be encrypted and injected into requests to api.anthropic.com."
                     : type === "openai"
-                      ? "Your key will be encrypted and injected into requests to api.openai.com."
+                      ? "Inject credentials into requests to api.openai.com."
                       : "Configure a custom secret to inject as a header or URL parameter into matching requests."}
               </DialogDescription>
-              {type === "generic" && !isEdit && !prefill && (
+              {effectiveType === "generic" && !isEdit && !prefill && (
                 <div className="flex items-center gap-2 pt-1">
                   <span className="text-muted-foreground text-xs">
                     Try an example:
@@ -415,17 +447,106 @@ export const SecretDialog = ({
             </DialogHeader>
 
             <div className="min-h-0 space-y-4 overflow-y-auto py-2">
+              {type === "openai" && !isEdit && (
+                <div className="space-y-2">
+                  <div
+                    className="flex w-full items-center gap-1 rounded-lg border p-1"
+                    role="radiogroup"
+                    aria-label="OpenAI auth method"
+                  >
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={openaiMode === "api-key"}
+                      className={cn(
+                        "flex-1 rounded-md px-3 py-1 text-sm font-medium transition-colors",
+                        openaiMode === "api-key"
+                          ? "bg-brand/10 text-brand"
+                          : "text-muted-foreground hover:bg-brand/5 hover:text-brand/80",
+                      )}
+                      onClick={() => {
+                        setOpenaiMode("api-key");
+                        setName("OpenAI Token");
+                        setValue("");
+                      }}
+                    >
+                      API Key
+                    </button>
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={openaiMode === "codex"}
+                      className={cn(
+                        "flex-1 rounded-md px-3 py-1 text-sm font-medium transition-colors",
+                        openaiMode === "codex"
+                          ? "bg-brand/10 text-brand"
+                          : "text-muted-foreground hover:bg-brand/5 hover:text-brand/80",
+                      )}
+                      onClick={() => {
+                        setOpenaiMode("codex");
+                        setName("Codex Token");
+                        setValue("");
+                      }}
+                    >
+                      Codex (OAuth)
+                    </button>
+                  </div>
+                  <p className="text-muted-foreground text-xs">
+                    {openaiMode === "api-key" ? (
+                      <>
+                        Paste your API key from{" "}
+                        <a
+                          href="https://platform.openai.com/api-keys"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-foreground underline underline-offset-2"
+                        >
+                          platform.openai.com
+                        </a>
+                        .{" "}
+                        <a
+                          href="https://onecli.sh/docs/integrations/openai#setup-api-key"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-foreground underline underline-offset-2"
+                        >
+                          Setup guide
+                        </a>
+                      </>
+                    ) : (
+                      <>
+                        Run{" "}
+                        <code className="bg-muted rounded px-1 py-0.5 text-[11px]">
+                          codex login --device-auth
+                        </code>{" "}
+                        and upload the auth.json file.{" "}
+                        <a
+                          href="https://onecli.sh/docs/integrations/openai#setup-codex-oauth"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-foreground underline underline-offset-2"
+                        >
+                          Setup guide
+                        </a>
+                      </>
+                    )}
+                  </p>
+                </div>
+              )}
+
               {!isPlatformEdit && (
                 <div className="space-y-2">
                   <Label htmlFor="secret-name">Name</Label>
                   <Input
                     id="secret-name"
                     placeholder={
-                      type === "anthropic"
+                      effectiveType === "anthropic"
                         ? "e.g. Anthropic Production Key"
-                        : type === "openai"
-                          ? "e.g. OpenAI Production Key"
-                          : "e.g. GitHub Token"
+                        : effectiveType === "codex"
+                          ? "e.g. Codex Personal"
+                          : effectiveType === "openai"
+                            ? "e.g. OpenAI Production Key"
+                            : "e.g. GitHub Token"
                     }
                     value={name}
                     onChange={(e) => setName(e.target.value)}
@@ -445,83 +566,139 @@ export const SecretDialog = ({
                     ? "Your API key"
                     : isEdit
                       ? "New value"
-                      : "Secret value"}{" "}
+                      : effectiveType === "codex"
+                        ? "Token file"
+                        : "Secret value"}{" "}
                   {isEdit && !isPlatformEdit && (
                     <span className="text-muted-foreground font-normal">
                       (leave empty to keep current)
                     </span>
                   )}
                 </Label>
-                <SecretInput
-                  ref={valueInputRef}
-                  id="secret-value"
-                  placeholder={
-                    type === "anthropic"
-                      ? "sk-ant-api03-..."
-                      : type === "openai"
-                        ? "sk-proj-..."
-                        : "Enter secret value"
-                  }
-                  value={value}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    setValue(val);
-                    if (type === "anthropic" && !name.trim()) {
-                      const detected = detectAnthropicAuthMode(val);
-                      if (detected === "api-key") setName("Anthropic API Key");
-                      else if (detected === "oauth")
-                        setName("Anthropic OAuth Token");
-                    }
-                    if (type === "openai" && !name.trim()) {
-                      if (looksLikeOpenaiKey(val)) setName("OpenAI API Key");
-                    }
-                  }}
-                />
-                <div className="flex items-center gap-2">
-                  {type === "anthropic" &&
-                  value.trim() &&
-                  !looksLikeAnthropicKey(value) ? (
-                    <p className="text-xs text-amber-600 dark:text-amber-400">
-                      {detectAnthropicAuthMode(value) !== null ? (
-                        "This key looks incomplete. Make sure you copied the full value."
+
+                {effectiveType === "codex" ? (
+                  <>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".json,application/json"
+                      className="hidden"
+                      onChange={handleFileUpload}
+                    />
+                    {value ? (
+                      <div className="border-brand/30 bg-brand/5 flex items-center justify-between rounded-md border px-3 py-2.5">
+                        <div className="flex items-center gap-2">
+                          <div className="bg-brand/10 flex size-6 items-center justify-center rounded-full">
+                            <Upload className="text-brand size-3" />
+                          </div>
+                          <span className="text-sm font-medium">auth.json</span>
+                        </div>
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-foreground shrink-0 text-xs transition-colors"
+                          onClick={() => setValue("")}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="border-input hover:border-brand/30 hover:bg-brand/5 flex w-full items-center gap-3 rounded-md border border-dashed px-4 py-3.5 transition-colors"
+                      >
+                        <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-full">
+                          <Upload className="text-muted-foreground size-4" />
+                        </div>
+                        <div className="text-left">
+                          <span className="text-sm font-medium">
+                            Upload auth.json
+                          </span>
+                          <p className="text-muted-foreground text-xs">
+                            ~/.codex/auth.json
+                          </p>
+                        </div>
+                      </button>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <SecretInput
+                      ref={valueInputRef}
+                      id="secret-value"
+                      placeholder={
+                        effectiveType === "anthropic"
+                          ? "sk-ant-api03-..."
+                          : effectiveType === "openai"
+                            ? "sk-proj-..."
+                            : "Enter secret value"
+                      }
+                      value={value}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setValue(val);
+                        if (effectiveType === "anthropic" && !name.trim()) {
+                          const detected = detectAnthropicAuthMode(val);
+                          if (detected === "api-key")
+                            setName("Anthropic API Key");
+                          else if (detected === "oauth")
+                            setName("Anthropic OAuth Token");
+                        }
+                        if (effectiveType === "openai" && !name.trim()) {
+                          if (looksLikeOpenaiKey(val))
+                            setName("OpenAI API Key");
+                        }
+                      }}
+                    />
+                    <div className="flex items-center gap-2">
+                      {effectiveType === "anthropic" &&
+                      value.trim() &&
+                      !looksLikeAnthropicKey(value) ? (
+                        <p className="text-xs text-amber-600 dark:text-amber-400">
+                          {detectAnthropicAuthMode(value) !== null ? (
+                            "This key looks incomplete. Make sure you copied the full value."
+                          ) : (
+                            <>
+                              Keys typically start with{" "}
+                              <code className="text-[11px]">sk-ant-api</code> or{" "}
+                              <code className="text-[11px]">sk-ant-oat</code>
+                            </>
+                          )}
+                        </p>
+                      ) : effectiveType === "openai" &&
+                        value.trim() &&
+                        !looksLikeOpenaiKey(value) ? (
+                        <p className="text-xs text-amber-600 dark:text-amber-400">
+                          {value.startsWith("sk-ant-") ? (
+                            "This looks like an Anthropic key, not an OpenAI key."
+                          ) : value.startsWith("sk-") ? (
+                            "This key looks incomplete. Make sure you copied the full value."
+                          ) : (
+                            <>
+                              Keys typically start with{" "}
+                              <code className="text-[11px]">sk-proj-</code> or{" "}
+                              <code className="text-[11px]">sk-</code>
+                            </>
+                          )}
+                        </p>
                       ) : (
-                        <>
-                          Keys typically start with{" "}
-                          <code className="text-[11px]">sk-ant-api</code> or{" "}
-                          <code className="text-[11px]">sk-ant-oat</code>
-                        </>
+                        <p className="text-muted-foreground text-xs">
+                          {effectiveType === "anthropic"
+                            ? "Paste your API key or OAuth token from the Anthropic Console."
+                            : effectiveType === "openai"
+                              ? "Paste your API key from the OpenAI Dashboard."
+                              : "Encrypted at rest. You won\u2019t be able to view this value again."}
+                        </p>
                       )}
-                    </p>
-                  ) : type === "openai" &&
-                    value.trim() &&
-                    !looksLikeOpenaiKey(value) ? (
-                    <p className="text-xs text-amber-600 dark:text-amber-400">
-                      {value.startsWith("sk-ant-") ? (
-                        "This looks like an Anthropic key, not an OpenAI key."
-                      ) : value.startsWith("sk-") ? (
-                        "This key looks incomplete. Make sure you copied the full value."
-                      ) : (
-                        <>
-                          Keys typically start with{" "}
-                          <code className="text-[11px]">sk-proj-</code> or{" "}
-                          <code className="text-[11px]">sk-</code>
-                        </>
+                      {effectiveType === "anthropic" && (
+                        <AnthropicKeyBadge value={value} />
                       )}
-                    </p>
-                  ) : (
-                    <p className="text-muted-foreground text-xs">
-                      {type === "anthropic"
-                        ? "Paste your API key or OAuth token from the Anthropic Console."
-                        : type === "openai"
-                          ? "Paste your API key from the OpenAI Dashboard."
-                          : "Encrypted at rest. You won\u2019t be able to view this value again."}
-                    </p>
-                  )}
-                  {type === "anthropic" && <AnthropicKeyBadge value={value} />}
-                </div>
+                    </div>
+                  </>
+                )}
               </div>
 
-              {type === "generic" && !prefill && (
+              {effectiveType === "generic" && !prefill && (
                 <div className="space-y-2">
                   <Label htmlFor="secret-host">Host pattern</Label>
                   <Input
@@ -562,7 +739,7 @@ export const SecretDialog = ({
                     </AccordionTrigger>
                     <AccordionContent className="pb-0">
                       <div className="space-y-4">
-                        {(type !== "generic" || !!prefill) && (
+                        {(effectiveType !== "generic" || !!prefill) && (
                           <div className="space-y-2">
                             <Label htmlFor="secret-host">Host pattern</Label>
                             <Input
@@ -585,7 +762,7 @@ export const SecretDialog = ({
                           </div>
                         )}
 
-                        {type === "generic" && (
+                        {effectiveType === "generic" && (
                           <div className="flex items-center gap-3">
                             <Label
                               id="inject-as-label"
@@ -654,7 +831,7 @@ export const SecretDialog = ({
                           </div>
                         )}
 
-                        {type === "generic" && (
+                        {effectiveType === "generic" && (
                           <div
                             key={`name-${injectionTarget}`}
                             className="animate-in fade-in duration-150 space-y-2"
@@ -710,7 +887,7 @@ export const SecretDialog = ({
                           />
                         </div>
 
-                        {type === "generic" && (
+                        {effectiveType === "generic" && (
                           <div
                             key={`format-${injectionTarget}`}
                             className="animate-in fade-in duration-150 space-y-2"

--- a/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
@@ -89,6 +89,15 @@ export const SecretsContent = ({
       });
       setCreateOpen(true);
       router.replace(window.location.pathname, { scroll: false });
+    } else if (createType === "codex" && typeFilter === "llm") {
+      paramHandled.current = true;
+      setPrefill({
+        type: "codex",
+        hostPattern: "api.openai.com",
+        name: "Codex Token",
+      });
+      setCreateOpen(true);
+      router.replace(window.location.pathname, { scroll: false });
     } else if (createType === "generic" && typeFilter === "generic" && host) {
       paramHandled.current = true;
       setPrefill({

--- a/packages/api/src/services/secret-service.ts
+++ b/packages/api/src/services/secret-service.ts
@@ -7,6 +7,7 @@ import {
   detectAnthropicAuthMode,
   isHeaderInjection,
   isParamInjection,
+  parseCodexAuthJson,
   type CreateSecretInput,
   type UpdateSecretInput,
 } from "../validations/secret";
@@ -14,6 +15,7 @@ import {
 const SECRET_TYPE_LABELS: Record<string, string> = {
   anthropic: "Anthropic API Key",
   openai: "OpenAI API Key",
+  codex: "OpenAI Codex (OAuth)",
   generic: "Generic Secret",
 };
 
@@ -52,6 +54,13 @@ const buildMetadata = (
   }
   if (type === "openai") {
     return { authMode: "api-key" } as Prisma.InputJsonValue;
+  }
+  if (type === "codex") {
+    const parsed = parseCodexAuthJson(value);
+    return {
+      authMode: "oauth",
+      accountId: parsed?.tokens?.account_id ?? null,
+    } as Prisma.InputJsonValue;
   }
   return Prisma.JsonNull;
 };
@@ -99,6 +108,15 @@ export const createSecret = async (
   const hostPattern = input.hostPattern.trim();
   if (!hostPattern)
     throw new ServiceError("BAD_REQUEST", "Host pattern is required");
+
+  if (input.type === "codex") {
+    if (!parseCodexAuthJson(value)) {
+      throw new ServiceError(
+        "BAD_REQUEST",
+        "Codex value must be valid auth.json with tokens.access_token and tokens.refresh_token",
+      );
+    }
+  }
 
   if (input.type === "generic") {
     const config = input.injectionConfig;
@@ -205,6 +223,12 @@ export const updateSecret = async (
       } as Prisma.InputJsonValue;
     } else if (secret.type === "openai") {
       data.metadata = { authMode: "api-key" } as Prisma.InputJsonValue;
+    } else if (secret.type === "codex") {
+      const parsed = parseCodexAuthJson(value);
+      data.metadata = {
+        authMode: "oauth",
+        accountId: parsed?.tokens?.account_id ?? null,
+      } as Prisma.InputJsonValue;
     }
   }
 

--- a/packages/api/src/validations/secret.ts
+++ b/packages/api/src/validations/secret.ts
@@ -56,7 +56,7 @@ const hostPatternSchema = z
 
 export const createSecretSchema = z.object({
   name: z.string().trim().min(1).max(255),
-  type: z.enum(["anthropic", "openai", "generic"]),
+  type: z.enum(["anthropic", "openai", "codex", "generic"]),
   value: z.string().min(1).max(10000),
   hostPattern: hostPatternSchema,
   pathPattern: z.string().max(1000).optional(),
@@ -122,3 +122,36 @@ export const looksLikeOpenaiKey = (value: string): boolean =>
   value.startsWith("sk-") &&
   !value.startsWith("sk-ant-") &&
   value.length >= OPENAI_KEY_MIN_LENGTH;
+
+export interface CodexAuthJson {
+  auth_mode?: string;
+  tokens: {
+    id_token?: string | null;
+    access_token: string;
+    refresh_token: string;
+    account_id?: string;
+  };
+  last_refresh?: string;
+}
+
+export interface CodexSecretMetadata {
+  authMode: "oauth";
+  accountId?: string;
+}
+
+export const parseCodexAuthJson = (value: string): CodexAuthJson | null => {
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    const tokens = parsed.tokens as Record<string, unknown> | undefined;
+    if (
+      tokens &&
+      typeof tokens.access_token === "string" &&
+      typeof tokens.refresh_token === "string"
+    ) {
+      return parsed as unknown as CodexAuthJson;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary

- Add a new `codex` secret type for OpenAI Codex CLI OAuth credentials (auth.json)
- Gateway automatically refreshes expired access tokens using the stored refresh token
- Extract `secret_inject` module from `connect.rs` for injection building and codex token refresh
- Extract `util` module with shared `parse_jwt_exp` helper
- Frontend: OpenAI secret dialog now offers API Key / Codex (OAuth) toggle with file upload
- Add client-side and server-side validation for auth.json format
- Add 10s timeout to token refresh HTTP requests

## Changes

**Gateway (Rust):**
- New `secret_inject.rs` — builds injections from secrets, handles codex token refresh
- New `util.rs` — shared JWT exp parsing
- `db.rs` — added `id` and `metadata` to SecretRow, new `update_secret_value` fn
- `connect.rs` — reduced from 1573 to 1218 lines, delegates to `secret_inject`

**Frontend:**
- `secret-dialog.tsx` — OpenAI type now shows API Key / Codex toggle with contextual instructions and file upload for auth.json
- `secrets-content.tsx` — codex prefill handling

**API:**
- `secret-service.ts` — codex validation, metadata building
- `validations/secret.ts` — `parseCodexAuthJson`, `CodexAuthJson` interface
- `migrate-import.ts` — added `openai` and `codex` to migration schema