### PR TITLE
feat(gateway): add HostPattern::Env for self-hosted connector hosts

### DIFF
--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -50,6 +50,14 @@ pub(crate) enum HostPattern {
     /// Match any hostname ending with the suffix, strictly longer than the suffix
     /// (e.g., `"-aiplatform.googleapis.com"` matches `"us-central1-aiplatform.googleapis.com"`).
     Suffix(&'static str),
+    /// Match the hostname against the value of an environment variable, read
+    /// at match time (e.g., `Env("AFFINE_HOST")` with `AFFINE_HOST=affine.example.com`).
+    /// Used for self-hosted services whose hostname is deployment-specific.
+    /// Never matches when the env var is unset or empty.
+    // `allow(dead_code)`: this variant has no provider consumer yet — the first
+    // (AFFiNE) lands in a follow-up PR. Matching/tests already exercise it.
+    #[allow(dead_code)]
+    Env(&'static str),
 }
 
 /// A host pattern and its injection strategy for an app provider.
@@ -76,6 +84,9 @@ impl HostPattern {
         match self {
             Self::Exact(host) => *host == hostname,
             Self::Suffix(suffix) => hostname.ends_with(suffix) && hostname.len() > suffix.len(),
+            Self::Env(var) => std::env::var(var)
+                .ok()
+                .is_some_and(|v| !v.is_empty() && v.eq_ignore_ascii_case(hostname)),
         }
     }
 }
@@ -2746,6 +2757,7 @@ mod tests {
                 let host = match rule.pattern {
                     HostPattern::Exact(h) => h,
                     HostPattern::Suffix(_) => continue, // suffix rules don't share hosts
+                    HostPattern::Env(_) => continue,    // env rules are deployment-specific
                 };
                 let entry = hosts.entry(host).or_default();
                 if rule.path_prefix.is_some() {
@@ -2785,6 +2797,29 @@ mod tests {
     fn vertex_ai_suffix_no_false_positives() {
         assert!(providers_for_host("aiplatform.googleapis.com").is_empty());
         assert!(providers_for_host("-aiplatform.googleapis.com").is_empty());
+    }
+
+    // Uses a dedicated env var (not shared with any provider rule) so it can
+    // safely set/unset without racing other tests — env vars are process-global.
+    #[test]
+    fn host_pattern_env_matches() {
+        let pattern = HostPattern::Env("ONECLI_TEST_SELF_HOSTED_HOST");
+
+        // Unset → never matches.
+        std::env::remove_var("ONECLI_TEST_SELF_HOSTED_HOST");
+        assert!(!pattern.matches("svc.example.com"));
+
+        std::env::set_var("ONECLI_TEST_SELF_HOSTED_HOST", "svc.example.com");
+        // Exact match, case-insensitive; unrelated hosts do not match.
+        assert!(pattern.matches("svc.example.com"));
+        assert!(pattern.matches("SVC.Example.com"));
+        assert!(!pattern.matches("other.example.com"));
+
+        // Empty value → never matches (safe default).
+        std::env::set_var("ONECLI_TEST_SELF_HOSTED_HOST", "");
+        assert!(!pattern.matches("svc.example.com"));
+
+        std::env::remove_var("ONECLI_TEST_SELF_HOSTED_HOST");
     }
 
     #[test]

--- a/docs/self-hosted-connectors.md
+++ b/docs/self-hosted-connectors.md
@@ -1,0 +1,41 @@
+# Self-Hosted Connectors
+
+Some services OneCLI can connect to are self-hosted, so their hostname is
+deployment-specific (e.g. `affine.mycompany.com`, `gitea.homelab.local`) rather
+than a fixed SaaS domain like `api.github.com`. The gateway matches incoming
+requests to providers using a compiled host-pattern table, which means a
+self-hosted hostname is not known at build time.
+
+## How It Works
+
+The gateway `HostPattern` enum supports matching a provider's host against the
+value of an environment variable, read at match time:
+
+```rust
+HostPattern::Env("AFFINE_HOST") // matches when AFFINE_HOST == request hostname
+```
+
+- The variable is read once per request — no database access on the hot path.
+- Matching is case-insensitive.
+- It **never** matches when the variable is unset or empty, so an unconfigured
+  self-hosted provider is inert by default.
+- The existing `credential_host_field` gate still applies on top: injection only
+  proceeds when the request host also equals the host stored on the connection.
+  A token therefore cannot leak to a different host even if the environment
+  variable is later repointed.
+
+## Configuring a Self-Hosted Host
+
+Set the provider's host environment variable wherever the gateway runs — for
+example in `docker-compose.yml`:
+
+```yaml
+services:
+  gateway:
+    environment:
+      AFFINE_HOST: affine.mycompany.com
+```
+
+No restart-time config files or binary changes are required beyond setting the
+variable. Each provider that supports self-hosting documents the specific
+variable name it reads.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature (gateway).

## What is the current behavior?

The gateway matches incoming requests to providers using a compiled host-pattern table (`HostPattern::Exact` / `HostPattern::Suffix`), both of which require the hostname to be known at build time. There is no supported way to route a self-hosted service whose hostname is deployment-specific (e.g. `affine.mycompany.com`).

Closes #354.

## What is the new behavior?

Adds a third variant, `HostPattern::Env(&'static str)`, that matches a provider's host against the value of a named environment variable, read at match time:

- Case-insensitive match.
- **Never** matches when the variable is unset or empty (safe default).
- The existing `credential_host_field` gate still applies on top as a per-connection security layer, so a token cannot leak to a different host even if the env var is repointed.
- Unit test covers unset / empty / match / case-insensitive / other-host.
- Documents the mechanism in `docs/self-hosted-connectors.md`.

This satisfies the acceptance criteria in #354.

## Additional context

The variant carries `#[allow(dead_code)]` because it has no provider consumer in this PR. Its first consumer — the AFFiNE connector (#373) — lands in a follow-up PR stacked on this one, which removes the attribute.

Local checks pass: `pnpm check` (lint + types + format, including `cargo fmt --check` and `cargo clippy -- -D warnings`) and the gateway test suite.
