### PR TITLE
chore: add partner-layer schema and inert hook seams

### DIFF
--- a/apps/gateway/src/cloud/partner.rs
+++ b/apps/gateway/src/cloud/partner.rs
@@ -1,0 +1,6 @@
+//! Cloud partner stub — replaced by cloud overlay.
+//!
+//! This file exists so `cargo fmt` can resolve the `#[path = "cloud/partner.rs"]`
+//! module declaration. The real implementation lives in the cloud repo.
+
+pub(crate) use crate::partner::*;

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -52,6 +52,10 @@ pub(crate) struct ConnectResponse {
     /// Organization policy mode: "allow" (default) or "deny" (block by default).
     #[serde(default)]
     pub policy_mode: String,
+    /// Cloud-only: pending claim token when this org is a partner-created org
+    /// awaiting claim (claim mode). None otherwise. Inert in OSS.
+    #[serde(default)]
+    pub claim_token: Option<String>,
 }
 
 /// Result of per-request app connection resolution.
@@ -195,6 +199,11 @@ impl PolicyEngine {
         }
         .to_string();
 
+        // Cloud-only: resolve claim-mode state once here (cached with the rest
+        // of ConnectResponse for 60s). No-op in OSS (returns None).
+        let claim_token =
+            crate::partner::claim_token_for_org(&self.pool, &agent.organization_id).await;
+
         Ok(ConnectResponse {
             intercept: has_rules || access_restricted,
             injection_rules,
@@ -208,6 +217,7 @@ impl PolicyEngine {
             access_restricted,
             plan,
             policy_mode: agent.policy_mode.clone(),
+            claim_token,
         })
     }
 
@@ -224,12 +234,18 @@ impl PolicyEngine {
                 .await
                 .map_err(db_err)?
         } else {
-            // All mode: org first, project second (project implicitly overrides same-header)
-            let (org_result, project_result) = tokio::join!(
+            // All mode precedence (lowest → highest): partner, then org, then
+            // project. Later same-header injections override earlier ones, so
+            // partner is the lowest-priority fallback. All three tiers resolve
+            // concurrently (this only runs on a cache miss); `inherited_secret_rows`
+            // is a no-op in OSS (returns an empty Vec).
+            let (partner_rows, org_result, project_result) = tokio::join!(
+                crate::partner::inherited_secret_rows(&self.pool, &agent.organization_id),
                 db::find_secrets_by_org(&self.pool, &agent.organization_id),
                 db::find_secrets_by_project(&self.pool, &agent.project_id),
             );
-            let mut merged = org_result.map_err(db_err)?;
+            let mut merged = partner_rows;
+            merged.extend(org_result.map_err(db_err)?);
             merged.extend(project_result.map_err(db_err)?);
             merged
         };
@@ -1154,6 +1170,7 @@ mod tests {
             access_restricted: false,
             plan: "pro".to_string(),
             policy_mode: "allow".to_string(),
+            claim_token: None,
         };
 
         store
@@ -1198,6 +1215,7 @@ mod tests {
             access_restricted: false,
             plan: "pro".to_string(),
             policy_mode: "allow".to_string(),
+            claim_token: None,
         };
 
         // Pre-populate cache with the key format that resolve() uses
@@ -1238,6 +1256,7 @@ mod tests {
             access_restricted: true,
             plan: "pro".to_string(),
             policy_mode: "allow".to_string(),
+            claim_token: None,
         };
 
         store

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -828,6 +828,7 @@ async fn handle_http_proxy(
         finalizer: resolved_finalizer,
         body_transform: resolved_body_transform,
         policy_mode: resolved.policy_mode,
+        claim_token: resolved.claim_token,
     };
 
     let http_client =

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -267,7 +267,7 @@ pub(crate) async fn forward_request(
         inject::apply_injections(&mut headers, &mut upstream_path, &rules.injection_rules);
     let upstream_url = format!("{scheme}://{host}{upstream_path}");
 
-    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, cache, injection_count).await {
+    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, host, cache, injection_count).await {
         return Ok(resp);
     }
 

--- a/apps/gateway/src/gateway/hooks.rs
+++ b/apps/gateway/src/gateway/hooks.rs
@@ -53,6 +53,7 @@ pub(crate) fn prepare_request(
 pub(crate) async fn pre_forward(
     _rules: &ResolvedRules,
     _proxy_ctx: &ProxyContext,
+    _host: &str,
     _cache: &dyn crate::cache::CacheStore,
     _injection_count: usize,
 ) -> Option<Response<ForwardResponseBody>> {

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -209,6 +209,9 @@ pub(crate) struct ResolvedRules {
     pub body_transform: Option<crate::apps::BodyTransform>,
     /// Organization policy mode: "allow" (default) or "deny" (block by default).
     pub policy_mode: String,
+    /// Cloud-only: pending claim token when the org is in claim mode. Inert in OSS.
+    #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+    pub claim_token: Option<String>,
 }
 
 /// Result of per-request rule resolution including app connection disambiguation.
@@ -364,6 +367,7 @@ async fn resolve_rules(
             finalizer,
             body_transform,
             policy_mode: resp.policy_mode,
+            claim_token: resp.claim_token,
         },
         app_connections: resp.app_connections,
     })

--- a/apps/gateway/src/gateway/websocket.rs
+++ b/apps/gateway/src/gateway/websocket.rs
@@ -160,6 +160,12 @@ pub(super) async fn handle_websocket(
         PolicyDecision::Allow => {}
     }
 
+    // Claim mode: block non-LLM WebSocket upgrades until the project is claimed
+    // (cloud-only; no-op in OSS). injection_count is 0 here, so quota is skipped.
+    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, host, cache, 0).await {
+        return Ok(resp);
+    }
+
     let client_upgrade = hyper::upgrade::on(&mut req);
 
     let (parts, _body) = req.into_parts();

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -61,6 +61,15 @@ mod telemetry;
 #[path = "cloud/telemetry.rs"]
 mod telemetry;
 
