### PR TITLE
fix: use drive scope to allow managing existing Google Drive files

### DIFF
--- a/packages/api/src/apps/google-drive.ts
+++ b/packages/api/src/apps/google-drive.ts
@@ -18,7 +18,7 @@ export const googleDrive: AppDefinition = {
       "email",
       "profile",
       "https://www.googleapis.com/auth/drive.readonly",
-      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/drive",
     ],
     permissions: [
       {
@@ -28,9 +28,9 @@ export const googleDrive: AppDefinition = {
         access: "read",
       },
       {
-        scope: "https://www.googleapis.com/auth/drive.file",
-        name: "Manage app files",
-        description: "Create and edit files opened or created by OneCLI",
+        scope: "https://www.googleapis.com/auth/drive",
+        name: "Manage files",
+        description: "Create, edit, move, and delete all your Drive files",
         access: "write",
       },
       {


### PR DESCRIPTION
## Summary

- Replaces the `drive.file` scope with the full `drive` scope for Google Drive write access.
- `drive.file` only allows managing files OneCLI itself created or opened, so agents cannot **move, rename, or delete pre-existing files** in the user's Drive — even when the connected account has full edit rights (e.g. a Shared Drive manager). Re-parenting a file uploaded by someone else (the typical "organize into folders" flow) fails with `403`.
- This mirrors the Sheets fix in #319 (`drive.file` → `spreadsheets`) and the Docs fix in #336 (`drive.file` → `documents`). Unlike Sheets/Docs, Google Drive has **no narrower per-resource scope**, so the full `https://www.googleapis.com/auth/drive` scope is the only option for general file management.
- The per-operation permission gate (Create/Update/Delete/Share) still lets operators restrict what agents may actually do, mitigating the broader scope.

(Happy to file a tracking issue mirroring #289/#335 if you’d prefer one linked.)

## Test plan

- Connect a Google account with the updated scopes; confirm the consent screen now offers **"See, edit, create, and delete all of your Google Drive files"** rather than the `drive.file` ("only the specific files you use with this app") wording.
- Verify an agent can read an existing file (via `drive.readonly`).
- Verify an agent can **move/rename/delete a pre-existing file** the user already had (previously broken with `403`).
- Verify an agent can create a new file.