### PR TITLE
feat(gateway): answer Codex onecli-managed token refresh with a synthetic 200

### DIFF
--- a/apps/gateway/src/budget.rs
+++ b/apps/gateway/src/budget.rs
@@ -1,0 +1,50 @@
+//! Budget layer — stub for the OSS build. All functions are no-ops; the cloud
+//! build swaps this module for `cloud/budget.rs` via `#[path]` in `main.rs`.
+//!
+//! The shared types (`BudgetBinding`, `BudgetPeriod`) and `resolve_bindings` are
+//! referenced by the shared `connect.rs`/`gateway/mitm.rs` threading, so they
+//! exist in both builds with the same surface — inert in OSS
+//! (`resolve_bindings` always returns an empty Vec, so the threaded field stays
+//! empty and the cloud-only enforcement/metering in `cloud/hooks.rs` never runs).
+
+use serde::{Deserialize, Serialize};
+
+// ⚠ KEEP THE TYPES BELOW IDENTICAL to `cloud/budget.rs`. Only one of the two
+// modules compiles per build (feature swap), so a field added to one and not the
+// other will NOT fail compilation — the shared threading in `connect.rs`/
+// `gateway/mitm.rs` just uses whichever copy is active. Treat them as one type.
+
+/// How a budget's spend window resets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BudgetPeriod {
+    /// Resets on the 1st of each month (UTC).
+    Monthly,
+    /// Lifetime cap; never resets.
+    Total,
+}
+
+/// A resolved budget that governs the effective credential for a request's host.
+/// Resolved once at connect time and threaded `ConnectResponse → ResolvedRules`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct BudgetBinding {
+    pub secret_id: String,
+    pub organization_id: String,
+    /// Secret type, selects the metering strategy (e.g. "anthropic").
+    pub secret_type: String,
+    /// Spend ceiling in nano-dollars (1e-9 USD).
+    pub limit_nanos: i64,
+    pub period: BudgetPeriod,
+}
+
+/// Resolve budget bindings for the effective partner secrets among a request's
+/// host-filtered secrets. OSS: always empty (no budgets enforced). Concrete on
+/// `db::SecretRow` — the cloud impl is generic over a `BudgetSecret` trait, but
+/// the stub only needs to accept what `connect.rs` passes (`&[SecretRow]`).
+pub(crate) async fn resolve_bindings(
+    _pool: &sqlx::PgPool,
+    _org_id: &str,
+    _secrets: &[crate::db::SecretRow],
+) -> Vec<BudgetBinding> {
+    Vec::new()
+}

--- a/apps/gateway/src/cloud/budget.rs
+++ b/apps/gateway/src/cloud/budget.rs
@@ -1,0 +1,6 @@
+//! Cloud budget stub — replaced by cloud overlay.
+//!
+//! This file exists so `cargo fmt` can resolve the `#[path = "cloud/budget.rs"]`
+//! module declaration. The real implementation lives in the cloud repo.
+
+pub(crate) use crate::budget::*;

--- a/apps/gateway/src/cloud/trial.rs
+++ b/apps/gateway/src/cloud/trial.rs
@@ -1,4 +1,0 @@
-//! Cloud trial stub — replaced by cloud overlay.
-//!
-//! This file exists so `cargo fmt` can resolve the `#[path = "cloud/trial.rs"]`
-//! module declaration. The real implementation lives in the cloud repo.

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -56,6 +56,10 @@ pub(crate) struct ConnectResponse {
     /// awaiting claim (claim mode). None otherwise. Inert in OSS.
     #[serde(default)]
     pub claim_token: Option<String>,
+    /// Cloud-only: spend budgets governing the effective credential for this
+    /// host (0/1 in practice — the response is per-host). Empty in OSS.
+    #[serde(default)]
+    pub budget_bindings: Vec<crate::budget::BudgetBinding>,
 }
 
 /// Result of per-request app connection resolution.
@@ -179,7 +183,7 @@ impl PolicyEngine {
         agent: &db::AgentRow,
         hostname: &str,
     ) -> Result<ConnectResponse, ConnectError> {
-        let (injection_rules, _has_platform) =
+        let (injection_rules, _has_platform, budget_bindings) =
             self.resolve_secret_injections(agent, hostname).await?;
         let app_connections = self.resolve_app_connections(agent, hostname).await?;
         let policy_rules = self.resolve_policy_rules(agent, hostname).await?;
@@ -218,6 +222,7 @@ impl PolicyEngine {
             plan,
             policy_mode: agent.policy_mode.clone(),
             claim_token,
+            budget_bindings,
         })
     }
 
@@ -227,7 +232,7 @@ impl PolicyEngine {
         &self,
         agent: &db::AgentRow,
         hostname: &str,
-    ) -> Result<(Vec<InjectionRule>, bool), ConnectError> {
+    ) -> Result<(Vec<InjectionRule>, bool, Vec<crate::budget::BudgetBinding>), ConnectError> {
         let secrets = if agent.secret_mode == SECRET_MODE_SELECTIVE {
             // Selective: agent_secrets join returns both project + org assigned secrets
             db::find_secrets_by_agent(&self.pool, &agent.id)
@@ -325,7 +330,13 @@ impl PolicyEngine {
             });
         }
 
-        Ok((rules, has_platform))
+        // Cloud-only: resolve spend budgets for the effective partner credential
+        // among the host-filtered secrets. The budget module owns which partner
+        // secret is effective (by scope, not shadowed). No-op in OSS.
+        let budget_bindings =
+            crate::budget::resolve_bindings(&self.pool, &agent.organization_id, &matching).await;
+
+        Ok((rules, has_platform, budget_bindings))
     }
 
     /// Fetch app connections matching providers for this host (deferred resolution).
