### PR TITLE
fix: allow creating agents and secrets on self-hosted installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ docker compose -f docker/docker-compose.yml up -d --wait
 
 Open **http://localhost:10254**, create an agent, add your secrets, and point your agent's HTTP gateway to `localhost:10255`.
 
+> The Quick Start runs OneCLI in **local mode** (single-user, no login), so no `.env` or `NEXTAUTH_SECRET` is required. To enable Google OAuth for multiple users, set `NEXTAUTH_SECRET` and the Google credentials (see [Configuration](#configuration)).
+
 ## Features
 
 - **Transparent credential injection**: agents make normal HTTP calls, the gateway handles auth

--- a/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx
@@ -48,7 +48,6 @@ export const GetStartedDialog = ({
   useEffect(() => {
     if (!open) return;
     setLoading(true);
-    setActiveSection("agents");
     getInstallInfo({ fallbackToDefault: true })
       .then(setInstallInfo)
       .finally(() => setLoading(false));
@@ -158,18 +157,27 @@ export const GetStartedDialog = ({
                       </div>
                     </div>
                   ) : (
-                    <p className="text-muted-foreground rounded-lg border p-4 text-sm">
-                      One-command install is available with{" "}
-                      <a
-                        href="https://app.onecli.sh"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-foreground font-medium underline underline-offset-2"
-                      >
-                        OneCLI Cloud
-                      </a>
-                      .
-                    </p>
+                    <div className="space-y-3">
+                      <div className="space-y-2">
+                        <p className="text-muted-foreground text-xs">
+                          Run {activeAgentDef.name} through OneCLI:
+                        </p>
+                        <TryDemoCommand command={runCommand} />
+                      </div>
+                      <p className="text-muted-foreground text-xs">
+                        Requires the OneCLI CLI. One-command install is
+                        available with{" "}
+                        <a
+                          href="https://app.onecli.sh"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-foreground font-medium underline underline-offset-2"
+                        >
+                          OneCLI Cloud
+                        </a>
+                        .
+                      </p>
+                    </div>
                   )}
                 </div>
               )}

--- a/packages/api/src/middleware/auth/resolve.ts
+++ b/packages/api/src/middleware/auth/resolve.ts
@@ -1,4 +1,6 @@
 import { db } from "@onecli/db";
+import { IS_CLOUD } from "../../lib/env";
+import { findUserDefaultProject } from "../../services/organization-service";
 
 export const resolveUserEmail = async (userId: string): Promise<string> => {
   const user = await db.user.findUnique({
@@ -38,7 +40,17 @@ export const resolveProjectId = async (
   userId: string,
 ): Promise<string | null> => {
   const headerProjectId = request.headers.get("x-project-id");
-  if (!headerProjectId) return null;
+
+  if (!headerProjectId) {
+    // Self-hosted/OSS dashboards have no `/p/<projectId>` URL scope to inject
+    // an `x-project-id` header (the proxy strips it), so project-scoped API
+    // calls arrive without one. Fall back to the user's default project (in
+    // OSS there is exactly one). Cloud keeps requiring an explicit project to
+    // avoid ambiguity across a user's multiple projects.
+    if (IS_CLOUD) return null;
+    const defaultProject = await findUserDefaultProject(userId);
+    return defaultProject?.id ?? null;
+  }
 
   const memberOrgIds = await db.user
     .findUnique({


### PR DESCRIPTION
## Problem

On self-hosted (OSS) installs, creating an agent or secret from the dashboard failed. In OSS mode the dashboard has no `/p/<projectId>` URL scope, so the proxy never adds an `x-project-id` header to API calls. `resolveProjectId` returned `null` whenever that header was missing, so project-scoped requests had no project to resolve and were rejected.

## Changes

- **`packages/api/src/middleware/auth/resolve.ts`**: when no `x-project-id` header is present, fall back to the user's default project in OSS mode (`!IS_CLOUD`), where each user has a single project. Cloud still returns `null` so a project must be selected explicitly.
- **`apps/web/src/app/(dashboard)/_components/get-started-dialog.tsx`**: in OSS mode the Get Started dialog now shows a runnable `onecli run` command for the selected agent instead of only linking to OneCLI Cloud.
- **`README.md`**: note that Quick Start runs in local mode, so no `.env` or `NEXTAUTH_SECRET` is needed.

## Testing

- [ ] `@onecli/api` type-checks
- [ ] `web` type-checks
- [ ] Agent and secret creation works on a local/self-hosted install

A few notes:
- The title you have (fix: allow creating agents and secrets on self-hosted installs) is good as-is, and the bug label fits.
- I wrote Testing as an unchecked checklist rather than asserting results, since I haven't run the typechecks in this session. I can run pnpm --filter @onecli/api check-types and the web typecheck now and fill those in if you want verified checkmarks.
- I left off a "Generated with Claude Code" footer given your preference for content that doesn't read as AI-generated; say the word if you'd like the attribution added.