+// Partner layer (cloud-only). OSS build uses the no-op `partner.rs` stub; the
+// cloud build swaps in `cloud/partner.rs` (+ the `cloud/partner/` submodules).
+#[cfg(not(feature = "cloud"))]
+mod partner;
+
+#[cfg(feature = "cloud")]
+#[path = "cloud/partner.rs"]
+mod partner;
+
 mod vault;
 
 use std::path::{Path, PathBuf};

--- a/apps/gateway/src/partner.rs
+++ b/apps/gateway/src/partner.rs
@@ -1,0 +1,19 @@
+//! Partner layer — stub for the OSS build. All functions are no-ops; the cloud
+//! build swaps this module for `cloud/partner.rs` via `#[path]` in `main.rs`.
+//!
+//! Keeping the same `pub(crate)` surface in both builds lets the shared call
+//! sites (`connect.rs`, `gateway/cloud/hooks.rs`) stay identical and inert in OSS.
+
+use sqlx::PgPool;
+
+use crate::db::SecretRow;
+
+/// Pending claim token when the org is a partner-created org awaiting claim.
+pub(crate) async fn claim_token_for_org(_pool: &PgPool, _org_id: &str) -> Option<String> {
+    None
+}
+
+/// Partner-level inherited secrets (lowest-priority tier).
+pub(crate) async fn inherited_secret_rows(_pool: &PgPool, _org_id: &str) -> Vec<SecretRow> {
+    Vec::new()
+}

--- a/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
@@ -17,6 +17,7 @@ import { extractLabel } from "@onecli/api/services/connection-service";
 import { AppIcon } from "./app-icon";
 import { SecretDialog } from "./secret-dialog";
 import type { SecretActions } from "./types";