@@ -1171,6 +1182,7 @@ mod tests {
             plan: "pro".to_string(),
             policy_mode: "allow".to_string(),
             claim_token: None,
+            budget_bindings: vec![],
         };
 
         store
@@ -1216,6 +1228,7 @@ mod tests {
             plan: "pro".to_string(),
             policy_mode: "allow".to_string(),
             claim_token: None,
+            budget_bindings: vec![],
         };
 
         // Pre-populate cache with the key format that resolve() uses
@@ -1257,6 +1270,7 @@ mod tests {
             plan: "pro".to_string(),
             policy_mode: "allow".to_string(),
             claim_token: None,
+            budget_bindings: vec![],
         };
 
         store

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -36,6 +36,12 @@ pub(crate) struct AgentRow {
 #[derive(Debug, FromRow)]
 pub(crate) struct SecretRow {
     pub id: String,
+    /// "project" | "organization" | "partner". Lets the budget layer identify the
+    /// partner-tier credential by its actual scope — regardless of how the secret
+    /// was resolved (inherited vs. selectively assigned to an agent). Read only by
+    /// the cloud budget module (`BudgetSecret` impl), hence the cfg'd allow.
+    #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+    pub scope: String,
     #[sqlx(rename = "type")]
     pub type_: String,
     pub encrypted_value: String,
@@ -213,7 +219,7 @@ pub(crate) async fn find_secrets_by_project(
     project_id: &str,
 ) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT id, type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform, metadata FROM secrets WHERE project_id = $1"#,
+        r#"SELECT id, scope, type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform, metadata FROM secrets WHERE project_id = $1"#,
     )
     .bind(project_id)
     .fetch_all(pool)
@@ -224,7 +230,7 @@ pub(crate) async fn find_secrets_by_project(
 /// Find secrets assigned to a specific agent (selective mode).
 pub(crate) async fn find_secrets_by_agent(pool: &PgPool, agent_id: &str) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT s.id, s.type, s.encrypted_value, s.host_pattern, s.path_pattern, s.injection_config, s.is_platform, s.metadata
+        r#"SELECT s.id, s.scope, s.type, s.encrypted_value, s.host_pattern, s.path_pattern, s.injection_config, s.is_platform, s.metadata
            FROM secrets s
            INNER JOIN agent_secrets as_ ON s.id = as_.secret_id
            WHERE as_.agent_id = $1"#,
@@ -241,7 +247,7 @@ pub(crate) async fn find_secrets_by_org(
     organization_id: &str,
 ) -> Result<Vec<SecretRow>> {
     sqlx::query_as::<_, SecretRow>(
-        r#"SELECT id, type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform, metadata
+        r#"SELECT id, scope, type, encrypted_value, host_pattern, path_pattern, injection_config, is_platform, metadata
            FROM secrets
            WHERE organization_id = $1 AND scope = 'organization'"#,
     )

--- a/apps/gateway/src/default_interceptions.rs
+++ b/apps/gateway/src/default_interceptions.rs
@@ -1,0 +1,165 @@
+//! Default interceptions: gateway-authored responses for a small set of
+//! predefined endpoints, served WITHOUT forwarding upstream and independent of
+//! whether any secret or app connection is configured.
+//!
+//! Unlike secret/app injection (which rewrites a request that is then forwarded),
+//! a default interception short-circuits the request entirely. These are
+//! protocol workarounds that ship with the gateway, so the registry is static.
+//!
+//! First case: Codex (the OpenAI agent) runs against a stub `~/.codex/auth.json`
+//! whose tokens are the `"onecli-managed"` placeholder. When the stub's
+//! `last_refresh` ages past Codex's ~8-day window, Codex proactively
+//! `POST`s `auth.openai.com/oauth/token` to refresh — which can never succeed
+//! against the placeholder `refresh_token` and produces a retry storm. We answer
+//! that refresh with a synthetic `200`; Codex stamps `last_refresh = now` itself
+//! and goes quiet. The real token is still injected at the actual API call.
+
+use hyper::{Method, StatusCode};
+
+/// Sentinel value used for all placeholder credentials written into agent stubs.
+/// Only requests carrying this value are intercepted; real credentials pass through.
+const ONECLI_MANAGED: &str = "onecli-managed";
+
+/// A gateway-authored response for a predefined endpoint, returned to the client
+/// without forwarding upstream.
+#[derive(Debug)]
+pub(crate) struct SyntheticResponse {
+    pub status: StatusCode,
+    pub body: serde_json::Value,
+}
+
+/// One entry in the default-interception registry.
+#[derive(Debug)]
+pub(crate) struct DefaultInterception {
+    /// Exact hostname (no port), e.g. `"auth.openai.com"`.
+    host: &'static str,
+    /// Path pattern matched via [`crate::inject::path_matches`] (glob-aware).
+    path: &'static str,
+    /// HTTP method this interception applies to.
+    method: Method,
+    /// Inspects the request body and decides whether to intercept. Returning
+    /// `None` lets the request forward normally.
+    handler: fn(&[u8]) -> Option<SyntheticResponse>,
+}
+
+impl DefaultInterception {
+    /// Run this interception's handler against the (buffered) request body.
+    pub(crate) fn handle(&self, body: &[u8]) -> Option<SyntheticResponse> {
+        (self.handler)(body)
+    }
+}
+
+/// The static registry of predefined interceptions.
+static REGISTRY: &[DefaultInterception] = &[DefaultInterception {
+    host: "auth.openai.com",
+    path: "/oauth/token",
+    method: Method::POST,
+    handler: codex_oauth_refresh,
+}];
+
+/// Cheap pre-match on host + path + method, run for every forwarded request
+/// before any body is read. Returns the matching interception, if any.
+pub(crate) fn match_target(
+    host: &str,
+    path: &str,
+    method: &Method,
+) -> Option<&'static DefaultInterception> {
+    REGISTRY.iter().find(|i| {
+        i.host == host && *method == i.method && crate::inject::path_matches(path, i.path)
+    })
+}
+
+/// Seconds advertised in the synthetic refresh response's `expires_in`. Codex
+/// does not read this field (its refresh timing comes from the access-token JWT
+/// `exp` and the `last_refresh` age), so the value is cosmetic; it is kept large
+/// (~30 days) so any other client that did read it would not refresh frequently.
+const SYNTHETIC_EXPIRES_IN_SECS: u64 = 30 * 24 * 60 * 60;
+
+/// Handler for Codex refreshing its `onecli-managed` placeholder OAuth token.
+///
+/// Codex's refresh response type has all-optional fields and ignores any others,
+/// and on any `2xx` Codex stamps `last_refresh = now` to disk itself — so echoing
+/// the placeholders is enough to make it stop retrying. `id_token` is intentionally
+/// omitted: Codex keeps its existing valid one, and a placeholder JWT here would
+/// fail Codex's claim parsing and break the refresh. `token_type`/`expires_in` are
+/// not read by Codex and exist only to mirror a standard OAuth token response.
+///
+/// Real Codex logins carry a real `refresh_token`, fail the sentinel check, and
+/// are forwarded to the real `auth.openai.com` untouched.
+fn codex_oauth_refresh(body: &[u8]) -> Option<SyntheticResponse> {
+    let json: serde_json::Value = serde_json::from_slice(body).ok()?;
+    if json.get("grant_type").and_then(|v| v.as_str()) != Some("refresh_token") {
+        return None;
+    }
+    if json.get("refresh_token").and_then(|v| v.as_str()) != Some(ONECLI_MANAGED) {
+        return None;
+    }
+    Some(SyntheticResponse {
+        status: StatusCode::OK,
+        body: serde_json::json!({
+            "access_token": ONECLI_MANAGED,
+            "refresh_token": ONECLI_MANAGED,
+            "token_type": "Bearer",
+            "expires_in": SYNTHETIC_EXPIRES_IN_SECS,
+        }),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── match_target ───────────────────────────────────────────────────
+
+    #[test]
+    fn match_target_hits_codex_refresh() {
+        let target = match_target("auth.openai.com", "/oauth/token", &Method::POST);
+        assert!(target.is_some());
+    }
+
+    #[test]
+    fn match_target_respects_query_string() {
+        // path_matches strips the query string before comparison.
+        let target = match_target("auth.openai.com", "/oauth/token?foo=bar", &Method::POST);
+        assert!(target.is_some());
+    }
+
+    #[test]
+    fn match_target_misses_other_host_path_method() {
+        assert!(match_target("api.openai.com", "/oauth/token", &Method::POST).is_none());
+        assert!(match_target("auth.openai.com", "/oauth/authorize", &Method::POST).is_none());
+        assert!(match_target("auth.openai.com", "/oauth/token", &Method::GET).is_none());
+    }
+
+    // ── codex_oauth_refresh handler ────────────────────────────────────
+
+    #[test]
+    fn codex_oauth_refresh_intercepts_onecli_managed() {
+        let body = br#"{"client_id":"app_x","grant_type":"refresh_token","refresh_token":"onecli-managed"}"#;
+        let resp = codex_oauth_refresh(body).expect("should intercept");
+        assert_eq!(resp.status, StatusCode::OK);
+        assert_eq!(resp.body["access_token"], "onecli-managed");
+        assert_eq!(resp.body["refresh_token"], "onecli-managed");
+        // id_token is intentionally not returned (Codex keeps its existing one).
+        assert!(resp.body.get("id_token").is_none());
+    }
+
+    #[test]
+    fn codex_oauth_refresh_passes_through_real_token() {
+        let body = br#"{"grant_type":"refresh_token","refresh_token":"rt_real_user_token"}"#;
+        assert!(codex_oauth_refresh(body).is_none());
+    }
+
+    #[test]
+    fn codex_oauth_refresh_passes_through_non_refresh_grant() {
+        let body = br#"{"grant_type":"authorization_code","refresh_token":"onecli-managed"}"#;
+        assert!(codex_oauth_refresh(body).is_none());
+    }
+
+    #[test]
+    fn codex_oauth_refresh_ignores_malformed_or_empty_body() {
+        assert!(codex_oauth_refresh(b"not json").is_none());
+        assert!(codex_oauth_refresh(b"").is_none());
+        assert!(codex_oauth_refresh(b"{}").is_none());
+    }
+}

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -21,10 +21,10 @@ mod finalizers;
 pub(crate) mod forward;
 mod hints;
 #[cfg(not(feature = "cloud"))]
-mod hooks;
+pub(crate) mod hooks;
 #[cfg(feature = "cloud")]
 #[path = "cloud/hooks.rs"]
-mod hooks;
+pub(crate) mod hooks;
 mod mitm;
 mod response;
 mod transforms;
@@ -829,6 +829,7 @@ async fn handle_http_proxy(
         body_transform: resolved_body_transform,
         policy_mode: resolved.policy_mode,
         claim_token: resolved.claim_token,
+        budget_bindings: resolved.budget_bindings,
     };
 
     let http_client =

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use futures_util::{StreamExt, TryStreamExt};
-use http_body_util::{Either, Full};
+use http_body_util::{BodyExt, Either, Full};
 use hyper::body::{Bytes, Frame, Incoming};
 use hyper::header::HeaderName;
 use hyper::{Request, Response, StatusCode};
@@ -18,6 +18,7 @@ use crate::approval::{
 };
 use crate::apps;
 use crate::cache::CacheStore;
+use crate::default_interceptions;
 use crate::inject;
 use crate::policy::{self, PolicyDecision};
 
@@ -61,6 +62,17 @@ fn is_forwarded_response_header(name: &HeaderName) -> bool {
     !HOP_BY_HOP_HEADERS.contains(&name.as_str())
 }
 
+/// Returns true if the request declares a `Content-Length` no larger than `max`.
+/// Absent or oversized `Content-Length` ⇒ false, so the request is left to
+/// forward normally rather than buffered for a default-interception check.
+fn content_length_at_most(headers: &hyper::HeaderMap, max: usize) -> bool {
+    headers
+        .get(hyper::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<usize>().ok())
+        .is_some_and(|n| n <= max)
+}
+
 // ── Request forwarding ──────────────────────────────────────────────────
 
 /// Forward a single HTTP request to the real upstream server and stream the response back.
@@ -85,6 +97,10 @@ const BODY_PREVIEW_BYTES: usize = 4096;
 /// Maximum response body to buffer when checking if a 400 is auth-related.
 /// Auth error messages are small JSON; no need to scan large bodies.
 const AUTH_CHECK_BODY_LIMIT: usize = 8192;
+
+/// Maximum request body we'll buffer to evaluate a default interception.
+/// OAuth refresh bodies are tiny; this only guards against pathological inputs.
+const MAX_DEFAULT_INTERCEPT_BODY: usize = 64 * 1024;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn forward_request(
@@ -126,28 +142,50 @@ pub(crate) async fn forward_request(
                 "expires_in": intercept.expires_in,
                 "token_type": "Bearer",
             });
-            let bytes = Bytes::from(serde_json::to_vec(&body).expect("serializing JSON literal"));
-            let mut resp = Response::new(Either::Left(Full::new(bytes)));
-            *resp.status_mut() = StatusCode::OK;
-            resp.headers_mut().insert(
-                "content-type",
-                hyper::header::HeaderValue::from_static("application/json"),
-            );
-            return Ok(resp);
+            return Ok(response::json(StatusCode::OK, body));
         }
     }
 
-    // Buffer request body for condition matching if any rule has conditions.
-    // In OSS, needs_body_buffer() always returns false → zero overhead.
+    // Default interceptions: gateway-authored responses for predefined endpoints
+    // (e.g. Codex's onecli-managed OAuth refresh), independent of any connected
+    // secret or app. Cheap host/path/method pre-match for every request; only a
+    // matched, small request gets its body buffered and inspected below.
+    let default_target =
+        default_interceptions::match_target(super::strip_port(host), &path, &method)
+            .filter(|_| content_length_at_most(req.headers(), MAX_DEFAULT_INTERCEPT_BODY));
+
+    // Buffer request body for condition matching (cloud) or a matched default
+    // interception. In OSS, needs_body_buffer() is always false → zero overhead
+    // unless a default interception matched.
     let (condition_buffer, req) = if crate::condition_match::needs_body_buffer(&rules.policy_rules)
     {
         let (parts, incoming) = req.into_parts();
         let (buf, fwd_body) =
             crate::condition_match::prepare_body(incoming, method.as_str(), &url).await?;
         (buf, hyper::Request::from_parts(parts, fwd_body))
+    } else if default_target.is_some() {
+        // OSS-safe: fully buffer the known-small body, keeping the bytes for both
+        // the interception check and (if it declines) forwarding.
+        let (parts, incoming) = req.into_parts();
+        let bytes = incoming
+            .collect()
+            .await
+            .context("buffering request body for default interception")?
+            .to_bytes();
+        let req = hyper::Request::from_parts(parts, reqwest::Body::from(bytes.clone()));
+        (Some(bytes.to_vec()), req)
     } else {
         (None, req.map(reqwest::Body::wrap))
     };
+
+    // Answer a matched default interception before any forwarding. A handler that
+    // declines (e.g. a real refresh token) falls through to normal forwarding.
+    if let Some(target) = default_target {
+        if let Some(synth) = target.handle(condition_buffer.as_deref().unwrap_or(&[])) {
+            info!(method = %method, url = %url, "default interception — serving synthetic response");
+            return Ok(response::json(synth.status, synth.body));
+        }
+    }
 
     let has_injections = !rules.injection_rules.is_empty();
     let enforce_deny = has_injections && !policy::is_llm_host(host);
@@ -267,7 +305,9 @@ pub(crate) async fn forward_request(
         inject::apply_injections(&mut headers, &mut upstream_path, &rules.injection_rules);
     let upstream_url = format!("{scheme}://{host}{upstream_path}");
 
-    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, host, cache, injection_count).await {
+    if let Some(resp) =
+        hooks::pre_forward(rules, proxy_ctx, host, cache, pool, injection_count).await
+    {
         return Ok(resp);
     }
 
@@ -508,6 +548,11 @@ pub(crate) async fn forward_request(
         }
         None => forward_body,
     };
+
+    // ── Claim-mode request-body note (cloud) ──────────────────────
+    // For an unclaimed partner-created org, the cloud build injects a calm
+    // claim note into LLM requests; OSS is a passthrough no-op.
+    let forward_body = hooks::prepare_request_body(rules, host, forward_body).await;
 
     // ── Provider-specific request signing ─────────────────────────
     let forward_body = match rules
@@ -839,6 +884,7 @@ fn emit_policy_telemetry(
         connection_label: None,
         existing_log_id: None,
         log_id: None,
+        budget_charge: None,
     });
 }
 
