### PR TITLE
feat: per-agent granular access for app connections

### DIFF
--- a/apps/gateway/src/cloud/granular_access.rs
+++ b/apps/gateway/src/cloud/granular_access.rs
@@ -1,0 +1,9 @@
+//! Cloud granular-access stub — replaced by cloud overlay.
+//!
+//! This file exists so `cargo fmt` can resolve the
+//! `#[path = "cloud/granular_access.rs"]` module declaration in `main.rs`.
+//! The real implementation lives in the cloud repo.
+//!
+//! Unlike the other cloud stubs there is nothing to re-export: the module is
+//! `#[cfg(feature = "cloud")]`-only and is referenced solely from other cloud
+//! modules, so the OSS build never compiles it.

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -79,6 +79,11 @@ pub(crate) enum AppConnectionResult {
         body_transform: Option<apps::BodyTransform>,
         /// Provider name of the resolved connection (e.g., "github-app", "datadog").
         provider: String,
+        /// Per-agent granular-access policy of THIS connection — the one that
+        /// won injection. Carried here (rather than re-derived by a provider
+        /// scan) so request-level enforcement applies the correct policy even
+        /// when an agent has several same-provider connections.
+        session_policy: Option<serde_json::Value>,
     },
     /// No app connections available for this provider.
     NoConnections,
