### PR TITLE
fix: use non-temp path for CODEX_HOME in container config

### DIFF
--- a/packages/api/src/routes/container-config.ts
+++ b/packages/api/src/routes/container-config.ts
@@ -15,7 +15,7 @@ import { getCrypto } from "../providers";
 import { logger } from "../lib/logger";
 
 const CA_CONTAINER_PATH = "/tmp/onecli-gateway-ca.pem";
-const CODEX_HOME_CONTAINER_PATH = "/tmp/onecli-codex";
+const CODEX_HOME_CONTAINER_PATH = "/home/node/.codex";
 
 /**
  * Mark the onboarding survey to record that the agent container is up.


### PR DESCRIPTION
## Summary
- Change `CODEX_HOME_CONTAINER_PATH` from `/tmp/onecli-codex` to `/home/node/.codex`
- The Codex CLI refuses to create helper binaries under `/tmp` (built-in temporary directory safety check) and needs a writable home directory for config and session data
- When the SDK mounts `auth.json` as a read-only file, Docker creates the parent directory as root — making it unwritable for the container process. Using `/home/node/.codex` allows the orchestrator to mount a writable directory first, with the SDK's auth.json overlaid inside it

## Test plan
- [x] Tested end-to-end with nanoclaw agent runtime — Codex responds successfully
- [x] No more "Refusing to create helper binaries under temporary dir" errors
- [x] No more "Permission denied (os error 13)" errors
- [ ] Verify Anthropic path is unaffected (no files in that code path touched)