@@ -893,6 +939,7 @@ fn emit_approval_telemetry(
         connection_label: None,
         existing_log_id,
         log_id,
+        budget_charge: None,
     });
 }
 

--- a/apps/gateway/src/gateway/hooks.rs
+++ b/apps/gateway/src/gateway/hooks.rs
@@ -55,9 +55,20 @@ pub(crate) async fn pre_forward(
     _proxy_ctx: &ProxyContext,
     _host: &str,
     _cache: &dyn crate::cache::CacheStore,
+    _pool: &sqlx::PgPool,
     _injection_count: usize,
 ) -> Option<Response<ForwardResponseBody>> {
     None
+}
+
+/// Request-body transform hook. OSS: passthrough. The cloud build injects a
+/// claim note into LLM requests for unclaimed (partner-created) orgs.
+pub(crate) async fn prepare_request_body(
+    _rules: &ResolvedRules,
+    _host: &str,
+    body: reqwest::Body,
+) -> reqwest::Body {
+    body
 }
 
 pub(crate) fn track_and_wrap(
@@ -86,6 +97,7 @@ pub(crate) fn track_and_wrap(
         connection_label: meta.connection_label,
         existing_log_id: meta.existing_log_id,
         log_id: None,
+        budget_charge: None,
     });
     Box::pin(stream.map_ok(Frame::data))
 }

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -111,6 +111,7 @@ pub(super) async fn mitm(
                                     effective_host,
                                     &rules,
                                     &*cache,
+                                    &engine.pool,
                                     &ctx,
                                 )
                                 .await
