### PR TITLE
fix: allow digit-leading agent identifiers and flag unknown agents

### DIFF
--- a/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/create-agent-dialog.tsx
@@ -62,7 +62,7 @@ export const CreateAgentDialog = ({
     setIdentifier(value.toLowerCase().replace(/[^a-z0-9-]/g, ""));
   };
 
-  const isValidIdentifier = /^[a-z][a-z0-9-]{0,49}$/.test(identifier);
+  const isValidIdentifier = /^[a-z0-9][a-z0-9-]{0,49}$/.test(identifier);
 
   const handleCreate = () => {
     if (!isNameValid || !isValidIdentifier) return;
@@ -177,7 +177,7 @@ export const CreateAgentDialog = ({
                   }`}
                 >
                   {identifier && !isValidIdentifier
-                    ? "Must start with a letter and contain only lowercase letters, numbers, and hyphens."
+                    ? "Must start with a letter or number and contain only lowercase letters, numbers, and hyphens."
                     : "Used to select this agent in the SDK. Lowercase letters, numbers, and hyphens."}
                 </p>
               </div>

--- a/packages/api/src/routes/container-config.ts
+++ b/packages/api/src/routes/container-config.ts
@@ -76,8 +76,21 @@ export const containerConfigRoutes = () => {
           });
 
       if (!agent && agentIdentifier) {
+        // Fail loud: a container was started for an agent that isn't
+        // registered (its POST /api/agents create was rejected or never ran).
+        // Without this it manifests as a silent hang -- the container boots,
+        // never wires credentials, and never replies. Log it server-side and
+        // return an actionable, machine-detectable error so it's traceable.
+        logger.warn(
+          { projectId, agentIdentifier, route: "GET /v1/container-config" },
+          "container config requested for unregistered agent identifier",
+        );
         return c.json(
-          { error: "Agent with the given identifier not found." },
+          {
+            error: `No agent with identifier "${agentIdentifier}" exists in this project. Create it first via POST /api/agents, or omit the "agent" query parameter to use the project's default agent.`,
+            code: "AGENT_NOT_FOUND",
+            agentIdentifier,
+          },
           404,
         );
       }

--- a/packages/api/src/services/agent-service.ts
+++ b/packages/api/src/services/agent-service.ts
@@ -62,7 +62,7 @@ export const createAgent = async (
   if (!IDENTIFIER_REGEX.test(trimmedIdentifier)) {
     throw new ServiceError(
       "BAD_REQUEST",
-      "Identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens",
+      "Identifier must be 1-50 characters, start with a letter or number, and contain only lowercase letters, numbers, and hyphens",
     );
   }
 

--- a/packages/api/src/validations/agent.ts
+++ b/packages/api/src/validations/agent.ts
@@ -1,18 +1,18 @@
 import { z } from "zod";
 
-export const IDENTIFIER_REGEX = /^[a-z][a-z0-9-]{0,49}$/;
+export const IDENTIFIER_REGEX = /^[a-z0-9][a-z0-9-]{0,49}$/;
 
 export const createAgentSchema = z.object({
   name: z.string().trim().min(1).max(255),
   identifier: z.string().regex(IDENTIFIER_REGEX, {
     message:
-      "Identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens",
+      "Identifier must be 1-50 characters, start with a letter or number, and contain only lowercase letters, numbers, and hyphens",
   }),
   parentIdentifier: z
     .string()
     .regex(IDENTIFIER_REGEX, {
       message:
-        "Parent identifier must be 1-50 characters, start with a letter, and contain only lowercase letters, numbers, and hyphens",
+        "Parent identifier must be 1-50 characters, start with a letter or number, and contain only lowercase letters, numbers, and hyphens",
     })
     .optional(),
 });


### PR DESCRIPTION

## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Agent identifiers are validated against `^[a-z][a-z0-9-]{0,49}$`, which requires a
leading letter. UUID-style identifiers that start with a digit (~62% of UUIDs) get
a `400` on `POST /api/agents`, so the agent is never created — and the container
later boots without credentials and silently hangs. (Reported by Nanoclaw, which
uses UUID identifiers. Not a regression — this rule predates v1.23.)

## What is the new behavior?

- **Allow a leading digit:** `^[a-z0-9][a-z0-9-]{0,49}$`. Lowercased UUID and numeric
  IDs now work. Strictly additive — every existing identifier stays valid, no migration.
  Updated in the validator, the service check, and the dashboard dialog.
- **Loud failure:** `/container-config` now logs a warning and returns a `404` with
  `code: "AGENT_NOT_FOUND"` for an unregistered identifier, instead of a terse message.

## Additional context

- Affects only the `Agent` object (`identifier` + `parentIdentifier`) at create time.
  Gateway routes by access token, not identifier — no routing impact.
- Still lowercase-only (rejects uppercase UUIDs).
- Follow-up in `@onecli-sh/sdk`: `applyContainerConfig` will throw on `4xx` instead of
  silently degrading. (https://github.com/onecli/node-sdk/pull/38)
- `pnpm check` passes.