### PR TITLE
feat: sync shared changes from cloud

### DIFF
--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -119,10 +119,16 @@ pub(crate) async fn find_user_by_external_auth_id(
         .context("querying user by external_auth_id")
 }
 
-/// Find the default project ID for a user.
+/// Find the default project ID for a user (OSS only).
 ///
 /// Resolves user → first organization → first project in that organization.
 /// Mirrors the web's `resolveUser()` (apps/web/src/lib/actions/resolve-user.ts).
+///
+/// OSS-only: the cloud edition is multi-project and never falls back to a
+/// default project — it requires an explicit `X-Project-Id` and validates it
+/// with [`user_can_access_project`]. Gating this `not(cloud)` makes that a
+/// compile-time guarantee (a cloud caller fails to build).
+#[cfg(not(feature = "cloud"))]
 pub(crate) async fn find_default_project_id_by_user(
     pool: &PgPool,
     user_id: &str,
@@ -183,6 +189,30 @@ pub(crate) async fn verify_project_in_org(
             .fetch_optional(pool)
             .await
             .context("verifying project belongs to organization")?;
+    Ok(row.is_some())
+}
+
+/// Verify that a user may access a project — i.e. the project belongs to an
+/// organization the user is a member of. Scopes cloud browser (Cognito)
+/// requests to the `X-Project-Id` they specify instead of a default project.
+#[cfg(feature = "cloud")]
+pub(crate) async fn user_can_access_project(
+    pool: &PgPool,
+    user_id: &str,
+    project_id: &str,
+) -> Result<bool> {
+    let row: Option<(String,)> = sqlx::query_as(
+        r#"SELECT p.id
+           FROM organization_members om
+           INNER JOIN projects p ON p.organization_id = om.organization_id
+           WHERE om.user_id = $1 AND p.id = $2
+           LIMIT 1"#,
+    )
+    .bind(user_id)
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await
+    .context("verifying user has access to project")?;
     Ok(row.is_some())
 }
 

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -193,6 +193,10 @@ impl GatewayServer {
                 hyper::header::CONTENT_TYPE,
                 hyper::header::AUTHORIZATION,
                 hyper::header::ACCEPT,
+                // Cloud scopes browser → gateway vault calls to the active
+                // project via this header; it must be allow-listed or the CORS
+                // preflight blocks the request. (OSS never sends it.)
+                hyper::header::HeaderName::from_static("x-project-id"),
             ])
             .allow_methods([
                 Method::GET,

--- a/apps/gateway/src/vault/mod.rs
+++ b/apps/gateway/src/vault/mod.rs
@@ -52,7 +52,7 @@ pub(crate) struct ProviderStatus {
 #[derive(Debug)]
 pub(crate) enum VaultError {
     BadRequest(String),
-    #[allow(dead_code)] // kept for future providers
+    #[expect(dead_code, reason = "kept for future providers")]
     Forbidden(String),
     NotFound(String),
     Internal(String),

--- a/apps/gateway/src/vault/onepassword.rs
+++ b/apps/gateway/src/vault/onepassword.rs
@@ -39,7 +39,10 @@ const SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(1800);
 
 /// Persisted in `vault_connection.connection_data`. Rows written before the
 /// value-source refactor also carry a `mappings` key; serde ignores it.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Deliberately no `Debug`/`Clone`: the struct carries only a credential (the
+/// encrypted SA token), so it must not be `{:?}`-logged or cloned around.
+#[derive(Serialize, Deserialize)]
 pub(crate) struct OnePasswordConfig {
     pub encrypted_service_account_token: String,
 }
@@ -60,6 +63,17 @@ struct OnePasswordSession {
     error_until: Mutex<Option<Instant>>,
     /// Timestamp of the last successful connectivity check (positive `status` cache).
     last_ok: Mutex<Option<Instant>>,
+}
+
+impl OnePasswordSession {
+    /// Whether the session is still within its post-error cooldown window (set
+    /// when a `Transient` 1Password failure was last seen).
+    fn in_error_cooldown(&self) -> bool {
+        self.error_until
+            .lock()
+            .expect("session lock poisoned")
+            .is_some_and(|t| Instant::now() < t)
+    }
 }
 
 pub(crate) struct OnePasswordVaultProvider {
@@ -184,12 +198,7 @@ impl OnePasswordVaultProvider {
             session.ref_cache.remove(op_ref);
         }
 
-        if session
-            .error_until
-            .lock()
-            .expect("session lock poisoned")
-            .is_some_and(|t| Instant::now() < t)
-        {
+        if session.in_error_cooldown() {
             return Err(VaultError::Internal(
                 "1Password temporarily unavailable (cooldown)".into(),
             ));
@@ -381,12 +390,7 @@ impl VaultProvider for OnePasswordVaultProvider {
 /// Live connectivity check for `status`, gated by the error cooldown and a
 /// short positive TTL so dashboard polling doesn't hammer 1Password.
 async fn live_check(session: &OnePasswordSession) -> bool {
-    if session
-        .error_until
-        .lock()
-        .expect("session lock poisoned")
-        .is_some_and(|t| Instant::now() < t)
-    {
+    if session.in_error_cooldown() {
         return false;
     }
     if session

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -60,6 +60,7 @@ const nextConfig = {
           "@/lib/dashboard/session-redirect":
             "@/cloud/dashboard/session-redirect",
           "@/lib/granular-access": "@/cloud/granular-access",
+          "@/lib/plan-gate": "@/cloud/billing/plan-gate",
 
           // Cloud initialization (api, server actions, client)
           "@/lib/init/api": "@/cloud/init/api",

--- a/apps/web/src/app/(connect)/app-connect/_components/connect-flow.tsx
+++ b/apps/web/src/app/(connect)/app-connect/_components/connect-flow.tsx
@@ -201,7 +201,6 @@ export const ConnectFlow = ({
                   {
                     type: "app-configure",
                     provider: app.id,
-                    url: `/connections/apps/${app.id}`,
                   },
                   window.location.origin,
                 );

--- a/apps/web/src/app/(dashboard)/connections/_components/app-permission-group.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-permission-group.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Layers } from "lucide-react";
+import { Layers, Lock } from "lucide-react";
 import { cn } from "@onecli/ui/lib/utils";
 import {
   AccordionContent,
@@ -31,6 +31,7 @@ import {
 } from "./resolve-tool-permission";
 import { AppPermissionRow } from "./app-permission-row";
 import { permissionOptions, PermissionButtons } from "./permission-buttons";
+import { usePlanGate } from "@/lib/plan-gate";
 
 interface AppPermissionGroupProps {
   group: AppToolGroup;
@@ -76,6 +77,7 @@ export const AppPermissionGroup = ({
   orgConditions,
   defaultPermission = "allow",
 }: AppPermissionGroupProps) => {
+  const planGate = usePlanGate();
   const { wildcard } = group;
   const wildcardPermission = wildcard
     ? permissionStates[wildcard.id]?.permission
@@ -134,9 +136,13 @@ export const AppPermissionGroup = ({
         <Select
           value={groupPerm === "custom" ? "custom" : groupPerm}
           onValueChange={(v) => {
-            if (v !== "custom") {
-              onGroupChange(v as AppPermissionLevel);
-            }
+            if (v === "custom") return;
+            if (
+              v === "manual_approval" &&
+              planGate.guard("policy.manual_approval")
+            )
+              return;
+            onGroupChange(v as AppPermissionLevel);
           }}
           disabled={disabled || allOrgEnforced}
         >
@@ -149,15 +155,25 @@ export const AppPermissionGroup = ({
                 Custom
               </SelectItem>
             )}
-            {permissionOptions.map((opt) => (
-              <SelectItem
-                key={opt.value}
-                value={opt.value}
-                disabled={isGroupOptionDisabled(opt.value)}
-              >
-                {opt.label}
-              </SelectItem>
-            ))}
+            {permissionOptions.map((opt) => {
+              const locked =
+                opt.value === "manual_approval" &&
+                planGate.isLocked("policy.manual_approval");
+              return (
+                <SelectItem
+                  key={opt.value}
+                  value={opt.value}
+                  disabled={isGroupOptionDisabled(opt.value)}
+                >
+                  <span className="flex items-center gap-1.5">
+                    {opt.label}
+                    {locked && (
+                      <Lock className="text-muted-foreground size-3.5" />
+                    )}
+                  </span>
+                </SelectItem>
+              );
+            })}
           </SelectContent>
         </Select>
       </div>

--- a/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/apps-tab.tsx
@@ -11,7 +11,7 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import {
   PROJECT_PATH_RE,
   ORG_PATH_RE,
-  withProjectPrefix,
+  connectionsPath,
 } from "@/lib/navigation";
 import { ChevronRight, Search, X } from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
@@ -137,16 +137,18 @@ export const AppsTab = ({
       invalidateCache();
       if (provider) {
         router.push(
-          basePath
-            ? `${basePath}/apps/${provider}`
-            : withProjectPrefix(pathname, `/connections/apps/${provider}`),
+          connectionsPath({ pathname, basePath }, `/apps/${provider}`),
         );
       }
     },
     [fetchConnections, invalidateCache, router, basePath, pathname],
   );
 
-  useAppMessages({ onConnected: handleConnected, onConfigure: router.push });
+  useAppMessages({
+    onConnected: handleConnected,
+    onConfigure: (provider) =>
+      router.push(connectionsPath({ pathname, basePath }, `/apps/${provider}`)),
+  });
 
   const openConnectPopup = (
     provider: string,
@@ -350,12 +352,10 @@ export const AppsTab = ({
                     ? () => setProApp(app)
                     : () =>
                         router.push(
-                          basePath
-                            ? `${basePath}/apps/${app.id}`
-                            : withProjectPrefix(
-                                pathname,
-                                `/connections/apps/${app.id}`,
-                              ),
+                          connectionsPath(
+                            { pathname, basePath },
+                            `/apps/${app.id}`,
+                          ),
                         )
                 }
               />

--- a/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/connected-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
-import { withProjectPrefix } from "@/lib/navigation";
+import { connectionsPath } from "@/lib/navigation";
 import { ChevronRight, KeyRound } from "lucide-react";
 import { Badge } from "@onecli/ui/components/badge";
 import { Card } from "@onecli/ui/components/card";
@@ -135,9 +135,7 @@ export const ConnectedTab = ({
           detail: label
             ? `Connected as ${label}`
             : `${c.scopes.length} scope${c.scopes.length !== 1 ? "s" : ""} granted`,
-          href: basePath
-            ? `${basePath}/apps/${c.provider}`
-            : withProjectPrefix(pathname, `/connections/apps/${c.provider}`),
+          href: connectionsPath({ pathname, basePath }, `/apps/${c.provider}`),
           providerCount: hasMultiple
             ? providerCounts.get(c.provider)
             : undefined,
@@ -170,9 +168,7 @@ export const ConnectedTab = ({
         type: "vault" as const,
         typeLabel: "External Vault",
         detail: v.status === "connected" ? "Connected" : "Paired",
-        href: basePath
-          ? `${basePath}/vaults/${v.provider}`
-          : withProjectPrefix(pathname, `/connections/vaults/${v.provider}`),
+        href: connectionsPath({ pathname, basePath }, `/vaults/${v.provider}`),
       }));
 
       setItems([...appItems, ...secretItems, ...vaultItems]);
@@ -195,7 +191,11 @@ export const ConnectedTab = ({
     fetchItems();
   }, [fetchItems]);
 
-  useAppMessages({ onConnected: fetchItems, onConfigure: router.push });
+  useAppMessages({
+    onConnected: fetchItems,
+    onConfigure: (provider) =>
+      router.push(connectionsPath({ pathname, basePath }, `/apps/${provider}`)),
+  });
 
   const handleItemClick = (item: ConnectedItem) => {
     if (item.inherited) return;
@@ -233,11 +233,7 @@ export const ConnectedTab = ({
         <p className="text-sm text-muted-foreground">
           No connected services yet. Head to the{" "}
           <button
-            onClick={() =>
-              router.push(
-                basePath ?? withProjectPrefix(pathname, "/connections"),
-              )
-            }
+            onClick={() => router.push(connectionsPath({ pathname, basePath }))}
             className="text-brand hover:underline font-medium"
           >
             Apps

--- a/apps/web/src/app/(dashboard)/connections/_components/connections-tabs.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/connections-tabs.tsx
@@ -4,6 +4,7 @@ import { useMemo, useTransition } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAppMessages } from "@/hooks/use-app-connected";
+import { connectionsPath } from "@/lib/navigation";
 import {
   AnimatedTabs,
   AnimatedTabList,
@@ -98,7 +99,8 @@ export const ConnectionsTabs = ({
       queryClient.invalidateQueries({ queryKey: queryKeys.connections.all() });
       queryClient.invalidateQueries({ queryKey: queryKeys.secrets.all() });
     },
-    onConfigure: router.push,
+    onConfigure: (provider) =>
+      router.push(connectionsPath({ pathname, basePath }, `/apps/${provider}`)),
   });
 
   const handleTabChange = (value: string) => {

--- a/apps/web/src/app/(dashboard)/connections/_components/permission-buttons.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/permission-buttons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CircleCheck, Hand, Ban } from "lucide-react";
+import { CircleCheck, Hand, Ban, Lock } from "lucide-react";
 import { cn } from "@onecli/ui/lib/utils";
 import {
   Tooltip,
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
 } from "@onecli/ui/components/tooltip";
 import type { AppPermissionLevel } from "@onecli/api/apps/app-permissions";
+import { usePlanGate } from "@/lib/plan-gate";
 
 export const permissionOptions: {
   value: AppPermissionLevel;
@@ -33,48 +34,66 @@ export const PermissionButtons = ({
   isOptionDisabled,
   covered,
   disabled,
-}: PermissionButtonsProps) => (
-  <>
-    {permissionOptions.map((opt) => {
-      const isActive = activePermission === opt.value;
-      const isBlockActive = isActive && opt.value === "block";
-      const isApprovalActive = isActive && opt.value === "manual_approval";
-      const optDisabled = isOptionDisabled?.(opt.value) ?? false;
-      return (
-        <Tooltip key={opt.value}>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => onSelect(opt.value)}
-              disabled={disabled || optDisabled}
-              className={cn(
-                "flex items-center justify-center size-8 rounded-md transition-colors",
-                isBlockActive
-                  ? covered
-                    ? "bg-destructive/5 text-destructive/40"
-                    : "bg-destructive/10 text-destructive"
-                  : isApprovalActive
+}: PermissionButtonsProps) => {
+  const planGate = usePlanGate();
+  return (
+    <>
+      {permissionOptions.map((opt) => {
+        const isActive = activePermission === opt.value;
+        const isBlockActive = isActive && opt.value === "block";
+        const isApprovalActive = isActive && opt.value === "manual_approval";
+        const optDisabled = isOptionDisabled?.(opt.value) ?? false;
+        const locked =
+          opt.value === "manual_approval" &&
+          planGate.isLocked("policy.manual_approval");
+        return (
+          <Tooltip key={opt.value}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => {
+                  if (
+                    opt.value === "manual_approval" &&
+                    planGate.guard("policy.manual_approval")
+                  )
+                    return;
+                  onSelect(opt.value);
+                }}
+                disabled={disabled || optDisabled}
+                className={cn(
+                  "relative flex items-center justify-center size-8 rounded-md transition-colors",
+                  isBlockActive
                     ? covered
-                      ? "bg-blue-500/5 text-blue-500/40"
-                      : "bg-blue-500/10 text-blue-500"
-                    : isActive
+                      ? "bg-destructive/5 text-destructive/40"
+                      : "bg-destructive/10 text-destructive"
+                    : isApprovalActive
                       ? covered
-                        ? "bg-brand/5 text-brand/40"
-                        : "bg-brand/10 text-brand"
-                      : optDisabled
-                        ? "text-muted-foreground/50"
-                        : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50",
-                (disabled || optDisabled) && "opacity-50 cursor-not-allowed",
-              )}
-            >
-              <opt.icon className={cn("size-4", isActive && "stroke-[2.5]")} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="text-xs">
-            {opt.label}
-          </TooltipContent>
-        </Tooltip>
-      );
-    })}
-  </>
-);
+                        ? "bg-blue-500/5 text-blue-500/40"
+                        : "bg-blue-500/10 text-blue-500"
+                      : isActive
+                        ? covered
+                          ? "bg-brand/5 text-brand/40"
+                          : "bg-brand/10 text-brand"
+                        : optDisabled
+                          ? "text-muted-foreground/50"
+                          : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50",
+                  (disabled || optDisabled) && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                <opt.icon
+                  className={cn("size-4", isActive && "stroke-[2.5]")}
+                />
+                {locked && (
+                  <Lock className="text-muted-foreground bg-background ring-border absolute -top-1 -right-1 size-3.5 rounded-full p-0.5 ring-1" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              {locked ? `${opt.label} · Pro` : opt.label}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </>
+  );
+};

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@/providers/auth-provider";
 import { checkDashboardRedirect } from "@/lib/user-plan";
 import { getDashboardRedirect } from "@/lib/dashboard/session-redirect";
 import { apiFetch } from "@/lib/api-fetch";
+import { PlanGateProvider } from "@/lib/plan-gate";
 
 export default function DashboardLayout({
   children,
@@ -100,29 +101,31 @@ export default function DashboardLayout({
   }
 
   return (
-    <SidebarProvider
-      className="bg-background h-svh overflow-hidden"
-      style={{ "--sidebar-width-icon": "2rem" } as React.CSSProperties}
-    >
-      <DashboardSidebar />
-      <SidebarInset className="bg-background min-w-0 overflow-hidden rounded-none md:border md:rounded-xl md:peer-data-[variant=inset]:shadow-none md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-1">
-        <header className="flex h-12 shrink-0 items-center border-b">
-          <DashboardHeader />
-        </header>
-        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
-          {isSettings && (
-            <aside className="hidden w-56 shrink-0 overflow-y-auto border-r px-6 pt-6 md:block">
-              <SettingsNav />
-            </aside>
-          )}
-          <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
-            {isSettings && <SettingsMobileNav />}
-            <main className="mx-auto min-w-0 max-w-6xl p-4 sm:p-6">
-              {children}
-            </main>
+    <PlanGateProvider>
+      <SidebarProvider
+        className="bg-background h-svh overflow-hidden"
+        style={{ "--sidebar-width-icon": "2rem" } as React.CSSProperties}
+      >
+        <DashboardSidebar />
+        <SidebarInset className="bg-background min-w-0 overflow-hidden rounded-none md:border md:rounded-xl md:peer-data-[variant=inset]:shadow-none md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-1">
+          <header className="flex h-12 shrink-0 items-center border-b">
+            <DashboardHeader />
+          </header>
+          <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+            {isSettings && (
+              <aside className="hidden w-56 shrink-0 overflow-y-auto border-r px-6 pt-6 md:block">
+                <SettingsNav />
+              </aside>
+            )}
+            <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
+              {isSettings && <SettingsMobileNav />}
+              <main className="mx-auto min-w-0 max-w-6xl p-4 sm:p-6">
+                {children}
+              </main>
+            </div>
           </div>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+        </SidebarInset>
+      </SidebarProvider>
+    </PlanGateProvider>
   );
 }

--- a/apps/web/src/app/(dashboard)/rules/_components/application-rule-form.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/application-rule-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { CircleCheck, Hand, ShieldBan, Settings2 } from "lucide-react";
+import { CircleCheck, Hand, ShieldBan, Settings2, Lock } from "lucide-react";
 import { toast } from "sonner";
 import { useInvalidateGatewayCache } from "@/hooks/use-invalidate-cache";
 import { cn } from "@onecli/ui/lib/utils";
@@ -36,6 +36,7 @@ import type {
 } from "@onecli/api/validations/policy-rule";
 import { setAppPermissions as defaultSetAppPermissions } from "@/lib/actions/rules";
 import { ConditionBuilder } from "@/lib/components/condition-builder";
+import { usePlanGate } from "@/lib/plan-gate";
 import type { RuleActions } from "./types";
 import { AppPickerGrid } from "./app-picker-grid";
 
@@ -92,6 +93,7 @@ export const ApplicationRuleForm = ({
 }: ApplicationRuleFormProps) => {
   const isDenyMode = policyMode === "deny";
   const invalidateCache = useInvalidateGatewayCache();
+  const planGate = usePlanGate();
   const [step, setStep] = useState<Step>("app");
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [scope, setScope] = useState<Scope>("all");
@@ -267,11 +269,21 @@ export const ApplicationRuleForm = ({
             <div className="grid grid-cols-3 gap-2">
               {POLICY_OPTIONS.map((opt) => {
                 const isSelected = policy === opt.value;
+                const locked =
+                  opt.value === "manual_approval" &&
+                  planGate.isLocked("policy.manual_approval");
                 return (
                   <button
                     key={opt.value}
                     type="button"
-                    onClick={() => setPolicy(opt.value)}
+                    onClick={() => {
+                      if (
+                        opt.value === "manual_approval" &&
+                        planGate.guard("policy.manual_approval")
+                      )
+                        return;
+                      setPolicy(opt.value);
+                    }}
                     className={cn(
                       "flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors",
                       isSelected
@@ -296,6 +308,9 @@ export const ApplicationRuleForm = ({
                         )}
                       />
                       {opt.label}
+                      {locked && (
+                        <Lock className="text-muted-foreground ml-auto size-3.5" />
+                      )}
                     </span>
                     <span className="text-muted-foreground text-xs">
                       {opt.description}

--- a/apps/web/src/app/(dashboard)/rules/_components/custom-endpoint-form.tsx
+++ b/apps/web/src/app/(dashboard)/rules/_components/custom-endpoint-form.tsx
@@ -10,6 +10,7 @@ import {
   Hand,
   Check,
   Settings2,
+  Lock,
 } from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
 import { Input } from "@onecli/ui/components/input";
@@ -39,6 +40,7 @@ import type { CreateRuleInput } from "@/lib/api";
 import { queryKeys } from "@/lib/api/keys";
 import type { RuleCondition } from "@onecli/api/validations/policy-rule";
 import { ConditionBuilder } from "@/lib/components/condition-builder";
+import { usePlanGate } from "@/lib/plan-gate";
 import type { AgentOption, PolicyRuleItem, RuleActions } from "./types";
 
 const METHOD_OPTIONS = [
@@ -90,6 +92,7 @@ export const CustomEndpointForm = ({
   const isEdit = !!rule;
   const invalidateCache = useInvalidateGatewayCache();
   const queryClient = useQueryClient();
+  const planGate = usePlanGate();
   const [saving, setSaving] = useState(false);
   const [step, setStep] = useState<Step>("endpoint");
   const [name, setName] = useState("");
@@ -441,7 +444,10 @@ export const CustomEndpointForm = ({
             )}
             <button
               type="button"
-              onClick={() => setAction("rate_limit")}
+              onClick={() => {
+                if (planGate.guard("policy.rate_limit")) return;
+                setAction("rate_limit");
+              }}
               className={cn(
                 "flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors",
                 action === "rate_limit"
@@ -457,6 +463,9 @@ export const CustomEndpointForm = ({
                   )}
                 />
                 Rate Limit
+                {planGate.isLocked("policy.rate_limit") && (
+                  <Lock className="text-muted-foreground ml-auto size-3.5" />
+                )}
               </span>
               <span className="text-muted-foreground text-xs">
                 Allow up to N requests, then block
@@ -464,7 +473,10 @@ export const CustomEndpointForm = ({
             </button>
             <button
               type="button"
-              onClick={() => setAction("manual_approval")}
+              onClick={() => {
+                if (planGate.guard("policy.manual_approval")) return;
+                setAction("manual_approval");
+              }}
               className={cn(
                 "flex flex-col gap-1.5 rounded-md border p-3.5 text-left transition-colors",
                 action === "manual_approval"
@@ -480,6 +492,9 @@ export const CustomEndpointForm = ({
                   )}
                 />
                 Manual Approval
+                {planGate.isLocked("policy.manual_approval") && (
+                  <Lock className="text-muted-foreground ml-auto size-3.5" />
+                )}
               </span>
               <span className="text-muted-foreground text-xs">
                 Require human approval before proceeding

--- a/apps/web/src/hooks/use-app-connected.ts
+++ b/apps/web/src/hooks/use-app-connected.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export interface AppConnectedEvent {
   provider?: string;
@@ -8,28 +8,43 @@ export interface AppConnectedEvent {
 
 interface UseAppMessagesOptions {
   onConnected: (event: AppConnectedEvent) => void;
-  onConfigure?: (url: string) => void;
+  onConfigure?: (provider: string) => void;
 }
 
 /**
  * Listens for `postMessage` events from the app-connect popup.
  * Dispatches to `onConnected` or `onConfigure` based on message type.
+ *
+ * Handlers are read through refs so the `message` listener is attached once for
+ * the component's lifetime, instead of re-subscribing on every render when
+ * callers pass inline (non-memoized) callbacks.
  */
 export const useAppMessages = ({
   onConnected,
   onConfigure,
 }: UseAppMessagesOptions) => {
+  const onConnectedRef = useRef(onConnected);
+  useEffect(() => {
+    onConnectedRef.current = onConnected;
+  }, [onConnected]);
+  const onConfigureRef = useRef(onConfigure);
+  useEffect(() => {
+    onConfigureRef.current = onConfigure;
+  }, [onConfigure]);
+
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
       if (event.data?.type === "app-connected") {
-        onConnected({ provider: event.data.provider as string | undefined });
+        onConnectedRef.current({
+          provider: event.data.provider as string | undefined,
+        });
       }
-      if (event.data?.type === "app-configure" && event.data?.url) {
-        onConfigure?.(event.data.url);
+      if (event.data?.type === "app-configure" && event.data?.provider) {
+        onConfigureRef.current?.(event.data.provider as string);
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [onConnected, onConfigure]);
+  }, []);
 };

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -34,3 +34,23 @@ export const withOrgPrefix = (
   if (!match) return targetPath;
   return `/org/${match[1]}${targetPath}`;
 };
+
+/**
+ * Resolve a path inside the connections section, scoped to the current edition
+ * and page. Single source of truth so callers never hardcode the bare OSS
+ * `/connections...` path (which 404s in the cloud edition under `/p` or `/org`).
+ *
+ * - OSS:           `/connections{sub}`
+ * - Cloud project: `/p/<id>/connections{sub}`   (derived from `pathname`)
+ * - Cloud org:     `<basePath>{sub}`            (basePath = `/org/<id>/global-connections`)
+ *
+ * `sub` is the path under the connections root, e.g. "" (root),
+ * `/apps/<provider>`, or `/vaults/<provider>`.
+ */
+export const connectionsPath = (
+  { pathname, basePath }: { pathname: string; basePath?: string },
+  sub = "",
+): string =>
+  basePath
+    ? `${basePath}${sub}`
+    : withProjectPrefix(pathname, `/connections${sub}`);

--- a/apps/web/src/lib/plan-gate.tsx
+++ b/apps/web/src/lib/plan-gate.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export interface PlanGate {
+  /** Whether `feature` is locked for the current plan (drives the upfront lock UI). */
+  isLocked: (feature: string) => boolean;
+  /**
+   * Call when the user selects a gated feature. If locked, opens the upgrade
+   * paywall and returns `true` (the caller should abort the selection); returns
+   * `false` when the caller should proceed.
+   */
+  guard: (feature: string) => boolean;
+}
+
+const OSS_GATE: PlanGate = {
+  isLocked: () => false,
+  guard: () => false,
+};
+
+/**
+ * OSS default: nothing is gated. Cloud overrides this module via the
+ * `@/lib/plan-gate` turbopack alias (see next.config.js) to gate premium
+ * features behind paid plans.
+ */
+export const usePlanGate = (): PlanGate => OSS_GATE;
+
+/** OSS default: pass-through. Cloud renders the shared paywall dialog + context. */
+export const PlanGateProvider = ({ children }: { children: ReactNode }) => (
+  <>{children}</>
+);

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -61,12 +61,23 @@ export const proxy = (request: NextRequest) => {
 
   const requestHeaders = new Headers(request.headers);
 
-  const projectId = pathname.match(PROJECT_PATH_RE)?.[1];
+  // Scope normally comes from the URL path (/p/<id>, /org/<id>). The app-connect
+  // popup is a top-level window with no scoped path, so it carries scope in the
+  // query string instead — bridge that to the same headers here. The downstream
+  // resolveProjectContext still validates membership before trusting either source.
+  const { searchParams } = request.nextUrl;
+  const fromQuery = pathname.startsWith("/app-connect");
+
+  const projectId =
+    pathname.match(PROJECT_PATH_RE)?.[1] ||
+    (fromQuery ? searchParams.get("projectId") : null);
   if (projectId) {
     requestHeaders.set("x-project-id", projectId);
   }
 
-  const orgId = pathname.match(ORG_PATH_RE)?.[1];
+  const orgId =
+    pathname.match(ORG_PATH_RE)?.[1] ||
+    (fromQuery ? searchParams.get("orgId") : null);
   if (orgId) {
     requestHeaders.set("x-organization-id", orgId);
   }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,6 +40,7 @@
     "nanoid": "^5.1.9",
     "pino": "^10.3.1",
     "stripe": "^20.4.0",
+    "undici": "^8.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -6,6 +6,7 @@ import type {
   ResourceHooks,
   RoleResolver,
   PolicyValidator,
+  RuleActionGate,
 } from "./providers";
 import type { CryptoService } from "./lib/crypto-types";
 import type { AppDefinition } from "./apps/types";
@@ -21,6 +22,7 @@ import {
   initSelfUrl,
   initRoleResolver,
   initPolicyValidator,
+  initRuleActionGate,
 } from "./providers";
 import { registerAppPermission } from "./apps/app-permissions";
 import { errorHandler, notFoundHandler } from "./middleware/error-handler";
@@ -54,6 +56,7 @@ export interface CreateApiAppOptions {
   selfUrl?: string;
   roleResolver?: RoleResolver;
   policyValidator?: PolicyValidator;
+  ruleActionGate?: RuleActionGate;
   sessionHooks?: Partial<SessionHooks>;
   version?: string;
 }
@@ -76,6 +79,7 @@ export const createApiApp = (
   if (options?.selfUrl) initSelfUrl(options.selfUrl);
   if (options?.roleResolver) initRoleResolver(options.roleResolver);
   if (options?.policyValidator) initPolicyValidator(options.policyValidator);
+  if (options?.ruleActionGate) initRuleActionGate(options.ruleActionGate);
   if (options?.sessionHooks) initSessionHooks(options.sessionHooks);
 
   const app = new Hono<ApiEnv>().basePath("/v1");

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,6 +15,7 @@ export {
   initCloudApps,
   initCrypto,
   initRoleResolver,
+  initRuleActionGate,
 } from "./providers";
 export type { SessionHooks, SessionAttributes } from "./routes/auth-session";
 export { initSessionHooks } from "./routes/auth-session";

--- a/packages/api/src/lib/gateway-invalidate.ts
+++ b/packages/api/src/lib/gateway-invalidate.ts
@@ -4,10 +4,17 @@ import { GATEWAY_API_URL } from "./env";
 export const invalidateGatewayCache = (request: Request) => {
   const authorization = request.headers.get("authorization");
   const cookie = request.headers.get("cookie");
+  // Forward the project the request was scoped to. The cloud gateway requires
+  // X-Project-Id for session (Cognito) auth — without it the flush 401s (and
+  // previously hit the user's *default* project instead of this one). API-key
+  // auth ignores it (the key carries its project), so this is safe for the
+  // SDK/CLI and for OSS.
+  const projectId = request.headers.get("x-project-id");
 
   const headers: Record<string, string> = {};
   if (authorization) headers["authorization"] = authorization;
   if (cookie) headers["cookie"] = cookie;
+  if (projectId) headers["x-project-id"] = projectId;
 
   fetch(`${GATEWAY_API_URL}/v1/cache/invalidate`, {
     method: "POST",

--- a/packages/api/src/providers/hooks/index.ts
+++ b/packages/api/src/providers/hooks/index.ts
@@ -13,3 +13,9 @@ export {
   initPolicyValidator,
   getPolicyValidator,
 } from "./policy-validator";
+export {
+  type RuleActionGate,
+  type RuleWriteScope,
+  initRuleActionGate,
+  getRuleActionGate,
+} from "./rule-action-gate";

--- a/packages/api/src/providers/hooks/resource-hooks.ts
+++ b/packages/api/src/providers/hooks/resource-hooks.ts
@@ -1,13 +1,11 @@
 export interface ResourceHooks {
   beforeCreateAgent(organizationId: string): Promise<void>;
   beforeCreateSecret(organizationId: string): Promise<void>;
-  beforeCreateRule(organizationId: string, action: string): Promise<void>;
 }
 
 const defaultResourceHooks: ResourceHooks = {
   beforeCreateAgent: async () => {},
   beforeCreateSecret: async () => {},
-  beforeCreateRule: async () => {},
 };
 
 let _resourceHooks: ResourceHooks = defaultResourceHooks;

--- a/packages/api/src/providers/hooks/rule-action-gate.ts
+++ b/packages/api/src/providers/hooks/rule-action-gate.ts
@@ -1,0 +1,29 @@
+/** Scope of a policy-rule write. Structurally compatible with `ResourceScope`. */
+export interface RuleWriteScope {
+  projectId?: string;
+  organizationId?: string;
+}
+
+/**
+ * Authorizes which policy-rule actions an org may write. The OSS default allows
+ * everything; cloud injects a plan-based implementation via `createApiApp`.
+ *
+ * Called by the policy-rule service itself, so every write path — HTTP routes,
+ * server actions, project scope and org scope — is gated in one place and no
+ * caller can bypass it.
+ */
+export interface RuleActionGate {
+  assertAllowed(scope: RuleWriteScope, actions: string[]): Promise<void>;
+}
+
+const defaultRuleActionGate: RuleActionGate = {
+  assertAllowed: async () => {},
+};
+
+let _ruleActionGate: RuleActionGate = defaultRuleActionGate;
+
+export const initRuleActionGate = (a: RuleActionGate) => {
+  _ruleActionGate = a;
+};
+
+export const getRuleActionGate = (): RuleActionGate => _ruleActionGate;

--- a/packages/api/src/providers/index.ts
+++ b/packages/api/src/providers/index.ts
@@ -26,4 +26,8 @@ export {
   type PolicyValidator,
   initPolicyValidator,
   getPolicyValidator,
+  type RuleActionGate,
+  type RuleWriteScope,
+  initRuleActionGate,
+  getRuleActionGate,
 } from "./hooks";

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -5,6 +5,7 @@ import { invalidateGatewayCache } from "../lib/gateway-invalidate";
 import {
   listAgents,
   createAgent,
+  agentExistsByIdentifier,
   getDefaultAgent,
   setDefaultAgent,
   renameAgent,
@@ -63,10 +64,18 @@ export const agentRoutes = () => {
       );
     }
 
-    await getResourceHooks().beforeCreateAgent(auth.organizationId);
+    const projectId = requireProjectId(auth);
+
+    // The agent quota gates *new* agents only -- re-creating an existing
+    // identifier consumes no slot. Skip the quota check when it already exists
+    // so createAgent returns the canonical 409 instead of a 403 that shadows it
+    // at the cap and breaks idempotent ensureAgent. See onecli/node-sdk#40.
+    if (!(await agentExistsByIdentifier(projectId, parsed.data.identifier))) {
+      await getResourceHooks().beforeCreateAgent(auth.organizationId);
+    }
 
     const agent = await createAgent(
-      requireProjectId(auth),
+      projectId,
       parsed.data.name,
       parsed.data.identifier,
       parsed.data.parentIdentifier,

--- a/packages/api/src/routes/rules.ts
+++ b/packages/api/src/routes/rules.ts
@@ -13,7 +13,6 @@ import {
   createPolicyRuleSchema,
   updatePolicyRuleSchema,
 } from "../validations/policy-rule";
-import { getResourceHooks } from "../providers";
 
 export const ruleRoutes = () => {
   const app = new Hono<ApiEnv>();
@@ -51,11 +50,6 @@ export const ruleRoutes = () => {
         400,
       );
     }
-
-    await getResourceHooks().beforeCreateRule(
-      auth.organizationId,
-      parsed.data.action,
-    );
 
     const rule = await createPolicyRule(
       { projectId: requireProjectId(auth) },

--- a/packages/api/src/services/agent-service.ts
+++ b/packages/api/src/services/agent-service.ts
@@ -44,6 +44,17 @@ export const getDefaultAgent = async (projectId: string) => {
   });
 };
 
+export const agentExistsByIdentifier = async (
+  projectId: string,
+  identifier: string,
+): Promise<boolean> => {
+  const existing = await db.agent.findFirst({
+    where: { projectId, identifier: identifier.trim() },
+    select: { id: true },
+  });
+  return existing !== null;
+};
+
 export const createAgent = async (
   projectId: string,
   name: string,

--- a/packages/api/src/services/onepassword-service.ts
+++ b/packages/api/src/services/onepassword-service.ts
@@ -8,6 +8,13 @@
  */
 import { createClient, type Client } from "@1password/sdk";
 import { createHash } from "node:crypto";
+import {
+  Agent,
+  fetch as undiciFetch,
+  Headers as undiciHeaders,
+  Request as undiciRequest,
+  Response as undiciResponse,
+} from "undici";
 
 import { logger } from "../lib/logger";
 import { ServiceError } from "./errors";
@@ -29,6 +36,75 @@ const tokenKey = (token: string): string =>
 
 const errMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err);
+
+// Node's fetch (undici) puts the real failure in `err.cause`; the 1Password SDK
+// hides it behind a vague "error sending request", so surface the cause for logs.
+const errCause = (err: unknown): string | undefined => {
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause == null) return undefined;
+  if (cause instanceof Error) return cause.message;
+  const code = (cause as { code?: string }).code;
+  return code ?? String(cause);
+};
+
+// ── undici isolation ────────────────────────────────────────────────────────
+// The 1Password SDK's WASM core makes HTTP through the global fetch/Request/
+// Response/Headers and undici's global dispatcher. Prisma (@onecli/db) bundles
+// its own copy of undici and installs *its* Agent as the global dispatcher, so
+// the SDK's fetch would stream response bodies from a different undici instance
+// than the one decoding them and fail with "request library compatibility issue:
+// error sending request". We pin every SDK call onto one self-consistent undici
+// (its fetch + Request/Response/Headers + a dedicated Agent passed per request,
+// so the global dispatcher is never touched), restoring the originals after.
+// See https://github.com/1Password/onepassword-sdk-js/issues/134.
+const sdkAgent = new Agent();
+const pinnedFetch = ((
+  input: Parameters<typeof undiciFetch>[0],
+  init?: Parameters<typeof undiciFetch>[1],
+) =>
+  undiciFetch(input, {
+    ...init,
+    dispatcher: sdkAgent,
+  })) as unknown as typeof globalThis.fetch;
+
+let pinDepth = 0;
+let savedHttp: Pick<
+  typeof globalThis,
+  "fetch" | "Request" | "Response" | "Headers"
+> | null = null;
+
+/**
+ * Run an SDK operation with a self-consistent undici pinned to the global HTTP
+ * primitives. Reference-counted so concurrent calls share one swap window and
+ * the originals are restored exactly once.
+ */
+const withPinnedUndici = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (pinDepth === 0) {
+    savedHttp = {
+      fetch: globalThis.fetch,
+      Request: globalThis.Request,
+      Response: globalThis.Response,
+      Headers: globalThis.Headers,
+    };
+    globalThis.fetch = pinnedFetch;
+    globalThis.Request = undiciRequest as unknown as typeof globalThis.Request;
+    globalThis.Response =
+      undiciResponse as unknown as typeof globalThis.Response;
+    globalThis.Headers = undiciHeaders as unknown as typeof globalThis.Headers;
+  }
+  pinDepth++;
+  try {
+    return await fn();
+  } finally {
+    if (--pinDepth === 0 && savedHttp) {
+      globalThis.fetch = savedHttp.fetch;
+      globalThis.Request = savedHttp.Request;
+      globalThis.Response = savedHttp.Response;
+      globalThis.Headers = savedHttp.Headers;
+      savedHttp = null;
+    }
+  }
+};
 
 const getClient = async (token: string): Promise<Client> => {
   const now = Date.now();
@@ -53,6 +129,10 @@ const getClient = async (token: string): Promise<Client> => {
       integrationVersion: INTEGRATION_VERSION,
     });
   } catch (err) {
+    logger.warn(
+      { err: errMessage(err), cause: errCause(err) },
+      "1Password createClient failed",
+    );
     throw new ServiceError(
       "BAD_REQUEST",
       `invalid 1Password service account token: ${errMessage(err)}`,
@@ -66,18 +146,23 @@ const getClient = async (token: string): Promise<Client> => {
  * Validate a Service-Account token with a cheap connectivity check (vault list).
  * Used at pair time and for the gateway's `status` check.
  */
-export const validateToken = async (token: string): Promise<void> => {
-  const client = await getClient(token);
-  try {
-    await client.vaults.list();
-  } catch (err) {
-    clients.delete(tokenKey(token));
-    throw new ServiceError(
-      "BAD_REQUEST",
-      `1Password token validation failed: ${errMessage(err)}`,
-    );
-  }
-};
+export const validateToken = async (token: string): Promise<void> =>
+  withPinnedUndici(async () => {
+    const client = await getClient(token);
+    try {
+      await client.vaults.list();
+    } catch (err) {
+      clients.delete(tokenKey(token));
+      logger.warn(
+        { err: errMessage(err), cause: errCause(err) },
+        "1Password token validation failed",
+      );
+      throw new ServiceError(
+        "BAD_REQUEST",
+        `1Password token validation failed: ${errMessage(err)}`,
+      );
+    }
+  });
 
 /**
  * Resolve an `op://vault/item/field` reference to its secret value.
@@ -89,18 +174,22 @@ export const validateToken = async (token: string): Promise<void> => {
 export const resolveSecret = async (
   token: string,
   opRef: string,
-): Promise<string> => {
-  const client = await getClient(token);
-  try {
-    return await client.secrets.resolve(opRef);
-  } catch (err) {
-    logger.warn({ opRef, err: errMessage(err) }, "1Password resolve failed");
-    throw new ServiceError(
-      "BAD_REQUEST",
-      `cannot resolve ${opRef}: ${errMessage(err)}`,
-    );
-  }
-};
+): Promise<string> =>
+  withPinnedUndici(async () => {
+    const client = await getClient(token);
+    try {
+      return await client.secrets.resolve(opRef);
+    } catch (err) {
+      logger.warn(
+        { opRef, err: errMessage(err), cause: errCause(err) },
+        "1Password resolve failed",
+      );
+      throw new ServiceError(
+        "BAD_REQUEST",
+        `cannot resolve ${opRef}: ${errMessage(err)}`,
+      );
+    }
+  });
 
 // ── Picker (browse vaults → items → fields) ──────────────────────────────
 
@@ -128,43 +217,45 @@ export interface OpItemFields {
 }
 
 /** List the vaults the service account can read. */
-export const listVaults = async (token: string): Promise<OpVault[]> => {
-  const client = await getClient(token);
-  try {
-    const vaults = await client.vaults.list();
-    return vaults.map((v) => ({ id: v.id, title: v.title }));
-  } catch (err) {
-    throw new ServiceError(
-      "BAD_REQUEST",
-      `cannot list vaults: ${errMessage(err)}`,
-    );
-  }
-};
+export const listVaults = async (token: string): Promise<OpVault[]> =>
+  withPinnedUndici(async () => {
+    const client = await getClient(token);
+    try {
+      const vaults = await client.vaults.list();
+      return vaults.map((v) => ({ id: v.id, title: v.title }));
+    } catch (err) {
+      throw new ServiceError(
+        "BAD_REQUEST",
+        `cannot list vaults: ${errMessage(err)}`,
+      );
+    }
+  });
 
 /** List the items in a vault. */
 export const listItems = async (
   token: string,
   vaultId: string,
-): Promise<OpItem[]> => {
-  const client = await getClient(token);
-  try {
-    // Active items only — never surface archived items in the picker.
-    const items = await client.items.list(vaultId, {
-      type: "ByState",
-      content: { active: true, archived: false },
-    });
-    return items.map((i) => ({
-      id: i.id,
-      title: i.title,
-      category: String(i.category),
-    }));
-  } catch (err) {
-    throw new ServiceError(
-      "BAD_REQUEST",
-      `cannot list items: ${errMessage(err)}`,
-    );
-  }
-};
+): Promise<OpItem[]> =>
+  withPinnedUndici(async () => {
+    const client = await getClient(token);
+    try {
+      // Active items only — never surface archived items in the picker.
+      const items = await client.items.list(vaultId, {
+        type: "ByState",
+        content: { active: true, archived: false },
+      });
+      return items.map((i) => ({
+        id: i.id,
+        title: i.title,
+        category: String(i.category),
+      }));
+    } catch (err) {
+      throw new ServiceError(
+        "BAD_REQUEST",
+        `cannot list items: ${errMessage(err)}`,
+      );
+    }
+  });
 
 /**
  * List an item's field labels — NOT values. The plaintext `field.value` the SDK
@@ -174,23 +265,24 @@ export const getItemFields = async (
   token: string,
   vaultId: string,
   itemId: string,
-): Promise<OpItemFields> => {
-  const client = await getClient(token);
-  try {
-    const item = await client.items.get(vaultId, itemId);
-    return {
-      fields: item.fields.map((f) => ({
-        id: f.id,
-        title: f.title,
-        fieldType: String(f.fieldType),
-        sectionId: f.sectionId,
-      })),
-      sections: item.sections.map((s) => ({ id: s.id, title: s.title })),
-    };
-  } catch (err) {
-    throw new ServiceError(
-      "BAD_REQUEST",
-      `cannot read item: ${errMessage(err)}`,
-    );
-  }
-};
+): Promise<OpItemFields> =>
+  withPinnedUndici(async () => {
+    const client = await getClient(token);
+    try {
+      const item = await client.items.get(vaultId, itemId);
+      return {
+        fields: item.fields.map((f) => ({
+          id: f.id,
+          title: f.title,
+          fieldType: String(f.fieldType),
+          sectionId: f.sectionId,
+        })),
+        sections: item.sections.map((s) => ({ id: s.id, title: s.title })),
+      };
+    } catch (err) {
+      throw new ServiceError(
+        "BAD_REQUEST",
+        `cannot read item: ${errMessage(err)}`,
+      );
+    }
+  });

--- a/packages/api/src/services/policy-rule-service.ts
+++ b/packages/api/src/services/policy-rule-service.ts
@@ -14,6 +14,7 @@ import {
   type PolicyMode,
 } from "../validations/policy-rule";
 import type { AppTool, AppPermissionLevel } from "../apps/app-permissions";
+import { getRuleActionGate } from "../providers";
 
 export type { CreatePolicyRuleInput, UpdatePolicyRuleInput };
 
@@ -55,6 +56,8 @@ export const createPolicyRule = async (
   scope: ResourceScope,
   input: CreatePolicyRuleInput,
 ) => {
+  await getRuleActionGate().assertAllowed(scope, [input.action]);
+
   const name = input.name.trim();
   const orgScope = isOrgScope(scope);
 
@@ -106,6 +109,9 @@ export const updatePolicyRule = async (
   ruleId: string,
   input: UpdatePolicyRuleInput,
 ) => {
+  if (input.action !== undefined)
+    await getRuleActionGate().assertAllowed(scope, [input.action]);
+
   const rule = await db.policyRule.findFirst({
     where: scopeOwnership(scope, ruleId),
     select: { id: true },
@@ -218,6 +224,11 @@ export const setAppPermissionsService = async (
   conditions?: RuleCondition[],
   policyMode?: PolicyMode,
 ) => {
+  await getRuleActionGate().assertAllowed(
+    scope,
+    changes.map((c) => c.permission),
+  );
+
   const isDenyMode = policyMode === "deny";
   const existing = await listAppPermissionRules(scope, provider);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       stripe:
         specifier: ^20.4.0
         version: 20.4.0(@types/node@22.19.11)
+      undici:
+        specifier: ^8.0.0
+        version: 8.5.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -4807,6 +4810,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -10661,6 +10668,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@8.5.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:


### PR DESCRIPTION
Syncs shared (edition-agnostic) changes from the downstream repo. No cloud-only code is included — the downstream cloud edition layers its behavior on top of these shared seams.

## Changes

- **1Password SDK service** — isolate the SDK's `undici` instance from Prisma's global dispatcher via `withPinnedUndici`, fixing the intermittent "request library compatibility issue: error sending request" failure; harden the connection config. Adds the `undici` dependency.
- **Gateway** — validate `X-Project-Id` for browser vault calls so requests scope to the active project (`user_can_access_project`), and allow-list the header for CORS preflight. The default-project resolution path is retained for the default build via `#[cfg(not(feature = "cloud"))]`.
- **Plan-gate extension seam** — add `lib/plan-gate.tsx` (default: allow) and a `rule-action-gate` provider hook as an extension point for gating rule actions.
- **Per-agent app-connection permissions** — connections UI, app permission groups, and `agents`/`rules` route updates.
- Supporting provider hooks, navigation, and proxy plumbing.

## Verification

- `pnpm check` (turbo lint + check-types + Prettier/Prisma format) — green
- Gateway `cargo clippy -- -D warnings` and `cargo check` (default build, no `cloud` feature) — green