@@ -212,13 +213,20 @@ pub(crate) struct ResolvedRules {
     /// Cloud-only: pending claim token when the org is in claim mode. Inert in OSS.
     #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
     pub claim_token: Option<String>,
+    /// Cloud-only: spend budgets governing the effective credential for this host
+    /// (0/1 in practice). Empty in OSS.
+    #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+    pub budget_bindings: Vec<crate::budget::BudgetBinding>,
 }
 
 /// Result of per-request rule resolution including app connection disambiguation.
 enum ResolveResult {
     /// Rules resolved successfully, with the raw app connections for the response header.
     Resolved {
-        rules: ResolvedRules,
+        /// Boxed: `ResolvedRules` is large, so inlining it makes this variant
+        /// dwarf the others (`clippy::large_enum_variant`). `Deref` keeps the box
+        /// transparent at the use sites.
+        rules: Box<ResolvedRules>,
         app_connections: Vec<db::AppConnectionRow>,
     },
     /// Multiple connections exist and no header was provided.
@@ -356,7 +364,7 @@ async fn resolve_rules(
     };
 
     Ok(ResolveResult::Resolved {
-        rules: ResolvedRules {
+        rules: Box::new(ResolvedRules {
             injection_rules,
             policy_rules: resp.policy_rules,
             access_restricted: resp.access_restricted,
@@ -368,7 +376,8 @@ async fn resolve_rules(
             body_transform,
             policy_mode: resp.policy_mode,
             claim_token: resp.claim_token,
-        },
+            budget_bindings: resp.budget_bindings,
+        }),
         app_connections: resp.app_connections,
     })
 }

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -39,12 +39,10 @@ fn scoped_url(base: &str, path: &str, project_id: Option<&str>) -> String {
     }
 }
 