+import { labelForScope, type ScopeLabelMap } from "./scope-label";
 
 const defaultGetConnections_ = () =>
   apiGet<{ connections: Awaited<ReturnType<typeof defaultGetConnections>> }>(
@@ -36,6 +37,7 @@ interface ConnectedItem {
   providerCount?: number;
   href?: string;
   inherited?: boolean;
+  scope?: string | null;
   secretData?: {
     id: string;
     name: string;
@@ -70,7 +72,8 @@ interface ConnectedTabProps {
   getVaultConnections?: typeof defaultGetVaultConnections | null;
   basePath?: string;
   secretActions?: SecretActions;
-  pageScope?: "project" | "organization";
+  pageScope?: string;
+  scopeLabels?: ScopeLabelMap;
 }
 
 export const ConnectedTab = ({
@@ -80,6 +83,7 @@ export const ConnectedTab = ({
   basePath,
   secretActions,
   pageScope = "project",
+  scopeLabels,
 }: ConnectedTabProps) => {
   const router = useRouter();
   const pathname = usePathname();
@@ -120,8 +124,9 @@ export const ConnectedTab = ({
           icon: appDef?.icon ?? null,
           darkIcon: appDef?.darkIcon,
           type: "app" as const,
+          scope: c.scope,
           typeLabel: isInherited
-            ? "Organization"
+            ? labelForScope(c.scope, scopeLabels)
             : appDef?.connectionMethod.type === "oauth"
               ? "OAuth"
               : appDef?.connectionMethod.type === "credentials_import"
@@ -147,7 +152,10 @@ export const ConnectedTab = ({
           name: s.name,
           icon: null,
           type: "secret" as const,
-          typeLabel: isInherited ? "Organization" : s.typeLabel,
+          scope: s.scope,
+          typeLabel: isInherited
+            ? labelForScope(s.scope, scopeLabels)
+            : s.typeLabel,
           detail: `Host: ${s.hostPattern}`,
           inherited: isInherited,
           secretData: isInherited ? undefined : s,
@@ -180,6 +188,7 @@ export const ConnectedTab = ({
     getSecrets,
     getVaultConnections,
     pageScope,
+    scopeLabels,
   ]);
 
   useEffect(() => {
@@ -281,7 +290,7 @@ export const ConnectedTab = ({
               <div className="flex items-center gap-2 shrink-0">
                 {item.inherited ? (
                   <Badge variant="outline" className="text-[10px]">
-                    Organization
+                    {labelForScope(item.scope, scopeLabels)}
                   </Badge>
                 ) : (
                   <>

--- a/apps/web/src/app/(dashboard)/connections/_components/scope-label.ts
+++ b/apps/web/src/app/(dashboard)/connections/_components/scope-label.ts
@@ -1,0 +1,27 @@
+/**
+ * Generic scope → display-label mapping for inherited connections/secrets.
+ *
+ * Feature-neutral: the defaults cover the scopes that exist in OSS
+ * (`organization`/`project`); any other scope falls back to a capitalized form,
+ * and callers may pass an `overrides` map to label additional tiers (e.g. a
+ * cloud "partner" tier supplies `{ partner: "Partner" }`). OSS callers pass no
+ * overrides, so behavior is unchanged.
+ */
+export type ScopeLabelMap = Record<string, string>;
+
+const DEFAULT_SCOPE_LABELS: ScopeLabelMap = {
+  organization: "Organization",
+  project: "Project",
+};
+
+export const labelForScope = (
+  scope: string | null | undefined,
+  overrides?: ScopeLabelMap,
+): string => {
+  if (!scope) return "";
+  return (
+    overrides?.[scope] ??
+    DEFAULT_SCOPE_LABELS[scope] ??
+    scope.charAt(0).toUpperCase() + scope.slice(1)
+  );
+};

--- a/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx
@@ -13,6 +13,7 @@ import { SecretCard } from "./secret-card";
 import { SecretDialog, type SecretPrefill } from "./secret-dialog";
 import type { SecretActions } from "./types";
 import { safeDecode } from "./safe-decode";
+import { labelForScope, type ScopeLabelMap } from "./scope-label";
 
 interface Secret {
   id: string;
@@ -32,7 +33,8 @@ interface SecretsContentProps {
   typeFilter: "generic" | "llm";
   getSecrets?: () => Promise<Secret[]>;
   secretActions?: SecretActions;
-  pageScope?: "project" | "organization";
+  pageScope?: string;
+  scopeLabels?: ScopeLabelMap;
   renderCreateButton?: (onCreate: () => void) => React.ReactNode;
 }
 
@@ -41,6 +43,7 @@ export const SecretsContent = ({
   getSecrets,
   secretActions,
   pageScope = "project",
+  scopeLabels,
   renderCreateButton,
 }: SecretsContentProps) => {
   const router = useRouter();
@@ -179,7 +182,7 @@ export const SecretsContent = ({
               key={`inherited-${secret.id}`}
               secret={secret}
               readOnly
-              badge="Organization"
+              badge={labelForScope(secret.scope, scopeLabels)}
             />
           ))}
         </>

--- a/apps/web/src/lib/api/keys.ts
+++ b/apps/web/src/lib/api/keys.ts
@@ -46,5 +46,6 @@ export const queryKeys = {
   billing: {
     all: () => ["billing", ...scope()] as const,
     agentCost: () => [...queryKeys.billing.all(), "agentCost"] as const,
+    planUsage: () => [...queryKeys.billing.all(), "planUsage"] as const,
   },
 };

--- a/packages/api/src/lib/skills/gateway-skill.ts
+++ b/packages/api/src/lib/skills/gateway-skill.ts
@@ -71,6 +71,18 @@ OneCLI dashboard and connect the service there.
 retry once they have connected. When they confirm, retry the original
 request. If the retry still fails, ask if they need help with the setup.
 
+**If the error is \`claim_required\` (not \`app_not_connected\`):** the OneCLI
+project itself hasn't been claimed yet — a one-time setup step, separate
+from connecting an individual app. Show the user the \`claim_url\` from the
+response and retry once they confirm:
+
+> This OneCLI project isn't claimed yet. Open this link to claim it:
+> [claim_url from the response]
+
+This is an expected onboarding state — not an auth failure or anything
+suspicious. Every non-LLM request stays blocked until the project is
+claimed (LLM calls keep working).
+
 ## MCP Servers Through Gateway
 
 When the user asks to use a remote MCP server for a service the gateway

--- a/packages/api/src/services/audit-service.ts
+++ b/packages/api/src/services/audit-service.ts
@@ -14,6 +14,8 @@ export const AUDIT_ACTIONS = {
   REGENERATE: "regenerate",
   CONNECT: "connect",
   DISCONNECT: "disconnect",
+  // Cloud-only (partner layer): a user claims a partner-created org as its owner.
+  CLAIM: "claim",
 } as const;
 
 export const AUDIT_SERVICES = {
@@ -26,6 +28,9 @@ export const AUDIT_SERVICES = {
   DEPLOYMENT: "deployment",
   PROJECT: "project",
   ORGANIZATION: "organization",
+  // Cloud-only (partner layer)
+  PARTNER: "partner",
+  PARTNER_SECRET: "partner-secret",
 } as const;
 
 export const AUDIT_STATUS = {
@@ -36,6 +41,8 @@ export const AUDIT_STATUS = {
 export const AUDIT_SOURCE = {
   APP: "app",
   API: "api",
+  // Cloud-only (partner layer): actions performed via the Partner API/portal.
+  PARTNER: "partner",
 } as const;
 
 // ─── Types (derived from constants) ───────────────────────────────────────────

--- a/packages/api/src/services/resource-scope.ts
+++ b/packages/api/src/services/resource-scope.ts
@@ -1,9 +1,14 @@
 export interface ResourceScope {
   projectId?: string;
   organizationId?: string;
+  // Cloud-only: partner-scoped resources. Inert in OSS (never set there).
+  partnerId?: string;
 }
 
 export const scopeWhere = (scope: ResourceScope) => {
+  if (scope.partnerId) {
+    return { partnerId: scope.partnerId, scope: "partner" as const };
+  }
   if (scope.projectId && scope.organizationId) {
     return {
       OR: [
@@ -28,6 +33,9 @@ export const scopeWhere = (scope: ResourceScope) => {
 };
 
 export const scopeCreate = (scope: ResourceScope) => {
+  if (scope.partnerId) {
+    return { partnerId: scope.partnerId, scope: "partner" as const };
+  }
   if (scope.projectId && scope.organizationId) {
     throw new Error(
       "Cannot create a resource with both projectId and organizationId",
@@ -46,6 +54,9 @@ export const scopeCreate = (scope: ResourceScope) => {
 };
 
 export const scopeOwnership = (scope: ResourceScope, id: string) => {
+  if (scope.partnerId) {
+    return { id, partnerId: scope.partnerId, scope: "partner" as const };
+  }
   if (scope.organizationId) {
     return {
       id,

--- a/packages/db/prisma/migrations/20260604143616_partner_layer/migration.sql
+++ b/packages/db/prisma/migrations/20260604143616_partner_layer/migration.sql
@@ -1,0 +1,129 @@
+-- AlterTable
+ALTER TABLE "app_configs" ADD COLUMN     "partner_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "app_connections" ADD COLUMN     "partner_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "partner_detached_at" TIMESTAMP(3),
+ADD COLUMN     "partner_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "policy_rules" ADD COLUMN     "partner_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "secrets" ADD COLUMN     "partner_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "partners" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "api_key" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "partners_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "partner_members" (
+    "partner_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "user_email" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'owner',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "partner_members_pkey" PRIMARY KEY ("partner_id","user_id")
+);
+
+-- CreateTable
+CREATE TABLE "partner_claims" (
+    "id" TEXT NOT NULL,
+    "partner_id" TEXT NOT NULL,
+    "organization_id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "placeholder_user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "expires_at" TIMESTAMP(3),
+    "claimed_at" TIMESTAMP(3),
+    "claimed_by_user_id" TEXT,
+    "claimed_by_email" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "partner_claims_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "partners_slug_key" ON "partners"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "partners_api_key_key" ON "partners"("api_key");
+
+-- CreateIndex
+CREATE INDEX "partner_members_user_id_idx" ON "partner_members"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "partner_claims_organization_id_key" ON "partner_claims"("organization_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "partner_claims_placeholder_user_id_key" ON "partner_claims"("placeholder_user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "partner_claims_token_key" ON "partner_claims"("token");
+
+-- CreateIndex
+CREATE INDEX "partner_claims_token_idx" ON "partner_claims"("token");
+
+-- CreateIndex
+CREATE INDEX "partner_claims_partner_id_idx" ON "partner_claims"("partner_id");
+
+-- CreateIndex
+CREATE INDEX "partner_claims_status_idx" ON "partner_claims"("status");
+
+-- CreateIndex
+CREATE INDEX "app_configs_partner_id_idx" ON "app_configs"("partner_id");
+
+-- CreateIndex
+CREATE INDEX "app_connections_partner_id_idx" ON "app_connections"("partner_id");
+
+-- CreateIndex
+CREATE INDEX "organizations_partner_id_idx" ON "organizations"("partner_id");
+
+-- CreateIndex
+CREATE INDEX "policy_rules_partner_id_idx" ON "policy_rules"("partner_id");
+
+-- CreateIndex
+CREATE INDEX "secrets_partner_id_idx" ON "secrets"("partner_id");
+
+-- AddForeignKey
+ALTER TABLE "organizations" ADD CONSTRAINT "organizations_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "secrets" ADD CONSTRAINT "secrets_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "policy_rules" ADD CONSTRAINT "policy_rules_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "app_connections" ADD CONSTRAINT "app_connections_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "app_configs" ADD CONSTRAINT "app_configs_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_members" ADD CONSTRAINT "partner_members_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_members" ADD CONSTRAINT "partner_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_claims" ADD CONSTRAINT "partner_claims_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_claims" ADD CONSTRAINT "partner_claims_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_claims" ADD CONSTRAINT "partner_claims_placeholder_user_id_fkey" FOREIGN KEY ("placeholder_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260607142149_partner_claim_placeholder_setnull/migration.sql
+++ b/packages/db/prisma/migrations/20260607142149_partner_claim_placeholder_setnull/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "partner_claims" DROP CONSTRAINT "partner_claims_placeholder_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "partner_claims" ALTER COLUMN "placeholder_user_id" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "partner_claims" ADD CONSTRAINT "partner_claims_placeholder_user_id_fkey" FOREIGN KEY ("placeholder_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -14,15 +14,20 @@ datasource db {
 // multiple organizations (today: one auto-created on signup; future: invited
 // to others, can create more). Projects under an org share its plan/quotas.
 model Organization {
-  id                 String   @id @default(uuid())
+  id                 String    @id @default(uuid())
   name               String
-  slug               String   @unique
-  stripeCustomerId   String?  @unique @map("stripe_customer_id")
-  subscriptionStatus String   @default("free") @map("subscription_status")
-  awsExternalId      String?  @map("aws_external_id")
-  policyMode         String   @default("allow") @map("policy_mode") // "allow" | "deny"
-  createdAt          DateTime @default(now()) @map("created_at")
-  updatedAt          DateTime @updatedAt @map("updated_at")
+  slug               String    @unique
+  stripeCustomerId   String?   @unique @map("stripe_customer_id")
+  subscriptionStatus String    @default("free") @map("subscription_status")
+  awsExternalId      String?   @map("aws_external_id")
+  policyMode         String    @default("allow") @map("policy_mode") // "allow" | "deny"
+  // Cloud-only (inert in OSS): set when this org was created by a Partner.
+  partnerId          String?   @map("partner_id")
+  // Cloud-only (inert in OSS): set when the org detaches from its partner —
+  // stops inheriting partner secrets but keeps partnerId for attribution.
+  partnerDetachedAt  DateTime? @map("partner_detached_at")
+  createdAt          DateTime  @default(now()) @map("created_at")
+  updatedAt          DateTime  @updatedAt @map("updated_at")
 
   projects       Project[]
   members        OrganizationMember[]
@@ -34,7 +39,10 @@ model Organization {
   policyRules    PolicyRule[]
   apiKeys        ApiKey[]
   auditLogs      AuditLog[]
+  partner        Partner?             @relation(fields: [partnerId], references: [id])
+  partnerClaim   PartnerClaim?
 
+  @@index([partnerId])
   @@map("organizations")
 }
 
@@ -124,6 +132,8 @@ model User {
   updatedAgentSecrets     AgentSecret[]        @relation("AgentSecretUpdater")
   provisionedAs           UserProvision?       @relation("ProvisionedUser")
   createdProvisions       UserProvision[]      @relation("ProvisionCreator")
+  partnerMemberships      PartnerMember[]
+  partnerPlaceholderClaim PartnerClaim?        @relation("PartnerPlaceholder")
 
   @@map("users")
 }
@@ -176,9 +186,10 @@ model Agent {
 
 model Secret {
   id              String        @id @default(uuid())
-  scope           String        @default("project") // "project" | "organization"
+  scope           String        @default("project") // "project" | "organization" | "partner"
   projectId       String?       @map("project_id")
   organizationId  String?       @map("organization_id")
+  partnerId       String?       @map("partner_id") // cloud-only: set when scope = "partner"
   name            String
   type            String // "anthropic", "generic"
   encryptedValue  String        @map("encrypted_value") // AES-256-GCM encrypted via CryptoService
@@ -191,20 +202,23 @@ model Secret {
   updatedAt       DateTime      @updatedAt @map("updated_at")
   project         Project?      @relation(fields: [projectId], references: [id])
   organization    Organization? @relation(fields: [organizationId], references: [id])
+  partner         Partner?      @relation(fields: [partnerId], references: [id])
 
   agentSecrets AgentSecret[]
 
   @@index([projectId])
   @@index([organizationId])
+  @@index([partnerId])
   @@index([scope])
   @@map("secrets")
 }
 
 model PolicyRule {
   id              String        @id @default(uuid())
-  scope           String        @default("project") // "project" | "organization"
+  scope           String        @default("project") // "project" | "organization" (partner reserved)
   projectId       String?       @map("project_id")
   organizationId  String?       @map("organization_id")
+  partnerId       String?       @map("partner_id") // cloud-only, reserved for future partner-level rules (inert)
   agentId         String?       @map("agent_id") // null = all agents, set = one agent only (project-scoped only)
   name            String
   hostPattern     String        @map("host_pattern") // "gmail.googleapis.com" or "*.googleapis.com"
@@ -221,9 +235,11 @@ model PolicyRule {
   project         Project?      @relation(fields: [projectId], references: [id])
   organization    Organization? @relation(fields: [organizationId], references: [id])
   agent           Agent?        @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  partner         Partner?      @relation(fields: [partnerId], references: [id])
 
   @@index([projectId])
   @@index([organizationId])
+  @@index([partnerId])
   @@index([scope])
   @@map("policy_rules")
 }
@@ -320,9 +336,10 @@ model OnboardingSurvey {
 
 model AppConnection {
   id                  String               @id @default(uuid())
-  scope               String               @default("project") // "project" | "organization"
+  scope               String               @default("project") // "project" | "organization" (partner reserved)
   projectId           String?              @map("project_id")
   organizationId      String?              @map("organization_id")
+  partnerId           String?              @map("partner_id") // cloud-only, reserved for future partner-level app connections (inert)
   provider            String // "github", "gmail", "google-calendar", "google-drive", etc.
   label               String?              @map("label") // auto-populated from metadata (email/username)
   status              String               @default("connected")
@@ -333,10 +350,12 @@ model AppConnection {
   updatedAt           DateTime             @updatedAt @map("updated_at")
   project             Project?             @relation(fields: [projectId], references: [id])
   organization        Organization?        @relation(fields: [organizationId], references: [id])
+  partner             Partner?             @relation(fields: [partnerId], references: [id])
   agentAppConnections AgentAppConnection[]
 
   @@index([projectId, provider])
   @@index([organizationId, provider])
+  @@index([partnerId])
   @@index([scope])
   @@map("app_connections")
 }
@@ -356,9 +375,10 @@ model AgentAppConnection {
 
 model AppConfig {
   id             String        @id @default(uuid())
-  scope          String        @default("project") // "project" | "organization"
+  scope          String        @default("project") // "project" | "organization" (partner reserved)
   projectId      String?       @map("project_id")
   organizationId String?       @map("organization_id")
+  partnerId      String?       @map("partner_id") // cloud-only, reserved for future partner-level app config (inert)
   provider       String // "github", "gmail", "google-calendar", "google-drive"
   enabled        Boolean       @default(false)
   credentials    String?       @map("credentials") // encrypted (clientSecret)
@@ -367,9 +387,11 @@ model AppConfig {
   updatedAt      DateTime      @updatedAt @map("updated_at")
   project        Project?      @relation(fields: [projectId], references: [id])
   organization   Organization? @relation(fields: [organizationId], references: [id])
+  partner        Partner?      @relation(fields: [partnerId], references: [id])
 
   @@unique([projectId, provider])
   @@unique([organizationId, provider])
+  @@index([partnerId])
   @@index([scope])
   @@map("app_configs")
 }
@@ -399,6 +421,76 @@ model UserProvision {
   @@index([organizationId])
   @@index([expiresAt, status])
   @@map("user_provisions")
+}
+
+// ── Partner (cloud-only) ────────────────────────────────────────────────
+// A Partner is a reseller/agency that sits ABOVE Organization. It creates orgs
+// via the Partner API, provides inherited (lowest-priority) partner secrets, and
+// hands out claim links. Cloud-only behaviour; these tables/columns are inert in
+// OSS (no OSS code reads or writes them), mirroring CliAuthSession/UserProvision.
+
+model Partner {
+  id        String   @id @default(uuid())
+  name      String
+  slug      String   @unique
+  apiKey    String   @unique @map("api_key") // "oc_partner_" + 32 hex
+  status    String   @default("active") // "active" | "suspended"
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  members        PartnerMember[]
+  organizations  Organization[]
+  secrets        Secret[]
+  appConnections AppConnection[]
+  appConfigs     AppConfig[]
+  policyRules    PolicyRule[]
+  partnerClaims  PartnerClaim[]
+
+  @@map("partners")
+}
+
+// Links a Cognito user (User row) to a Partner for partner-portal access.
+// Mirrors OrganizationMember; supports multiple staff per partner.
+model PartnerMember {
+  partnerId String   @map("partner_id")
+  userId    String   @map("user_id")
+  userEmail String   @map("user_email")
+  role      String   @default("owner") // "owner" | "member" (partner-staff role)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  partner Partner @relation(fields: [partnerId], references: [id])
+  user    User    @relation(fields: [userId], references: [id])
+
+  @@id([partnerId, userId])
+  @@index([userId])
+  @@map("partner_members")
+}
+
+// Claim record for a partner-pre-created (unclaimed) organization. Mirrors
+// UserProvision: a placeholder OWNER holds the org+project until a real Cognito
+// user claims it via the token and is promoted to OWNER.
+model PartnerClaim {
+  id                String    @id @default(uuid())
+  partnerId         String    @map("partner_id")
+  organizationId    String    @unique @map("organization_id")
+  projectId         String    @map("project_id")
+  placeholderUserId String?   @unique @map("placeholder_user_id")
+  token             String    @unique
+  status            String    @default("pending") // "pending" | "claimed" | "expired"
+  expiresAt         DateTime? @map("expires_at") // null = never expires (partner orgs are long-lived)
+  claimedAt         DateTime? @map("claimed_at")
+  claimedByUserId   String?   @map("claimed_by_user_id")
+  claimedByEmail    String?   @map("claimed_by_email")
+  createdAt         DateTime  @default(now()) @map("created_at")
+
+  partner      Partner      @relation(fields: [partnerId], references: [id])
+  organization Organization @relation(fields: [organizationId], references: [id])
+  placeholder  User?        @relation("PartnerPlaceholder", fields: [placeholderUserId], references: [id], onDelete: SetNull)
+
+  @@index([token])
+  @@index([partnerId])
+  @@index([status])
+  @@map("partner_claims")
 }
 
 // ── Standalone (no project scoping) ─────────────────────────────────────

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -62,8 +62,8 @@
   --muted-foreground: oklch(0.6 0 0);
   --accent: oklch(0.22 0 0);
   --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive: oklch(0.55 0.2 27.325);
+  --destructive-foreground: oklch(0.75 0.18 25.331);
   --border: oklch(0.3 0 0);
   --input: oklch(0.3 0 0);
   --ring: oklch(0.4 0 0);


### PR DESCRIPTION
Adds the schema and neutral extension points for an organization-level "partner" tier (resellers/agencies that manage organizations). Everything here is **inert by default** — optional schema columns plus no-op gateway/API hooks that an external build implements. OSS behavior is unchanged.

## What's included

- **db**: `Partner`, `PartnerMember`, `PartnerClaim` models and the `Organization.partner_id` / `partner_detached_at` columns, with their migrations.
- **gateway**: a no-op `partner.rs` module (plus the `src/cloud/partner.rs` fmt stub) and claim-mode / inherited-secret hook seams in `connect`, `forward`, `hooks`, `mitm`, `websocket`, and `main`. The seams resolve to no-ops without the `cloud` feature.
- **api**: partner audit actions/services, a `partnerId` resource scope, and a `claim_required` handling note in the gateway skill.
- **web**: a feature-neutral `scope-label` helper and inherited-secret display in the connections UI (no behavior change without partner data).

## Unrelated (also not yet synced)

Two small shared changes from earlier work that hadn't been synced: a `planUsage` billing query key and a dark-mode destructive color tweak.