@@ -468,6 +473,7 @@ impl PolicyEngine {
             let mut resolved_finalizer: Option<apps::RequestFinalizer> = None;
             let mut resolved_body_transform: Option<apps::BodyTransform> = None;
             let mut resolved_provider: Option<String> = None;
+            let mut resolved_session_policy: Option<serde_json::Value> = None;
             for conn in app_connections {
                 if let AppConnectionResult::Rules {
                     rules: r,
@@ -477,6 +483,7 @@ impl PolicyEngine {
                     finalizer,
                     body_transform,
                     provider,
+                    session_policy,
                 } = self
                     .resolve_connection_injections(
                         conn,
@@ -500,6 +507,17 @@ impl PolicyEngine {
                     if body_transform.is_some() {
                         resolved_body_transform = body_transform;
                     }
+                    // Tie the granular policy to the connection that actually
+                    // serves THIS host — not merely the first to yield rules. A
+                    // non-serving connection (e.g. a GitHub connection on a
+                    // Dropbox request) still returns `Rules` carrying its own
+                    // policy, so adopting the first would mis-apply it.
+                    let serves_host = request_path
+                        .map(|p| apps::provider_matches_host_and_path(&provider, hostname, p))
+                        .unwrap_or(false);
+                    if serves_host {
+                        resolved_session_policy = session_policy;
+                    }
                     if resolved_provider.is_none() {
                         resolved_provider = Some(provider);
                     }
@@ -518,6 +536,7 @@ impl PolicyEngine {
                 finalizer: resolved_finalizer,
                 body_transform: resolved_body_transform,
                 provider: resolved_provider.unwrap_or_default(),
+                session_policy: resolved_session_policy,
             });
         }
 
@@ -562,6 +581,7 @@ impl PolicyEngine {
                 finalizer: apps::finalizer_for_provider(&conn.provider),
                 body_transform: apps::body_transform_for_provider(&conn.provider),
                 provider: conn.provider.clone(),
+                session_policy: conn.session_policy.clone(),
             });
         }
 
@@ -723,6 +743,7 @@ impl PolicyEngine {
             finalizer: apps::finalizer_for_provider(&conn.provider),
             body_transform: apps::body_transform_for_provider(&conn.provider),
             provider: conn.provider.clone(),
+            session_policy: conn.session_policy.clone(),
         })
     }
 

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -733,6 +733,8 @@ async fn handle_http_proxy(
     // Per-request app connection disambiguation
     let mut resolved_finalizer: Option<crate::apps::RequestFinalizer> = None;
     let mut resolved_body_transform: Option<crate::apps::BodyTransform> = None;
+    // Granular-access policy of the connection that wins injection (if any).
+    let mut resolved_session_policy: Option<serde_json::Value> = None;
     if resolved.injection_rules.is_empty() && !resolved.app_connections.is_empty() {
         let oid = resolved.organization_id.as_deref().unwrap_or("");
         let pid = resolved.project_id.as_deref().unwrap_or("");
@@ -754,11 +756,13 @@ async fn handle_http_proxy(
                 rules,
                 finalizer,
                 body_transform,
+                session_policy,
                 ..
             }) => {
                 resolved.injection_rules = rules;
                 resolved_finalizer = finalizer;
                 resolved_body_transform = body_transform;
+                resolved_session_policy = session_policy;
             }
             Ok(AppConnectionResult::Ambiguous { connections }) => {
                 return Ok(response::multiple_connections_axum(&connections));
@@ -829,6 +833,7 @@ async fn handle_http_proxy(
         body_transform: resolved_body_transform,
         policy_mode: resolved.policy_mode,
         claim_token: resolved.claim_token,
+        session_policy: resolved_session_policy,
         budget_bindings: resolved.budget_bindings,
     };
 

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -154,10 +154,12 @@ pub(crate) async fn forward_request(
         default_interceptions::match_target(super::strip_port(host), &path, &method)
             .filter(|_| content_length_at_most(req.headers(), MAX_DEFAULT_INTERCEPT_BODY));
 
-    // Buffer request body for condition matching (cloud) or a matched default
-    // interception. In OSS, needs_body_buffer() is always false → zero overhead
-    // unless a default interception matched.
+    // Buffer the request body for condition matching, when the request guard needs
+    // to inspect it (e.g. Dropbox folder scoping reads the JSON body), or for a
+    // matched default interception. In OSS, both predicates return false → zero
+    // overhead unless a default interception matched.
     let (condition_buffer, req) = if crate::condition_match::needs_body_buffer(&rules.policy_rules)
+        || hooks::needs_request_body(rules, host, method.as_str(), &path)
     {
         let (parts, incoming) = req.into_parts();
         let (buf, fwd_body) =
@@ -305,8 +307,19 @@ pub(crate) async fn forward_request(
         inject::apply_injections(&mut headers, &mut upstream_path, &rules.injection_rules);
     let upstream_url = format!("{scheme}://{host}{upstream_path}");
 
-    if let Some(resp) =
-        hooks::pre_forward(rules, proxy_ctx, host, cache, pool, injection_count).await
+    if let Some(resp) = hooks::pre_forward(
+        rules,
+        proxy_ctx,
+        host,
+        cache,
+        pool,
+        injection_count,
+        method.as_str(),
+        &path,
+        &headers,
+        condition_buffer.as_deref(),
+    )
+    .await
     {
         return Ok(resp);
     }

--- a/apps/gateway/src/gateway/hooks.rs
+++ b/apps/gateway/src/gateway/hooks.rs
@@ -50,6 +50,18 @@ pub(crate) fn prepare_request(
 ) {
 }
 
+/// Whether the request guard needs the buffered request body to make a
+/// decision. OSS has no request guard → never buffer.
+pub(crate) fn needs_request_body(
+    _rules: &ResolvedRules,
+    _host: &str,
+    _method: &str,
+    _path: &str,
+) -> bool {
+    false
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn pre_forward(
     _rules: &ResolvedRules,
     _proxy_ctx: &ProxyContext,
@@ -57,6 +69,10 @@ pub(crate) async fn pre_forward(
     _cache: &dyn crate::cache::CacheStore,
     _pool: &sqlx::PgPool,
     _injection_count: usize,
+    _method: &str,
+    _path: &str,
+    _headers: &hyper::HeaderMap,
+    _body: Option<&[u8]>,
 ) -> Option<Response<ForwardResponseBody>> {
     None
 }

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -213,6 +213,11 @@ pub(crate) struct ResolvedRules {
     /// Cloud-only: pending claim token when the org is in claim mode. Inert in OSS.
     #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
     pub claim_token: Option<String>,
+    /// Per-agent resource policy (e.g. Dropbox folder allowlist) for the
+    /// connection serving this host. Consumed by the cloud request guard to
+    /// enforce granular access; `None` in the common, unrestricted case.
+    #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
+    pub session_policy: Option<serde_json::Value>,
     /// Cloud-only: spend budgets governing the effective credential for this host
     /// (0/1 in practice). Empty in OSS.
     #[cfg_attr(not(feature = "cloud"), allow(dead_code))]
@@ -220,6 +225,9 @@ pub(crate) struct ResolvedRules {
 }
 
 /// Result of per-request rule resolution including app connection disambiguation.
+// `Resolved` is the large, common variant; this value is built once per request
+// and consumed immediately, so boxing it would only add a hot-path allocation.
+#[allow(clippy::large_enum_variant)]
 enum ResolveResult {
     /// Rules resolved successfully, with the raw app connections for the response header.
     Resolved {
@@ -278,6 +286,8 @@ async fn resolve_rules(
     let mut connection_label: Option<String> = None;
     let mut finalizer: Option<crate::apps::RequestFinalizer> = None;
     let mut body_transform: Option<crate::apps::BodyTransform> = None;
+    // Granular-access policy of the connection that wins injection (if any).
+    let mut session_policy: Option<serde_json::Value> = None;
 
     // If no secret rules, try app connections (per-request disambiguation)
     if injection_rules.is_empty() && !resp.app_connections.is_empty() {
@@ -300,6 +310,7 @@ async fn resolve_rules(
                 connection_label: cl,
                 finalizer: f,
                 body_transform: bt,
+                session_policy: sp,
                 ..
             } => {
                 injection_rules = rules;
@@ -308,6 +319,7 @@ async fn resolve_rules(
                 connection_label = cl;
                 finalizer = f;
                 body_transform = bt;
+                session_policy = sp;
             }
             AppConnectionResult::Ambiguous { connections } => {
                 return Ok(ResolveResult::Ambiguous(connections));
@@ -376,6 +388,7 @@ async fn resolve_rules(
             body_transform,
             policy_mode: resp.policy_mode,
             claim_token: resp.claim_token,
+            session_policy,
             budget_bindings: resp.budget_bindings,
         }),
         app_connections: resp.app_connections,

--- a/apps/gateway/src/gateway/websocket.rs
+++ b/apps/gateway/src/gateway/websocket.rs
@@ -163,7 +163,22 @@ pub(super) async fn handle_websocket(
 
     // Claim mode: block non-LLM WebSocket upgrades until the project is claimed
     // (cloud-only; no-op in OSS). injection_count is 0 here, so quota is skipped.
-    if let Some(resp) = hooks::pre_forward(rules, proxy_ctx, host, cache, pool, 0).await {
+    // WebSocket upgrades are GET with no inspectable body (the resource guard
+    // is a no-op here; Dropbox/folder traffic never arrives over WebSocket).
+    if let Some(resp) = hooks::pre_forward(
+        rules,
+        proxy_ctx,
+        host,
+        cache,
+        pool,
+        0,
+        req.method().as_str(),
+        &path,
+        req.headers(),
+        None,
+    )
+    .await
+    {
         return Ok(resp);
     }
 

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -71,6 +71,14 @@ mod partner;
 #[path = "cloud/partner.rs"]
 mod partner;
 
+// Granular access (cloud-only): generic per-agent scoping for app connections —
+// token-level (e.g. GitHub repo-scoped tokens) or request-level (e.g. Dropbox
+// folder allowlist). No OSS stub: it is referenced only from other cloud-only
+// modules (`cloud/hooks.rs`, `cloud/cloud_apps.rs`).
+#[cfg(feature = "cloud")]
+#[path = "cloud/granular_access.rs"]
+mod granular_access;
+
 // Budget layer (cloud-only). OSS build uses the no-op `budget.rs` stub; the
 // cloud build swaps in `cloud/budget.rs` (+ the `cloud/budget/` submodules).
 #[cfg(not(feature = "cloud"))]

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,29 @@
+import { readdirSync } from "node:fs";
+import path from "node:path";
+
 const isCloud = process.env.NEXT_PUBLIC_EDITION === "cloud";
+
+// Dashboard paths that cloud intentionally serves at the SAME bare URL as OSS (shared).
+// Empty today: cloud namespaces every dashboard feature under /p, /org, /account, so no
+// bare (dashboard) path is shared. Escape hatch if OSS ever adds a dashboard route cloud
+// also wants to keep bare — add it here and it won't be 404'd.
+const CLOUD_SHARED_DASHBOARD_PATHS = new Set([]);
+
+// Bare OSS dashboard route segments, read from the filesystem at build time so new OSS
+// dashboard routes are covered automatically with no list to maintain. Excludes route
+// groups "(x)", private "_x", dynamic "[x]", parallel "@x", and files via a positive
+// name pattern. process.cwd() is apps/web during `next dev`/`next build`.
+const getOssDashboardSegments = () => {
+  const dir = path.join(process.cwd(), "src", "app", "(dashboard)");
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && /^[a-z0-9][a-z0-9-]*$/.test(e.name))
+      .map((e) => `/${e.name}`)
+      .filter((p) => !CLOUD_SHARED_DASHBOARD_PATHS.has(p));
+  } catch {
+    return [];
+  }
+};
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -45,6 +70,19 @@ const nextConfig = {
           "@/lib/api-fetch": "@/cloud/api-fetch",
         }
       : {},
+  },
+  async rewrites() {
+    // Cloud ships the OSS bare dashboard routes too (cloud may only add files), but only
+    // serves them namespaced under /p, /org, /account. Shadow each bare path (and its
+    // subpaths) before the filesystem route matches, rewriting to Next's built-in
+    // not-found route ("/_not-found") so the existing app/not-found.tsx renders with a
+    // real 404 and the requested URL is preserved. OSS edition: no-op.
+    if (!isCloud) return [];
+    const beforeFiles = getOssDashboardSegments().flatMap((seg) => [
+      { source: seg, destination: "/_not-found" },
+      { source: `${seg}/:path*`, destination: "/_not-found" },
+    ]);
+    return { beforeFiles };
   },
 };
 

--- a/apps/web/src/app/(dashboard)/agents/_components/manage-access-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/agents/_components/manage-access-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useMemo } from "react";
-import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { AppIcon } from "@/app/(dashboard)/connections/_components/app-icon";
 import {
   KeyRound,
@@ -25,20 +24,16 @@ import { Badge } from "@onecli/ui/components/badge";
 import { Checkbox } from "@onecli/ui/components/checkbox";
 import { ScrollArea } from "@onecli/ui/components/scroll-area";
 import { cn } from "@onecli/ui/lib/utils";
-import { useQueryClient } from "@tanstack/react-query";
 import {
-  secrets as secretsApi,
-  connections as connectionsApi,
-} from "@/lib/api";
+  useAgentSecrets,
+  useAgentConnections,
+  useUpdateSecretMode,
+  useUpdateAgentSecrets,
+  useUpdateAgentConnections,
+} from "@/hooks/use-agents";
+import { useSecrets } from "@/hooks/use-secrets";
+import { useConnections } from "@/hooks/use-connections";
 import type { Secret, Connection } from "@/lib/api";
-import { queryKeys } from "@/lib/api/keys";
-import {
-  getAgentSecrets,
-  updateAgentSecretMode,
-  updateAgentSecrets,
-  getAgentAppConnections,
-  updateAgentAppConnections,
-} from "@/lib/actions/agents";
 import { getApp } from "@onecli/api/apps/registry";
 import { extractLabel } from "@onecli/api/services/connection-service";
 import type { SecretMode } from "@onecli/api/services/agent-service";
@@ -62,22 +57,31 @@ export const ManageAccessDialog = ({
   onOpenChange,
   onUpdated,
 }: ManageAccessDialogProps) => {
-  const invalidateCache = useInvalidateGatewayCache();
-  const queryClient = useQueryClient();
+  // Reads via React Query. The shared secret/connection lists are cached and
+  // deduped; the agent's current assignments are gated on `open` so they don't
+  // fetch while the dialog is closed.
+  const { data: secretsList = [], isPending: secretsLoading } = useSecrets();
+  const { data: connectionsList = [], isPending: connectionsLoading } =
+    useConnections();
+  const { data: assignedSecretIds, isPending: assignedSecretsLoading } =
+    useAgentSecrets(agent.id, open);
+  const { data: assignedConnections, isPending: assignedConnectionsLoading } =
+    useAgentConnections(agent.id, open);
+
+  const updateSecretMode = useUpdateSecretMode();
+  const updateAgentSecrets = useUpdateAgentSecrets();
+  const updateAgentConnections = useUpdateAgentConnections();
+
+  // User-editable buffers, seeded from the agent's assignments on open.
   const [mode, setMode] = useState<SecretMode>(
     agent.secretMode === "selective" ? "selective" : "all",
   );
-  const [secrets, setSecrets] = useState<Secret[]>([]);
-  const [orgSecrets, setOrgSecrets] = useState<Secret[]>([]);
-  const [appConnections, setConnections] = useState<Connection[]>([]);
-  const [orgConnections, setOrgConnections] = useState<Connection[]>([]);
   const [selectedSecretIds, setSelectedSecretIds] = useState<Set<string>>(
     () => new Set(),
   );
   const [connectionPolicies, setConnectionPolicies] = useState<
     Map<string, Record<string, unknown> | null>
   >(() => new Map());
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [search, setSearch] = useState("");
 
@@ -89,55 +93,57 @@ export const ManageAccessDialog = ({
     unknown
   > | null>(null);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [allSecrets, assignedSecretIds, allConnections, assignedConns] =
-        await Promise.all([
-          secretsApi.list(),
-          getAgentSecrets(agent.id),
-          connectionsApi.list(),
-          getAgentAppConnections(agent.id),
-        ]);
-      const projectSecrets: typeof allSecrets = [];
-      const orgSecretsList: typeof allSecrets = [];
-      for (const s of allSecrets) {
-        (s.scope === "organization" ? orgSecretsList : projectSecrets).push(s);
-      }
-      setSecrets(projectSecrets);
-      setOrgSecrets(orgSecretsList);
-      setSelectedSecretIds(new Set(assignedSecretIds));
-      const projectConns: typeof allConnections = [];
-      const orgConns: typeof allConnections = [];
-      for (const c of allConnections) {
-        if (c.status !== "connected") continue;
-        (c.scope === "organization" ? orgConns : projectConns).push(c);
-      }
-      setConnections(projectConns);
-      setOrgConnections(orgConns);
-      const policies = new Map<string, Record<string, unknown> | null>();
-      for (const ac of assignedConns) {
-        policies.set(
-          ac.appConnectionId,
-          ac.sessionPolicy as Record<string, unknown> | null,
-        );
-      }
-      setConnectionPolicies(policies);
-    } catch {
-      toast.error("Failed to load credentials");
-    } finally {
-      setLoading(false);
-    }
-  }, [agent.id]);
+  const loading =
+    secretsLoading ||
+    connectionsLoading ||
+    assignedSecretsLoading ||
+    assignedConnectionsLoading;
 
-  useEffect(() => {
-    if (open) {
-      setMode(agent.secretMode === "selective" ? "selective" : "all");
-      setSearch("");
-      setGranularDialogConnId(null);
-      fetchData();
+  // Split the shared lists into project/org buckets (connections must be live).
+  const { secrets, orgSecrets } = useMemo(() => {
+    const project: Secret[] = [];
+    const org: Secret[] = [];
+    for (const s of secretsList) {
+      (s.scope === "organization" ? org : project).push(s);
     }
-  }, [open, agent.secretMode, fetchData]);
+    return { secrets: project, orgSecrets: org };
+  }, [secretsList]);
+
+  const { appConnections, orgConnections } = useMemo(() => {
+    const project: Connection[] = [];
+    const org: Connection[] = [];
+    for (const c of connectionsList) {
+      if (c.status !== "connected") continue;
+      (c.scope === "organization" ? org : project).push(c);
+    }
+    return { appConnections: project, orgConnections: org };
+  }, [connectionsList]);
+
+  // Reset transient UI + mode whenever the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    setMode(agent.secretMode === "selective" ? "selective" : "all");
+    setSearch("");
+    setGranularDialogConnId(null);
+  }, [open, agent.secretMode]);
+
+  // Seed the edit buffers once per open, once the agent's assignments load —
+  // guarded so a background refetch can't clobber in-progress edits.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      seededRef.current = false;
+      return;
+    }
+    if (seededRef.current || !assignedSecretIds || !assignedConnections) return;
+    setSelectedSecretIds(new Set(assignedSecretIds));
+    setConnectionPolicies(
+      new Map(
+        assignedConnections.map((c) => [c.appConnectionId, c.sessionPolicy]),
+      ),
+    );
+    seededRef.current = true;
+  }, [open, assignedSecretIds, assignedConnections]);
 
   const filterSecrets = useCallback(
     (list: Secret[]) => {
@@ -248,7 +254,7 @@ export const ManageAccessDialog = ({
   const handleSave = async () => {
     setSaving(true);
     try {
-      await updateAgentSecretMode(agent.id, mode);
+      await updateSecretMode.mutateAsync({ agentId: agent.id, mode });
       if (mode === "selective") {
         const connPayload = Array.from(connectionPolicies.entries()).map(
           ([id, policy]) => ({
@@ -257,14 +263,18 @@ export const ManageAccessDialog = ({
           }),
         );
         await Promise.all([
-          updateAgentSecrets(agent.id, Array.from(selectedSecretIds)),
-          updateAgentAppConnections(agent.id, connPayload),
+          updateAgentSecrets.mutateAsync({
+            agentId: agent.id,
+            secretIds: Array.from(selectedSecretIds),
+          }),
+          updateAgentConnections.mutateAsync({
+            agentId: agent.id,
+            connections: connPayload,
+          }),
         ]);
       }
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.all() });
       onUpdated?.();
       onOpenChange(false);
-      invalidateCache();
       toast.success("Credential access updated");
     } catch {
       toast.error("Failed to update credential access");
@@ -427,9 +437,11 @@ export const ManageAccessDialog = ({
                 >
                   <config.Icon className="text-muted-foreground size-3" />
                   <span className="text-muted-foreground text-xs">
-                    {isAllItems
-                      ? `All ${config.itemLabel.plural}`
-                      : `${selectedItemIds.size} of ${policyItems.length} ${config.itemLabel.plural}`}
+                    {config.formatSummary
+                      ? config.formatSummary(policy ?? null, meta ?? {})
+                      : isAllItems
+                        ? `All ${config.itemLabel.plural}`
+                        : `${selectedItemIds.size} of ${policyItems.length} ${config.itemLabel.plural}`}
                   </span>
                   <span className="text-muted-foreground/30 text-xs">·</span>
                   <span className="text-muted-foreground text-xs font-medium">
@@ -675,6 +687,7 @@ export const ManageAccessDialog = ({
             </DialogHeader>
 
             <granularDialogConfig.PolicyDialogContent
+              connectionId={granularDialogConnId}
               metadata={granularDialogMeta}
               policy={editingPolicy}
               onPolicyChange={setEditingPolicy}

--- a/apps/web/src/app/(dashboard)/rules/_components/granular-access-summary.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/granular-access-summary.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Badge } from "@onecli/ui/components/badge";
+import { Button } from "@onecli/ui/components/button";
+import { getApp } from "@onecli/api/apps/registry";
+import { withProjectPrefix } from "@/lib/navigation";
+import { AppIcon } from "@/app/(dashboard)/connections/_components/app-icon";
+import { granularAccessConfigs } from "@/lib/granular-access";
+import type { AgentGranularAccess } from "@/lib/api/types";
+
+type ResolvedEntry = AgentGranularAccess & {
+  summary: string;
+  appName: string;
+  icon?: string;
+  darkIcon?: string;
+};
+
+interface GranularAccessSummaryProps {
+  entries: AgentGranularAccess[];
+}
+
+export const GranularAccessSummary = ({
+  entries,
+}: GranularAccessSummaryProps) => {
+  const pathname = usePathname();
+  const agentsHref = withProjectPrefix(pathname, "/agents");
+
+  // Resolve each entry's one-line summary via its provider config, dropping
+  // entries that resolve to "all access" (no real restriction).
+  const resolved: ResolvedEntry[] = entries.flatMap((e) => {
+    const config = granularAccessConfigs.get(e.provider);
+    if (!config) return [];
+    const selected = config.getSelectedItems(e.policy);
+    if (selected.length === 0) return [];
+    const summary = config.formatSummary
+      ? config.formatSummary(e.policy, {})
+      : `${selected.length} ${
+          selected.length === 1
+            ? config.itemLabel.singular
+            : config.itemLabel.plural
+        }`;
+    const app = getApp(e.provider);
+    return [
+      {
+        ...e,
+        summary,
+        appName: app?.name ?? e.provider,
+        icon: app?.icon,
+        darkIcon: app?.darkIcon,
+      },
+    ];
+  });
+
+  if (resolved.length === 0) return null;
+
+  const byAgent = new Map<string, ResolvedEntry[]>();
+  for (const e of resolved) {
+    const list = byAgent.get(e.agentId) ?? [];
+    list.push(e);
+    byAgent.set(e.agentId, list);
+  }
+
+  return (
+    <div className="space-y-2">
+      {[...byAgent.values()].map((list) => {
+        const agentName = list[0]?.agentName ?? "Agent";
+        const agentId = list[0]?.agentId ?? "";
+        return (
+          <div key={agentId} className="rounded-lg border p-4">
+            <div className="flex items-center gap-3">
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                {agentName}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground text-xs"
+                asChild
+              >
+                <Link href={agentsHref}>Manage</Link>
+              </Button>
+            </div>
+            <div className="mt-2 space-y-1.5 border-t pt-2">
+              {list.map((e) => (
+                <div key={e.connectionId} className="flex items-center gap-2.5">
+                  {e.icon && (
+                    <AppIcon
+                      icon={e.icon}
+                      darkIcon={e.darkIcon}
+                      name={e.appName}
+                      size={14}
+                    />
+                  )}
+                  <span className="text-muted-foreground min-w-0 truncate text-xs">
+                    {e.connectionLabel ?? e.appName}
+                  </span>
+                  <span className="text-muted-foreground/40 text-xs">·</span>
+                  <Badge
+                    variant="outline"
+                    className="text-muted-foreground shrink-0 text-xs"
+                  >
+                    {e.summary}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/web/src/app/(dashboard)/rules/_components/rules-content.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/rules-content.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Plus, Settings2, Shield, ShieldOff } from "lucide-react";
 import { rules as rulesApi } from "@/lib/api";
 import { queryKeys } from "@/lib/api/keys";
-import { useAgents } from "@/hooks/use-agents";
+import { useAgents, useAgentGranularAccess } from "@/hooks/use-agents";
 import { useConnections } from "@/hooks/use-connections";
 import { Button } from "@onecli/ui/components/button";
 import { Card } from "@onecli/ui/components/card";
@@ -15,6 +15,7 @@ import { Separator } from "@onecli/ui/components/separator";
 import { RuleCard } from "./rule-card";
 import { RuleDialog } from "./rule-dialog";
 import { AppPermissionSummary } from "./app-permission-summary";
+import { GranularAccessSummary } from "./granular-access-summary";
 import type { PolicyMode } from "@onecli/api/validations/policy-rule";
 import type { AgentOption, PolicyRuleItem, RuleActions } from "./types";
 export type { PolicyRuleItem, AgentOption, RuleActions } from "./types";
@@ -51,6 +52,9 @@ export const RulesContent = ({
   const agents: AgentOption[] = useMemo(
     () => agentsList.map((a) => ({ id: a.id, name: a.name })),
     [agentsList],
+  );
+  const { data: granularEntries = [] } = useAgentGranularAccess(
+    pageScope === "project",
   );
   const { data: connectionsList = [] } = useConnections();
   const connectedProviders = useMemo(() => {
@@ -115,7 +119,9 @@ export const RulesContent = ({
         </Button>
       </div>
 
-      {customRules.length === 0 && appPermRules.length === 0 ? (
+      {customRules.length === 0 &&
+      appPermRules.length === 0 &&
+      granularEntries.length === 0 ? (
         <Card className="flex flex-col items-center justify-center py-16 text-center">
           {isDenyMode ? (
             <>
@@ -184,6 +190,21 @@ export const RulesContent = ({
                 pageScope={pageScope}
                 connectedProviders={connectedProviders}
               />
+            </>
+          )}
+
+          {granularEntries.length > 0 && (
+            <>
+              {(customRules.length > 0 || appPermRules.length > 0) && (
+                <div className="flex items-center gap-3 pt-2">
+                  <Separator className="flex-1" />
+                  <span className="text-muted-foreground shrink-0 text-xs">
+                    Granular access
+                  </span>
+                  <Separator className="flex-1" />
+                </div>
+              )}
+              <GranularAccessSummary entries={granularEntries} />
             </>
           )}
         </>

--- a/apps/web/src/hooks/use-agents.ts
+++ b/apps/web/src/hooks/use-agents.ts
@@ -10,27 +10,31 @@ import {
   renameAgent,
   regenerateAgentToken,
   setDefaultAgent,
-  getAgentSecrets,
-  updateAgentSecretMode,
-  updateAgentSecrets,
-  getAgentAppConnections,
-  updateAgentAppConnections,
 } from "@/lib/actions/agents";
 import { invalidateGatewayCache } from "@/lib/actions/gateway-cache";
 
 export const useAgents = () =>
   useQuery({ queryKey: queryKeys.agents.list(), queryFn: getAgents });
 
-export const useAgentSecrets = (agentId: string) =>
+export const useAgentGranularAccess = (enabled = true) =>
   useQuery({
-    queryKey: queryKeys.agents.secrets(agentId),
-    queryFn: () => getAgentSecrets(agentId),
+    queryKey: queryKeys.agents.granularAccess(),
+    queryFn: agents.granularAccess,
+    enabled,
   });
 
-export const useAgentConnections = (agentId: string) =>
+export const useAgentSecrets = (agentId: string, enabled = true) =>
+  useQuery({
+    queryKey: queryKeys.agents.secrets(agentId),
+    queryFn: () => agents.secrets(agentId),
+    enabled: enabled && agentId.length > 0,
+  });
+
+export const useAgentConnections = (agentId: string, enabled = true) =>
   useQuery({
     queryKey: queryKeys.agents.connections(agentId),
-    queryFn: () => getAgentAppConnections(agentId),
+    queryFn: () => agents.connections(agentId),
+    enabled: enabled && agentId.length > 0,
   });
 
 export const useCreateAgent = () => {
@@ -102,6 +106,11 @@ export const useSetDefaultAgent = () => {
   });
 };
 
+// Credential-access mutations. These invalidate only the React Query cache;
+// the audited API routes invalidate the gateway cache server-side (withAudit),
+// and the caller (the manage-access dialog) shows a single consolidated toast,
+// so these are intentionally headless (no gateway call, no per-hook toast).
+
 export const useUpdateSecretMode = () => {
   const qc = useQueryClient();
   return useMutation({
@@ -111,13 +120,11 @@ export const useUpdateSecretMode = () => {
     }: {
       agentId: string;
       mode: "all" | "selective";
-    }) => updateAgentSecretMode(agentId, mode),
+    }) => agents.updateSecretMode(agentId, mode),
     onSuccess: (_data, { agentId }) => {
-      qc.invalidateQueries({ queryKey: queryKeys.agents.all() });
       qc.invalidateQueries({ queryKey: queryKeys.agents.secrets(agentId) });
-      invalidateGatewayCache();
+      qc.invalidateQueries({ queryKey: queryKeys.agents.all() });
     },
-    onError: () => toast.error("Failed to update secret mode"),
   });
 };
 
@@ -130,13 +137,11 @@ export const useUpdateAgentSecrets = () => {
     }: {
       agentId: string;
       secretIds: string[];
-    }) => updateAgentSecrets(agentId, secretIds),
+    }) => agents.updateSecrets(agentId, secretIds),
     onSuccess: (_data, { agentId }) => {
       qc.invalidateQueries({ queryKey: queryKeys.agents.secrets(agentId) });
       qc.invalidateQueries({ queryKey: queryKeys.agents.all() });
-      invalidateGatewayCache();
     },
-    onError: () => toast.error("Failed to update agent secrets"),
   });
 };
 
@@ -152,14 +157,10 @@ export const useUpdateAgentConnections = () => {
         appConnectionId: string;
         sessionPolicy?: Record<string, unknown> | null;
       }[];
-    }) => updateAgentAppConnections(agentId, connections),
+    }) => agents.updateConnections(agentId, connections),
     onSuccess: (_data, { agentId }) => {
-      qc.invalidateQueries({
-        queryKey: queryKeys.agents.connections(agentId),
-      });
+      qc.invalidateQueries({ queryKey: queryKeys.agents.connections(agentId) });
       qc.invalidateQueries({ queryKey: queryKeys.agents.all() });
-      invalidateGatewayCache();
     },
-    onError: () => toast.error("Failed to update agent connections"),
   });
 };

--- a/apps/web/src/lib/actions/agents.ts
+++ b/apps/web/src/lib/actions/agents.ts
@@ -1,10 +1,6 @@
 "use server";
 
 import { resolveProjectContext } from "@/lib/actions/resolve-user";
-import type {
-  SecretMode,
-  AgentAppConnectionInput,
-} from "@onecli/api/services/agent-service";
 import {
   listAgents,
   getDefaultAgent as getDefaultAgentService,
@@ -13,11 +9,6 @@ import {
   deleteAgent as deleteAgentService,
   renameAgent as renameAgentService,
   regenerateAgentToken as regenerateAgentTokenService,
-  getAgentSecrets as getAgentSecretsService,
-  updateAgentSecretMode as updateAgentSecretModeService,
-  updateAgentSecrets as updateAgentSecretsService,
-  getAgentAppConnections as getAgentAppConnectionsService,
-  updateAgentAppConnections as updateAgentAppConnectionsService,
 } from "@onecli/api/services/agent-service";
 import {
   withAudit,
@@ -109,70 +100,6 @@ export const regenerateAgentToken = async (agentId: string) => {
       action: AUDIT_ACTIONS.REGENERATE,
       service: AUDIT_SERVICES.AGENT,
       metadata: { agentId },
-    }),
-  );
-};
-
-export const getAgentSecrets = async (agentId: string) => {
-  const { projectId } = await resolveProjectContext();
-  return getAgentSecretsService(projectId, agentId);
-};
-
-export const updateAgentSecretMode = async (
-  agentId: string,
-  mode: SecretMode,
-): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveProjectContext();
-  return withAudit(
-    () => updateAgentSecretModeService(projectId, agentId, mode),
-    () => ({
-      projectId,
-      userId,
-      userEmail,
-      action: AUDIT_ACTIONS.UPDATE,
-      service: AUDIT_SERVICES.AGENT,
-      metadata: { agentId, secretMode: mode },
-    }),
-  );
-};
-
-export const updateAgentSecrets = async (
-  agentId: string,
-  secretIds: string[],
-): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveProjectContext();
-  return withAudit(
-    () => updateAgentSecretsService(projectId, agentId, secretIds),
-    () => ({
-      projectId,
-      userId,
-      userEmail,
-      action: AUDIT_ACTIONS.UPDATE,
-      service: AUDIT_SERVICES.AGENT,
-      metadata: { agentId, secretCount: secretIds.length },
-    }),
-  );
-};
-
-export const getAgentAppConnections = async (agentId: string) => {
-  const { projectId } = await resolveProjectContext();
-  return getAgentAppConnectionsService(projectId, agentId);
-};
-
-export const updateAgentAppConnections = async (
-  agentId: string,
-  connections: AgentAppConnectionInput[],
-): Promise<void> => {
-  const { userId, userEmail, projectId } = await resolveProjectContext();
-  return withAudit(
-    () => updateAgentAppConnectionsService(projectId, agentId, connections),
-    () => ({
-      projectId,
-      userId,
-      userEmail,
-      action: AUDIT_ACTIONS.UPDATE,
-      service: AUDIT_SERVICES.AGENT,
-      metadata: { agentId, appConnectionCount: connections.length },
     }),
   );
 };

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -1,7 +1,41 @@
-import { apiGet, apiPost } from "./client";
-import type { Agent, CreatedAgent, CreateAgentInput } from "./types";
+import { apiGet, apiPost, apiPut, apiPatch } from "./client";
+import type {
+  Agent,
+  CreatedAgent,
+  CreateAgentInput,
+  AgentGranularAccess,
+  AgentConnection,
+} from "./types";
 
 export const list = () => apiGet<Agent[]>("/v1/agents");
 
 export const create = (input: CreateAgentInput) =>
   apiPost<CreatedAgent>("/v1/agents", input);
+
+export const granularAccess = () =>
+  apiGet<AgentGranularAccess[]>("/v1/agents/granular-access");
+
+// ── Credential access (secret mode, secrets, app connections) ──────────────
+
+export const secrets = (agentId: string) =>
+  apiGet<string[]>(`/v1/agents/${agentId}/secrets`);
+
+export const updateSecrets = (agentId: string, secretIds: string[]) =>
+  apiPut<{ success: boolean }>(`/v1/agents/${agentId}/secrets`, { secretIds });
+
+export const updateSecretMode = (agentId: string, mode: "all" | "selective") =>
+  apiPatch<{ success: boolean }>(`/v1/agents/${agentId}/secret-mode`, { mode });
+
+export const connections = (agentId: string) =>
+  apiGet<AgentConnection[]>(`/v1/agents/${agentId}/connections`);
+
+export const updateConnections = (
+  agentId: string,
+  connections: {
+    appConnectionId: string;
+    sessionPolicy?: Record<string, unknown> | null;
+  }[],
+) =>
+  apiPut<{ success: boolean }>(`/v1/agents/${agentId}/connections`, {
+    connections,
+  });

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -41,6 +41,18 @@ export const apiPatch = async <T>(path: string, body: unknown): Promise<T> => {
   return res.json();
 };
 
+export const apiPut = async <T>(path: string, body: unknown): Promise<T> => {
+  const res = await apiFetch(path, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(extractErrorMessage(data, res.status));
+  }
+  return res.json();
+};
+
 export const apiDelete = async (path: string): Promise<void> => {
   const res = await apiFetch(path, { method: "DELETE" });
   if (!res.ok) {

--- a/apps/web/src/lib/api/dropbox.ts
+++ b/apps/web/src/lib/api/dropbox.ts
@@ -1,0 +1,10 @@
+import { apiGet } from "./client";
+import type { DropboxFolder } from "./types";
+
+/** Subfolders of `path` for a Dropbox connection (path "" or "/" = root). */
+export const folders = (connectionId: string, path: string) =>
+  apiGet<DropboxFolder[]>(
+    `/v1/apps/dropbox/folders?connectionId=${encodeURIComponent(
+      connectionId,
+    )}&path=${encodeURIComponent(path)}`,
+  );

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -4,8 +4,9 @@ import * as rules from "./rules";
 import * as connections from "./connections";
 import * as counts from "./counts";
 import * as appBlocklist from "./app-blocklist";
+import * as dropbox from "./dropbox";
 
-export { agents, secrets, rules, connections, counts, appBlocklist };
+export { agents, secrets, rules, connections, counts, appBlocklist, dropbox };
 export type {
   Agent,
   CreatedAgent,

--- a/apps/web/src/lib/api/keys.ts
+++ b/apps/web/src/lib/api/keys.ts
@@ -11,6 +11,8 @@ export const queryKeys = {
       [...queryKeys.agents.all(), agentId, "secrets"] as const,
     connections: (agentId: string) =>
       [...queryKeys.agents.all(), agentId, "connections"] as const,
+    granularAccess: () =>
+      [...queryKeys.agents.all(), "granular-access"] as const,
   },
   secrets: {
     all: () => ["secrets", ...scope()] as const,
@@ -47,5 +49,12 @@ export const queryKeys = {
     all: () => ["billing", ...scope()] as const,
     agentCost: () => [...queryKeys.billing.all(), "agentCost"] as const,
     planUsage: () => [...queryKeys.billing.all(), "planUsage"] as const,
+    subscriptionStatus: () =>
+      [...queryKeys.billing.all(), "subscriptionStatus"] as const,
+  },
+  dropbox: {
+    all: () => ["dropbox", ...scope()] as const,
+    folders: (connectionId: string, path: string) =>
+      [...queryKeys.dropbox.all(), "folders", connectionId, path] as const,
   },
 };

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -16,6 +16,27 @@ export interface CreatedAgent {
   createdAt: string;
 }
 
+export interface AgentGranularAccess {
+  agentId: string;
+  agentName: string;
+  connectionId: string;
+  provider: string;
+  connectionLabel: string | null;
+  policy: Record<string, unknown>;
+}
+
+export interface AgentConnection {
+  appConnectionId: string;
+  sessionPolicy: Record<string, unknown> | null;
+}
+
+export interface DropboxFolder {
+  id: string;
+  name: string;
+  pathLower: string;
+  pathDisplay: string;
+}
+
 export interface Secret {
   id: string;
   name: string;

--- a/apps/web/src/lib/granular-access/configs/dropbox.ts
+++ b/apps/web/src/lib/granular-access/configs/dropbox.ts
@@ -1,0 +1,21 @@
+import { Folder } from "lucide-react";
+import type { GranularAccessConfig } from "../types";
+
+export const dropboxConfig: GranularAccessConfig = {
+  // Folders are browsed live in the policy dialog (Dropbox has no
+  // connect-time folder list), so granular access is always available for a
+  // connected Dropbox account.
+  isSupported: () => true,
+  // Items come from the live folder browser, not connection metadata.
+  getItems: () => [],
+  buildPolicy: (folders) => (folders.length > 0 ? { folders } : {}),
+  getSelectedItems: (policy) => (policy.folders as string[]) ?? [],
+  itemLabel: { singular: "folder", plural: "folders" },
+  Icon: Folder,
+  formatSummary: (policy) => {
+    const folders = (policy?.folders as string[] | undefined) ?? [];
+    return folders.length > 0
+      ? `${folders.length} ${folders.length === 1 ? "folder" : "folders"}`
+      : "All folders";
+  },
+};

--- a/apps/web/src/lib/granular-access/index.ts
+++ b/apps/web/src/lib/granular-access/index.ts
@@ -1,4 +1,5 @@
 import { githubAppConfig } from "./configs/github-app";
+import { dropboxConfig } from "./configs/dropbox";
 import type { GranularAccessConfig } from "./types";
 
 export type {
@@ -9,4 +10,5 @@ export type {
 
 export const granularAccessConfigs = new Map<string, GranularAccessConfig>([
   ["github-app", githubAppConfig],
+  ["dropbox", dropboxConfig],
 ]);

--- a/apps/web/src/lib/granular-access/types.ts
+++ b/apps/web/src/lib/granular-access/types.ts
@@ -6,6 +6,10 @@ export interface GranularAccessItem {
 }
 
 export interface PolicyDialogContentProps {
+  /** The app connection being scoped — needed by providers that browse
+   * resources live (e.g. Dropbox folders) instead of reading them from
+   * connect-time metadata. Providers that don't need it simply ignore it. */
+  connectionId: string;
   metadata: Record<string, unknown>;
   policy: Record<string, unknown> | null;
   onPolicyChange: (policy: Record<string, unknown> | null) => void;
@@ -21,4 +25,11 @@ export interface GranularAccessConfig {
   itemLabel: { singular: string; plural: string };
   Icon: ComponentType<{ className?: string }>;
   PolicyDialogContent?: ComponentType<PolicyDialogContentProps>;
+  /** Optional override for the one-line access summary shown on the row.
+   * Use when the count of granted items can't be derived from `getItems`
+   * (e.g. live-browsed Dropbox folders, where `getItems` returns []). */
+  formatSummary?: (
+    policy: Record<string, unknown> | null,
+    metadata: Record<string, unknown>,
+  ) => string;
 }

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -13,12 +13,22 @@ import {
   updateAgentSecretMode,
   getAgentSecrets,
   updateAgentSecrets,
+  getAgentAppConnections,
+  updateAgentAppConnections,
+  listAgentGranularAccess,
 } from "../services/agent-service";
+import {
+  withAudit,
+  AUDIT_ACTIONS,
+  AUDIT_SERVICES,
+  AUDIT_SOURCE,
+} from "../services/audit-service";
 import {
   createAgentSchema,
   renameAgentSchema,
   secretModeSchema,
   updateAgentSecretsSchema,
+  updateAgentConnectionsSchema,
 } from "../validations/agent";
 import { getResourceHooks } from "../providers";
 
@@ -31,6 +41,14 @@ export const agentRoutes = () => {
     const auth = c.get("auth");
     const agents = await listAgents(requireProjectId(auth));
     return c.json(agents);
+  });
+
+  // GET /agents/granular-access — read-only overview of per-agent granular
+  // policies (GitHub repos, Dropbox folders) across the project.
+  app.get("/granular-access", async (c) => {
+    const auth = c.get("auth");
+    const entries = await listAgentGranularAccess(requireProjectId(auth));
+    return c.json(entries);
   });
 
   // POST /agents
@@ -124,12 +142,19 @@ export const agentRoutes = () => {
       );
     }
 
-    await updateAgentSecretMode(
-      requireProjectId(auth),
-      agentId,
-      parsed.data.mode,
+    const projectId = requireProjectId(auth);
+    await withAudit(
+      () => updateAgentSecretMode(projectId, agentId, parsed.data.mode),
+      () => ({
+        projectId,
+        userId: auth.userId,
+        userEmail: auth.userEmail,
+        action: AUDIT_ACTIONS.UPDATE,
+        service: AUDIT_SERVICES.AGENT,
+        source: AUDIT_SOURCE.API,
+        metadata: { agentId, secretMode: parsed.data.mode },
+      }),
     );
-    invalidateGatewayCache(c.req.raw);
     return c.json({ success: true });
   });
 
@@ -154,12 +179,64 @@ export const agentRoutes = () => {
       );
     }
 
-    await updateAgentSecrets(
+    const projectId = requireProjectId(auth);
+    await withAudit(
+      () => updateAgentSecrets(projectId, agentId, parsed.data.secretIds),
+      () => ({
+        projectId,
+        userId: auth.userId,
+        userEmail: auth.userEmail,
+        action: AUDIT_ACTIONS.UPDATE,
+        service: AUDIT_SERVICES.AGENT,
+        source: AUDIT_SOURCE.API,
+        metadata: { agentId, secretCount: parsed.data.secretIds.length },
+      }),
+    );
+    return c.json({ success: true });
+  });
+
+  // GET /agents/:agentId/connections
+  app.get("/:agentId/connections", async (c) => {
+    const auth = c.get("auth");
+    const agentId = c.req.param("agentId");
+    const connections = await getAgentAppConnections(
       requireProjectId(auth),
       agentId,
-      parsed.data.secretIds,
     );
-    invalidateGatewayCache(c.req.raw);
+    return c.json(connections);
+  });
+
+  // PUT /agents/:agentId/connections — replace the agent's app-connection
+  // assignments and their per-connection granular-access policies.
+  app.put("/:agentId/connections", async (c) => {
+    const auth = c.get("auth");
+    const agentId = c.req.param("agentId");
+    const body = await c.req.json().catch(() => null);
+    const parsed = updateAgentConnectionsSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid request body" },
+        400,
+      );
+    }
+
+    const projectId = requireProjectId(auth);
+    await withAudit(
+      () =>
+        updateAgentAppConnections(projectId, agentId, parsed.data.connections),
+      () => ({
+        projectId,
+        userId: auth.userId,
+        userEmail: auth.userEmail,
+        action: AUDIT_ACTIONS.UPDATE,
+        service: AUDIT_SERVICES.AGENT,
+        source: AUDIT_SOURCE.API,
+        metadata: {
+          agentId,
+          appConnectionCount: parsed.data.connections.length,
+        },
+      }),
+    );
     return c.json({ success: true });
   });
 

--- a/packages/api/src/services/agent-service.ts
+++ b/packages/api/src/services/agent-service.ts
@@ -349,6 +349,48 @@ export const getAgentAppConnections = async (
   }));
 };
 
+export interface AgentGranularAccessEntry {
+  agentId: string;
+  agentName: string;
+  connectionId: string;
+  provider: string;
+  connectionLabel: string | null;
+  policy: SessionPolicy;
+}
+
+/**
+ * Lists every agent→connection assignment in the project that carries a
+ * non-empty granular policy (e.g. GitHub repository or Dropbox folder scoping).
+ * Read-only overview for the Rules page; unrestricted assignments are skipped.
+ */
+export const listAgentGranularAccess = async (
+  projectId: string,
+): Promise<AgentGranularAccessEntry[]> => {
+  const rows = await db.agentAppConnection.findMany({
+    where: { agent: { projectId } },
+    select: {
+      sessionPolicy: true,
+      agent: { select: { id: true, name: true } },
+      appConnection: { select: { id: true, provider: true, label: true } },
+    },
+  });
+
+  const entries: AgentGranularAccessEntry[] = [];
+  for (const r of rows) {
+    const policy = r.sessionPolicy as SessionPolicy | null;
+    if (!policy || Object.keys(policy).length === 0) continue;
+    entries.push({
+      agentId: r.agent.id,
+      agentName: r.agent.name,
+      connectionId: r.appConnection.id,
+      provider: r.appConnection.provider,
+      connectionLabel: r.appConnection.label,
+      policy,
+    });
+  }
+  return entries;
+};
+
 export interface AgentAppConnectionInput {
   appConnectionId: string;
   sessionPolicy?: SessionPolicy | null;

--- a/packages/api/src/validations/agent.ts
+++ b/packages/api/src/validations/agent.ts
@@ -28,3 +28,15 @@ export const secretModeSchema = z.object({
 export const updateAgentSecretsSchema = z.object({
   secretIds: z.array(z.string()),
 });
+
+export const updateAgentConnectionsSchema = z.object({
+  connections: z.array(
+    z.object({
+      appConnectionId: z.string(),
+      // Provider-specific granular-access policy (e.g. Dropbox folders, GitHub
+      // repos). Shape is validated per-provider in the service; here we only
+      // constrain the envelope.
+      sessionPolicy: z.record(z.string(), z.unknown()).nullable().optional(),
+    }),
+  ),
+});


### PR DESCRIPTION
## Summary

Adds generic per-agent granular-access scoping for app connections and migrates agent credential-access management from server actions to API routes backed by React Query. A connection's session policy can now restrict what an agent reaches *within* a provider (e.g. specific GitHub repositories or Dropbox folders); the Rules page surfaces a read-only summary of any agent that has a granular policy.

## Changes

**Gateway** — thread a generic per-connection `session_policy` through rule resolution so a request guard can enforce it; the new field and the extended `pre_forward` / `needs_request_body` hook args are inert in the OSS build.

**API** — add `GET /agents/granular-access` and `GET`/`PUT /agents/:agentId/connections`; move the secret-mode/secrets audit into the route handlers.

**Web** — migrate the manage-access dialog and agent hooks onto the typed API client + React Query; add a granular-access summary to the Rules page; register a Dropbox granular-access config; `next.config.js` gains an edition-gated `rewrites()` hook (no-op in OSS).