-/// Build a JSON error response with the given status code and body.
-/// Used by `forward_request` (MITM and HTTP proxy forwarding path).
-pub(super) fn json_error<S>(
-    status: StatusCode,
-    body: serde_json::Value,
-) -> Response<ForwardBody<S>> {
+/// Build a JSON response with the given status code and body.
+/// Used directly for gateway-authored success responses (token-endpoint and
+/// default interceptions) and via [`json_error`] for error responses.
+pub(super) fn json<S>(status: StatusCode, body: serde_json::Value) -> Response<ForwardBody<S>> {
     let json = body.to_string();
     let mut response = Response::new(Either::Left(Full::new(Bytes::from(json))));
     *response.status_mut() = status;
@@ -52,6 +50,15 @@ pub(super) fn json_error<S>(
         .headers_mut()
         .insert("content-type", HeaderValue::from_static("application/json"));
     response
+}
+
+/// Build a JSON error response with the given status code and body.
+/// Used by `forward_request` (MITM and HTTP proxy forwarding path).
+pub(super) fn json_error<S>(
+    status: StatusCode,
+    body: serde_json::Value,
+) -> Response<ForwardBody<S>> {
+    json(status, body)
 }
 
 /// Build a JSON error response with `axum::body::Body`.

--- a/apps/gateway/src/gateway/websocket.rs
+++ b/apps/gateway/src/gateway/websocket.rs
@@ -90,6 +90,7 @@ pub(super) async fn handle_websocket(
     host: &str,
     rules: &ResolvedRules,
     cache: &dyn CacheStore,
+    pool: &sqlx::PgPool,
     proxy_ctx: &ProxyContext,
 ) -> Result<Response<Either<Full<Bytes>, http_body_util::StreamBody<hooks::BodyStream>>>> {
     let start = std::time::Instant::now();
@@ -162,7 +163,7 @@ pub(super) async fn handle_websocket(
 
     // Claim mode: block non-LLM WebSocket upgrades until the project is claimed
     // (cloud-only; no-op in OSS). injection_count is 0 here, so quota is skipped.
-    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, host, cache, 0).await {
+    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, host, cache, pool, 0).await {
         return Ok(resp);
     }
 
@@ -411,6 +412,7 @@ fn emit_telemetry(
             connection_label: None,
             existing_log_id: None,
             log_id: None,
+            budget_charge: None,
         });
     }
 }

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -47,6 +47,7 @@ mod crypto;
 mod crypto;
 
 mod db;
+mod default_interceptions;
 mod gateway;
 mod inject;
 mod policy;
@@ -69,6 +70,15 @@ mod partner;
 #[cfg(feature = "cloud")]
 #[path = "cloud/partner.rs"]
 mod partner;
+
+// Budget layer (cloud-only). OSS build uses the no-op `budget.rs` stub; the
+// cloud build swaps in `cloud/budget.rs` (+ the `cloud/budget/` submodules).
+#[cfg(not(feature = "cloud"))]
+mod budget;
+
+#[cfg(feature = "cloud")]
+#[path = "cloud/budget.rs"]
+mod budget;
 
 mod vault;
 

--- a/apps/gateway/src/telemetry_core.rs
+++ b/apps/gateway/src/telemetry_core.rs
@@ -40,6 +40,18 @@ pub(crate) enum RequestDecision {
     BlockedByDefaultPolicy,
 }
 
+/// A metered spend charge attached to a request event (cloud budget feature).
+/// Plain data so this shared core stays independent of the swapped `budget`
+/// module; the cloud telemetry flush reads it to accumulate spend. `cost_nanos`
+/// is already priced by the meter — the flush stays provider-agnostic.
+#[allow(dead_code)] // read by cloud telemetry (budget flush), unused in OSS
+pub(crate) struct BudgetCharge {
+    pub secret_id: String,
+    pub organization_id: String,
+    pub period_key: String,
+    pub cost_nanos: i64,
+}
+
 pub(crate) struct RequestEvent {
     #[allow(dead_code)] // read by cloud telemetry (Redis counters), unused in OSS
     pub org_id: String,
@@ -65,6 +77,10 @@ pub(crate) struct RequestEvent {
     pub existing_log_id: Option<String>,
     #[allow(dead_code)] // read by cloud telemetry (pre-assigned INSERT id), unused in OSS
     pub log_id: Option<String>,
+    /// Cloud-only: a metered spend charge to accumulate in the budget flush.
+    /// `None` for non-budgeted requests; always `None` in OSS.
+    #[allow(dead_code)] // read by cloud telemetry (budget flush), unused in OSS
+    pub budget_charge: Option<BudgetCharge>,
 }
 
 pub(crate) static SENDER: OnceLock<mpsc::Sender<RequestEvent>> = OnceLock::new();
@@ -167,6 +183,7 @@ mod tests {
             connection_label: None,
             existing_log_id: None,
             log_id: None,
+            budget_charge: None,
         }
     }
 

--- a/apps/gateway/tests/integration.rs
+++ b/apps/gateway/tests/integration.rs
@@ -330,3 +330,52 @@ fn ca_persists_across_restarts() {
     // Same CA cert across restarts
     assert_eq!(cert_content_1, cert_content_2, "CA cert should persist");
 }
+
+/// A Codex `onecli-managed` token refresh is answered by the gateway's default
+/// interception with a synthetic 200 — never forwarded to the real
+/// `auth.openai.com`. Exercised via the HTTP-proxy path (no TLS/CA/MITM needed),
+/// which reaches the same `forward_request` as the MITM path.
+#[test]
+fn codex_onecli_managed_refresh_is_intercepted() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let db_url = std::env::var("DATABASE_URL").unwrap_or_default();
+    if db_url.is_empty() {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    }
+    let key = std::env::var("SECRET_ENCRYPTION_KEY").unwrap_or_default();
+    if key.is_empty() {
+        eprintln!("skipping: SECRET_ENCRYPTION_KEY not set");
+        return;
+    }
+    let (port, mut child) = start_gateway_with_db(tmp.path(), &db_url, &key, &[]);
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect to gateway");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+
+    // HTTP-proxy POST (absolute URI) carrying the onecli-managed sentinel. The
+    // gateway short-circuits before forwarding, so no egress to auth.openai.com.
+    let body = r#"{"grant_type":"refresh_token","refresh_token":"onecli-managed","client_id":"app_EMoamEEZ73f0CkXaXp7hrann"}"#;
+    let req = format!(
+        "POST http://auth.openai.com/oauth/token HTTP/1.1\r\nHost: auth.openai.com\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    stream.write_all(req.as_bytes()).expect("send request");
+
+    // Read to EOF (Connection: close) so the full synthetic body is captured.
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).ok();
+
+    assert!(
+        resp.contains("HTTP/1.1 200"),
+        "expected synthetic 200, got: {resp}"
+    );
+    assert!(
+        resp.contains("onecli-managed"),
+        "expected synthetic onecli-managed token body, got: {resp}"
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,7 @@
     "./cloud/apps/*": "./src/cloud/apps/*.ts",
     "./cloud/apps/app-permissions/*": "./src/cloud/apps/app-permissions/*.ts",
     "./cloud/auth/*": "./src/cloud/auth/*.ts",
+    "./cloud/partner/*": "./src/cloud/partner/*.ts",
     "./cloud/granular-access": "./src/cloud/granular-access/index.ts"
   },
   "scripts": {

--- a/packages/api/src/lib/codex-stubs.ts
+++ b/packages/api/src/lib/codex-stubs.ts
@@ -4,21 +4,28 @@ const CODEX_ID_TOKEN = [
   "b25lY2xpLW1hbmFnZWQtc2lnbmF0dXJl",
 ].join(".");
 
-export const CODEX_OAUTH_STUB = JSON.stringify(
-  {
-    auth_mode: "chatgpt",
-    OPENAI_API_KEY: null,
-    tokens: {
-      id_token: CODEX_ID_TOKEN,
-      access_token: "onecli-managed",
-      refresh_token: "onecli-managed",
-      account_id: "onecli-managed",
+// Codex treats ~/.codex/auth.json as stale and tries to self-refresh when
+// last_refresh is older than its refresh window — which fails against the
+// onecli-managed placeholder tokens. Build the stub on demand and stamp
+// last_refresh with the current time so it always looks freshly refreshed and
+// the gateway retains refresh control. Generated per call so a long-running
+// API process never serves a stale timestamp.
+export const buildCodexOAuthStub = () =>
+  JSON.stringify(
+    {
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: CODEX_ID_TOKEN,
+        access_token: "onecli-managed",
+        refresh_token: "onecli-managed",
+        account_id: "onecli-managed",
+      },
+      last_refresh: new Date().toISOString(),
     },
-    last_refresh: "2025-01-01T00:00:00Z",
-  },
-  null,
-  2,
-);
+    null,
+    2,
+  );
 
 export const CODEX_APIKEY_STUB = JSON.stringify(
   {

--- a/packages/api/src/routes/container-config.ts
+++ b/packages/api/src/routes/container-config.ts
@@ -8,7 +8,7 @@ import {
   parseAnthropicMetadata,
   parseOpenaiMetadata,
 } from "../validations/secret";
-import { CODEX_OAUTH_STUB } from "../lib/codex-stubs";
+import { buildCodexOAuthStub } from "../lib/codex-stubs";
 import { DEFAULT_AGENT_NAME, DEFAULT_AGENT_IDENTIFIER } from "../lib/constants";
 import { generateAccessToken } from "../services/agent-service";
 import { getCrypto } from "../providers";
@@ -175,7 +175,7 @@ export const containerConfigRoutes = () => {
           openaiEnv.CODEX_HOME = CODEX_HOME_CONTAINER_PATH;
           credentialStubs.push({
             containerPath: `${CODEX_HOME_CONTAINER_PATH}/auth.json`,
-            content: CODEX_OAUTH_STUB,
+            content: buildCodexOAuthStub(),
           });
         } else {
           openaiEnv.OPENAI_API_KEY = "placeholder";

--- a/packages/api/src/routes/credential-stubs.ts
+++ b/packages/api/src/routes/credential-stubs.ts
@@ -3,7 +3,7 @@ import { db } from "@onecli/db";
 import type { ApiEnv } from "../types";
 import { authMiddleware, requireProjectId } from "../middleware/auth";
 import { parseOpenaiMetadata } from "../validations/secret";
-import { CODEX_OAUTH_STUB, CODEX_APIKEY_STUB } from "../lib/codex-stubs";
+import { buildCodexOAuthStub, CODEX_APIKEY_STUB } from "../lib/codex-stubs";
 
 const resolveCodexStub = async (projectId: string, organizationId: string) => {
   const openaiSecrets = await db.secret.findMany({
@@ -27,7 +27,7 @@ const resolveCodexStub = async (projectId: string, organizationId: string) => {
   return {
     agent: "codex",
     filePath: "~/.codex/auth.json",
-    content: allApiKey ? CODEX_APIKEY_STUB : CODEX_OAUTH_STUB,
+    content: allApiKey ? CODEX_APIKEY_STUB : buildCodexOAuthStub(),
     authMode: allApiKey ? "api-key" : "oauth",
     permissions: "0600",
   };

--- a/packages/api/src/services/audit-service.ts
+++ b/packages/api/src/services/audit-service.ts
@@ -31,6 +31,8 @@ export const AUDIT_SERVICES = {
   // Cloud-only (partner layer)
   PARTNER: "partner",
   PARTNER_SECRET: "partner-secret",
+  // Cloud-only (budget module): per-(secret, org) spend caps
+  BUDGET: "budget",
 } as const;
 
 export const AUDIT_STATUS = {

--- a/packages/db/prisma/migrations/20260609114114_partner_member_one_partner_per_user/migration.sql
+++ b/packages/db/prisma/migrations/20260609114114_partner_member_one_partner_per_user/migration.sql
@@ -1,0 +1,6 @@
+-- DropIndex
+DROP INDEX "partner_members_user_id_idx";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "partner_members_user_id_key" ON "partner_members"("user_id");
+

--- a/packages/db/prisma/migrations/20260609154548_budget_module/migration.sql
+++ b/packages/db/prisma/migrations/20260609154548_budget_module/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "budgets" (
+    "id" TEXT NOT NULL,
+    "secret_id" TEXT NOT NULL,
+    "organization_id" TEXT,
+    "project_id" TEXT,
+    "limit_cents" INTEGER NOT NULL,
+    "period" TEXT NOT NULL DEFAULT 'monthly',
+    "created_by" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "budgets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "budget_spends" (
+    "secret_id" TEXT NOT NULL,
+    "organization_id" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "spent_nanos" BIGINT NOT NULL DEFAULT 0,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "budget_spends_pkey" PRIMARY KEY ("secret_id","organization_id","period")
+);
+
+-- CreateIndex
+CREATE INDEX "budgets_secret_id_idx" ON "budgets"("secret_id");
+
+-- CreateIndex
+CREATE INDEX "budgets_organization_id_idx" ON "budgets"("organization_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "budgets_secret_id_organization_id_key" ON "budgets"("secret_id", "organization_id");
+
+-- AddForeignKey
+ALTER TABLE "budgets" ADD CONSTRAINT "budgets_secret_id_fkey" FOREIGN KEY ("secret_id") REFERENCES "secrets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "budgets" ADD CONSTRAINT "budgets_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "budgets" ADD CONSTRAINT "budgets_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Organization {
   auditLogs      AuditLog[]
   partner        Partner?             @relation(fields: [partnerId], references: [id])
   partnerClaim   PartnerClaim?
+  budgets        Budget[] // cloud-only: per-secret spend budgets for this org (inert in OSS)
 
   @@index([partnerId])
   @@map("organizations")
@@ -104,6 +105,7 @@ model Project {
   onboardingSurvey OnboardingSurvey?
   appConnections   AppConnection[]
   appConfigs       AppConfig[]
+  budgets          Budget[] // cloud-only: per-secret spend budgets for this project (inert in OSS)
 
   @@unique([organizationId, slug])
   @@index([organizationId])
@@ -205,6 +207,7 @@ model Secret {
   partner         Partner?      @relation(fields: [partnerId], references: [id])
 
   agentSecrets AgentSecret[]
+  budgets      Budget[] // cloud-only: spend budgets on this secret (inert in OSS)
 
   @@index([projectId])
   @@index([organizationId])
@@ -455,14 +458,16 @@ model PartnerMember {
   partnerId String   @map("partner_id")
   userId    String   @map("user_id")
   userEmail String   @map("user_email")
-  role      String   @default("owner") // "owner" | "member" (partner-staff role)
+  role      String   @default("owner") // "owner" | "admin" | "member" (partner-staff role)
   createdAt DateTime @default(now()) @map("created_at")
 
   partner Partner @relation(fields: [partnerId], references: [id])
   user    User    @relation(fields: [userId], references: [id])
 
   @@id([partnerId, userId])
-  @@index([userId])
+  // A user belongs to at most one partner (the portal / API-key resolution is
+  // single-partner). Unique — not just an index — enforces that at the DB level.
+  @@unique([userId])
   @@map("partner_members")
 }
 
@@ -491,6 +496,46 @@ model PartnerClaim {
   @@index([partnerId])
   @@index([status])
   @@map("partner_claims")
+}
+
+// Cloud-only (inert in OSS): a spend budget on a secret for a consuming scope.
+// Scope-agnostic — partner-ness is implied by the bound secret's scope, so the
+// same model serves a future non-partner flow (org/project capping its own key).
+// Now: secretId = a partner secret, organizationId = the consuming org.
+model Budget {
+  id             String   @id @default(uuid())
+  secretId       String   @map("secret_id")
+  organizationId String?  @map("organization_id")
+  projectId      String?  @map("project_id") // future non-partner scoping
+  limitCents     Int      @map("limit_cents")
+  period         String   @default("monthly") // "monthly" | "total"
+  createdBy      String   @map("created_by")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
+
+  secret       Secret        @relation(fields: [secretId], references: [id], onDelete: Cascade)
+  organization Organization? @relation(fields: [organizationId], references: [id])
+  project      Project?      @relation(fields: [projectId], references: [id])
+
+  @@unique([secretId, organizationId]) // one budget per (secret, consuming org)
+  @@index([secretId])
+  @@index([organizationId])
+  @@map("budgets")
+}
+
+// Cloud-only (inert in OSS): durable accumulated spend, period-windowed to match
+// the gateway's Redis hot counter key. The Redis counter is the hot enforcement
+// source of truth; this is the durable floor (rehydrated into Redis on cache miss
+// so a flush can't silently refill a budget). `spentNanos` = nano-dollars (1e-9).
+model BudgetSpend {
+  secretId       String   @map("secret_id")
+  organizationId String   @map("organization_id")
+  period         String // "m:YYYY-MM" (monthly window) | "total"
+  spentNanos     BigInt   @default(0) @map("spent_nanos")
+  updatedAt      DateTime @updatedAt @map("updated_at")
+
+  @@id([secretId, organizationId, period])
+  @@map("budget_spends")
 }
 
 // ── Standalone (no project scoping) ─────────────────────────────────────


### PR DESCRIPTION
## What

Codex (the OpenAI agent) runs against a stub `~/.codex/auth.json` whose tokens are the `onecli-managed` placeholder. Once the stub's `last_refresh` ages past Codex's ~8-day window, Codex proactively `POST`s `auth.openai.com/oauth/token` to refresh — which can never succeed against the placeholder `refresh_token` and produces a retry storm.

This adds a **default-interception** path: the gateway answers that refresh with a synthetic `200` (served without forwarding upstream), so Codex stamps `last_refresh = now` itself and goes quiet. The real token is still injected at the actual API call.

## Changes

- **Gateway:** new `default_interceptions` module, plus forward/response and request-body hook threading to support gateway-authored responses returned without forwarding upstream.
- **API:** stamp the Codex auth stub's `last_refresh` at request time; tidy credential-stub wiring.
- **Schema:** shared schema alignments — new inert tables and relations, with their matching migrations.
