### PR TITLE
feat: add AFFiNE connector for self-hosted instances (+ internal-CA upstream TLS)

### DIFF
--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -50,6 +50,14 @@ pub(crate) enum HostPattern {
     /// Match any hostname ending with the suffix, strictly longer than the suffix
     /// (e.g., `"-aiplatform.googleapis.com"` matches `"us-central1-aiplatform.googleapis.com"`).
     Suffix(&'static str),
+    /// Match the hostname against the value of an environment variable, read
+    /// at match time (e.g., `Env("AFFINE_HOST")` with `AFFINE_HOST=affine.example.com`).
+    /// Used for self-hosted services whose hostname is deployment-specific.
+    /// Never matches when the env var is unset or empty.
+    // `allow(dead_code)`: this variant has no provider consumer yet — the first
+    // (AFFiNE) lands in a follow-up PR. Matching/tests already exercise it.
+    #[allow(dead_code)]
+    Env(&'static str),
 }
 
 /// A host pattern and its injection strategy for an app provider.
@@ -76,6 +84,9 @@ impl HostPattern {
         match self {
             Self::Exact(host) => *host == hostname,
             Self::Suffix(suffix) => hostname.ends_with(suffix) && hostname.len() > suffix.len(),
+            Self::Env(var) => std::env::var(var)
+                .ok()
+                .is_some_and(|v| !v.is_empty() && v.eq_ignore_ascii_case(hostname)),
         }
     }
 }
@@ -2746,6 +2757,7 @@ mod tests {
                 let host = match rule.pattern {
                     HostPattern::Exact(h) => h,
                     HostPattern::Suffix(_) => continue, // suffix rules don't share hosts
+                    HostPattern::Env(_) => continue,    // env rules are deployment-specific
                 };
                 let entry = hosts.entry(host).or_default();
                 if rule.path_prefix.is_some() {
@@ -2785,6 +2797,29 @@ mod tests {
     fn vertex_ai_suffix_no_false_positives() {
         assert!(providers_for_host("aiplatform.googleapis.com").is_empty());
         assert!(providers_for_host("-aiplatform.googleapis.com").is_empty());
+    }
+
+    // Uses a dedicated env var (not shared with any provider rule) so it can
+    // safely set/unset without racing other tests — env vars are process-global.
+    #[test]
+    fn host_pattern_env_matches() {
+        let pattern = HostPattern::Env("ONECLI_TEST_SELF_HOSTED_HOST");
+
+        // Unset → never matches.
+        std::env::remove_var("ONECLI_TEST_SELF_HOSTED_HOST");
+        assert!(!pattern.matches("svc.example.com"));
+
+        std::env::set_var("ONECLI_TEST_SELF_HOSTED_HOST", "svc.example.com");
+        // Exact match, case-insensitive; unrelated hosts do not match.
+        assert!(pattern.matches("svc.example.com"));
+        assert!(pattern.matches("SVC.Example.com"));
+        assert!(!pattern.matches("other.example.com"));
+
+        // Empty value → never matches (safe default).
+        std::env::set_var("ONECLI_TEST_SELF_HOSTED_HOST", "");
+        assert!(!pattern.matches("svc.example.com"));
+
+        std::env::remove_var("ONECLI_TEST_SELF_HOSTED_HOST");
     }
 
     #[test]

--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -54,9 +54,6 @@ pub(crate) enum HostPattern {
     /// at match time (e.g., `Env("AFFINE_HOST")` with `AFFINE_HOST=affine.example.com`).
     /// Used for self-hosted services whose hostname is deployment-specific.
     /// Never matches when the env var is unset or empty.
-    // `allow(dead_code)`: this variant has no provider consumer yet — the first
-    // (AFFiNE) lands in a follow-up PR. Matching/tests already exercise it.
-    #[allow(dead_code)]
     Env(&'static str),
 }
 
@@ -1109,6 +1106,28 @@ static APP_PROVIDERS: &[AppProvider] = &[
             strategy: AuthStrategy::Bearer,
             intercept: false,
             credential_host_field: Some("subdomain"),
+        }],
+        refresh: None,
+        metadata_headers: &[],
+        credential_headers: &[],
+        credential_params: &[],
+        host_rewrite: None,
+        finalizer: None,
+        body_transform: None,
+    },
+    AppProvider {
+        provider: "affine",
+        display_name: "AFFiNE",
+        // Self-hosted instances have deployment-specific hostnames, so the
+        // host is configured via the AFFINE_HOST env var. The stored `host`
+        // credential field additionally gates injection per connection so a
+        // token never leaks if AFFINE_HOST is repointed.
+        host_rules: &[HostRule {
+            pattern: HostPattern::Env("AFFINE_HOST"),
+            path_prefix: None,
+            strategy: AuthStrategy::Bearer,
+            intercept: false,
+            credential_host_field: Some("host"),
         }],
         refresh: None,
         metadata_headers: &[],
@@ -3042,6 +3061,48 @@ mod tests {
     #[test]
     fn jfrog_has_no_refresh_config() {
         assert!(refresh_config("jfrog-artifactory").is_none());
+    }
+
+    // ── AFFiNE ────────────────────────────────────────────────────────
+
+    // Single test for everything that depends on AFFINE_HOST: env vars are
+    // process-global and tests run in parallel, so only ONE test may touch
+    // this variable.
+    #[test]
+    fn affine_env_host_rule() {
+        // Unset → never matches.
+        std::env::remove_var("AFFINE_HOST");
+        assert!(providers_for_host("affine.example.com").is_empty());
+
+        std::env::set_var("AFFINE_HOST", "affine.example.com");
+
+        // Host matching: exact env value, case-insensitive, no other hosts.
+        assert_eq!(providers_for_host("affine.example.com"), vec!["affine"]);
+        assert_eq!(providers_for_host("AFFINE.example.com"), vec!["affine"]);
+        assert!(providers_for_host("other.example.com").is_empty());
+        assert_eq!(
+            provider_for_host("affine.example.com"),
+            Some(("affine", "AFFiNE"))
+        );
+
+        // Injection: Bearer auth.
+        let injections = build_app_injections("affine", "affine.example.com", "ut_test");
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: "Bearer ut_test".to_string(),
+            }
+        );
+
+        // Per-connection host gate.
+        assert_eq!(
+            credential_host_field("affine", "affine.example.com"),
+            Some("host")
+        );
+
+        std::env::remove_var("AFFINE_HOST");
     }
 
     // ── credential_host_field ─────────────────────────────────────────

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -103,11 +103,84 @@ pub struct GatewayServer {
 /// - Redirects are disabled so 3xx responses are forwarded to the client as-is.
 /// - `accept_invalid_certs` skips TLS certificate validation for upstream connections.
 fn build_http_client(accept_invalid_certs: bool) -> reqwest::Client {
-    reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
-        .danger_accept_invalid_certs(accept_invalid_certs)
-        .build()
-        .expect("build HTTP client")
+        .danger_accept_invalid_certs(accept_invalid_certs);
+    // Trust extra CA certificate(s) for UPSTREAM TLS verification (e.g. a
+    // self-hosted internal / Smallstep CA), so the gateway can forward to
+    // internal HTTPS services with full verification instead of skipping it.
+    // Public webpki roots stay trusted, so SaaS hosts are unaffected.
+    for cert in load_upstream_ca_certs() {
+        builder = builder.add_root_certificate(cert);
+    }
+    builder.build().expect("build HTTP client")
+}
+
+/// Extra trusted CA certificates for upstream TLS verification, loaded from
+/// `GATEWAY_UPSTREAM_CA_CERT` (a path to a PEM file, or inline PEM). Returns an
+/// empty vec when unset/empty. A bad path or unparseable cert is logged and
+/// skipped rather than crashing the gateway.
+fn load_upstream_ca_certs() -> Vec<reqwest::Certificate> {
+    let Ok(value) = std::env::var("GATEWAY_UPSTREAM_CA_CERT") else {
+        return Vec::new();
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Vec::new();
+    }
+    let pem = if value.starts_with("-----BEGIN") {
+        value.as_bytes().to_vec()
+    } else {
+        match std::fs::read(value) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                warn!(path = %value, error = %e, "GATEWAY_UPSTREAM_CA_CERT: failed to read CA file");
+                return Vec::new();
+            }
+        }
+    };
+    let certs = parse_ca_pem_bundle(&pem);
+    if certs.is_empty() {
+        warn!("GATEWAY_UPSTREAM_CA_CERT set but no certificates were parsed");
+    } else {
+        info!(
+            count = certs.len(),
+            "trusting extra upstream CA certificate(s) from GATEWAY_UPSTREAM_CA_CERT"
+        );
+    }
+    certs
+}
+
+/// Parse a PEM bundle into individual reqwest certificates. Splits on
+/// `CERTIFICATE` blocks and parses each independently so one bad block doesn't
+/// discard the rest (and to avoid depending on a specific reqwest minor for
+/// bundle parsing).
+fn parse_ca_pem_bundle(pem: &[u8]) -> Vec<reqwest::Certificate> {
+    let text = String::from_utf8_lossy(pem);
+    let mut certs = Vec::new();
+    let mut current = String::new();
+    let mut in_cert = false;
+    for line in text.lines() {
+        if line.contains("BEGIN CERTIFICATE") {
+            in_cert = true;
+            current.clear();
+        }
+        if in_cert {
+            current.push_str(line);
+            current.push('\n');
+        }
+        if line.contains("END CERTIFICATE") {
+            in_cert = false;
+            match reqwest::Certificate::from_pem(current.as_bytes()) {
+                Ok(cert) => certs.push(cert),
+                Err(e) => {
+                    warn!(error = %e, "skipping unparseable certificate in GATEWAY_UPSTREAM_CA_CERT")
+                }
+            }
+            current.clear();
+        }
+    }
+    certs
 }
 
 /// Parse `GATEWAY_SKIP_VERIFY_HOSTS` into a list of hostname patterns.
@@ -921,6 +994,27 @@ pub(crate) fn strip_port(host: &str) -> &str {
 mod tests {
     use super::*;
     use std::net::TcpListener;
+
+    /// GATEWAY_UPSTREAM_CA_CERT parsing: a PEM bundle yields one cert per
+    /// CERTIFICATE block, and non-cert input yields none (and is not fatal).
+    #[test]
+    fn parse_ca_pem_bundle_handles_single_multiple_and_garbage() {
+        let c1 = rcgen::generate_simple_self_signed(vec!["a.test".to_string()])
+            .unwrap()
+            .cert
+            .pem();
+        let c2 = rcgen::generate_simple_self_signed(vec!["b.test".to_string()])
+            .unwrap()
+            .cert
+            .pem();
+
+        assert_eq!(parse_ca_pem_bundle(c1.as_bytes()).len(), 1);
+        let bundle = format!("{c1}\n{c2}");
+        assert_eq!(parse_ca_pem_bundle(bundle.as_bytes()).len(), 2);
+        // Non-PEM input (e.g. a wrong/empty file) yields nothing and never panics.
+        assert!(parse_ca_pem_bundle(b"not a pem at all").is_empty());
+        assert!(parse_ca_pem_bundle(b"").is_empty());
+    }
 
     /// Verify that the production HTTP client does not follow redirects.
     /// A proxy must forward 3xx responses to the client so the client's HTTP

--- a/apps/web/public/icons/affine.svg
+++ b/apps/web/public/icons/affine.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <defs>
+    <linearGradient id="affine-a" x1="3" y1="21" x2="21" y2="3" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1E96EB"/>
+      <stop offset="1" stop-color="#8C9DF7"/>
+    </linearGradient>
+  </defs>
+  <path d="M13.96 2.5 21.5 21.5h-3.62l-1.62-4.2H7.74l-1.62 4.2H2.5L10.04 2.5h3.92Zm-1.96 4.9-2.98 7.7h5.96l-2.98-7.7Z" fill="url(#affine-a)"/>
+</svg>

--- a/apps/web/src/app/(dashboard)/connections/_components/app-categories.ts
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-categories.ts
@@ -55,6 +55,7 @@ export const APP_CATEGORIES: Record<string, AppCategory> = {
   jira: "project-management",
   confluence: "project-management",
   notion: "project-management",
+  affine: "project-management",
   todoist: "project-management",
   trello: "project-management",
   monday: "project-management",

--- a/docs/self-hosted-connectors.md
+++ b/docs/self-hosted-connectors.md
@@ -39,3 +39,49 @@ services:
 No restart-time config files or binary changes are required beyond setting the
 variable. Each provider that supports self-hosting documents the specific
 variable name it reads.
+
+## TLS for self-hosted hosts (internal / non-public CAs)
+
+Self-hosted services in a homelab or private network usually present a TLS
+certificate issued by an **internal CA** (e.g. Smallstep, a corporate root, or
+mkcert) rather than a publicly-trusted ("top-tier") CA. The gateway's upstream
+HTTP client uses the bundled public root store, so it will **not** trust such a
+certificate — and forwarding fails with a gateway `502 {"error":
+"resolution_failed"}` (the underlying error is a TLS handshake failure, visible
+in the gateway logs as `error sending request for url`).
+
+> This is purely an upstream-TLS trust issue: provider host-matching and
+> credential injection still work — the gateway just can't complete the TLS
+> handshake to the internal host.
+
+You have two options:
+
+### Option 1 — Trust the internal root CA (recommended; keeps full verification)
+
+Point the gateway at your internal CA so it verifies the certificate normally.
+`GATEWAY_UPSTREAM_CA_CERT` accepts a PEM file path **or** inline PEM, and the CA
+is added **on top of** the public roots (so SaaS hosts keep working):
+
+```yaml
+services:
+  gateway:
+    environment:
+      GATEWAY_UPSTREAM_CA_CERT: /etc/onecli/internal-root-ca.crt
+    volumes:
+      - ./internal-root-ca.crt:/etc/onecli/internal-root-ca.crt:ro
+```
+
+### Option 2 — Skip verification for specific hosts (quick; less secure)
+
+If you can't supply the CA, disable verification for the affected hosts only.
+`GATEWAY_SKIP_VERIFY_HOSTS` is comma-separated and supports `*.wildcard`:
+
+```yaml
+services:
+  gateway:
+    environment:
+      GATEWAY_SKIP_VERIFY_HOSTS: affine.mycompany.com,*.internal.corp
+```
+
+This skips TLS verification for those hosts (a potential MITM risk on the
+network), so prefer Option 1 where you have access to the root CA.

--- a/docs/self-hosted-connectors.md
+++ b/docs/self-hosted-connectors.md
@@ -1,0 +1,41 @@
+# Self-Hosted Connectors
+
+Some services OneCLI can connect to are self-hosted, so their hostname is
+deployment-specific (e.g. `affine.mycompany.com`, `gitea.homelab.local`) rather
+than a fixed SaaS domain like `api.github.com`. The gateway matches incoming
+requests to providers using a compiled host-pattern table, which means a
+self-hosted hostname is not known at build time.
+
+## How It Works
+
+The gateway `HostPattern` enum supports matching a provider's host against the
+value of an environment variable, read at match time:
+
+```rust
+HostPattern::Env("AFFINE_HOST") // matches when AFFINE_HOST == request hostname
+```
+
+- The variable is read once per request — no database access on the hot path.
+- Matching is case-insensitive.
+- It **never** matches when the variable is unset or empty, so an unconfigured
+  self-hosted provider is inert by default.
+- The existing `credential_host_field` gate still applies on top: injection only
+  proceeds when the request host also equals the host stored on the connection.
+  A token therefore cannot leak to a different host even if the environment
+  variable is later repointed.
+
+## Configuring a Self-Hosted Host
+
+Set the provider's host environment variable wherever the gateway runs — for
+example in `docker-compose.yml`:
+
+```yaml
+services:
+  gateway:
+    environment:
+      AFFINE_HOST: affine.mycompany.com
+```
+
+No restart-time config files or binary changes are required beyond setting the
+variable. Each provider that supports self-hosting documents the specific
+variable name it reads.

--- a/packages/api/src/apps/affine.ts
+++ b/packages/api/src/apps/affine.ts
@@ -1,0 +1,75 @@
+import type { AppDefinition } from "./types";
+
+/**
+ * AFFiNE connector (self-hosted instances).
+ *
+ * Cribbed from the Notion connector in spirit (workspace pages/docs), but
+ * AFFiNE exposes a GraphQL API with personal access tokens rather than OAuth,
+ * so the connection is a plain api_key. The instance hostname is per-deployment;
+ * the gateway matches it via the AFFINE_HOST env var and gates injection on the
+ * stored `host` field (see gateway apps.rs).
+ */
+export const affine: AppDefinition = {
+  id: "affine",
+  name: "AFFiNE",
+  icon: "/icons/affine.svg",
+  description: "Workspaces, docs, and collaboration on your AFFiNE instance.",
+  connectionMethod: {
+    type: "api_key",
+    // Token MUST come first: the connect handler treats fields[0] as the
+    // access token (credentials.access_token = fields[0]). Host second.
+    fields: [
+      {
+        name: "token",
+        label: "Access Token",
+        description:
+          "A personal access token from your AFFiNE instance (Settings → Access Tokens).",
+        placeholder: "ut_...",
+        secret: true,
+      },
+      {
+        name: "host",
+        label: "AFFiNE Host",
+        description:
+          "Your instance host (must match the gateway's AFFINE_HOST), e.g. affine.example.com",
+        placeholder: "affine.example.com",
+        secret: false,
+      },
+    ],
+    resolveMetadata: async (fields) => {
+      // Resolve the connected user via GraphQL. Non-fatal — fall back to the
+      // host as the connection label.
+      try {
+        const res = await fetch(`https://${fields.host}/graphql`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${fields.token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            query: "query { currentUser { name email } }",
+          }),
+        });
+        if (res.ok) {
+          const data = (await res.json()) as {
+            data?: { currentUser?: { name?: string; email?: string } };
+          };
+          const user = data.data?.currentUser;
+          if (user?.email || user?.name) {
+            return {
+              name: user.name ?? user.email,
+              username: user.email ?? user.name,
+              email: user.email,
+              host: fields.host,
+            };
+          }
+        }
+      } catch {
+        // Non-fatal
+      }
+      return { name: fields.host, username: fields.host };
+    },
+  },
+  labelHint: 'e.g. "affine.int.example.com"',
+  available: true,
+};

--- a/packages/api/src/apps/app-permissions/affine.ts
+++ b/packages/api/src/apps/app-permissions/affine.ts
@@ -1,0 +1,59 @@
+import type { AppPermissionDefinition } from "./types";
+
+/**
+ * AFFiNE runs on a per-deployment host; "*" matches any host here because the
+ * gateway already restricts injection to the AFFINE_HOST instance, and the
+ * stored `host` credential field gates each connection.
+ *
+ * AFFiNE's API is GraphQL-first: queries and mutations share POST /graphql,
+ * so the GraphQL tool lives in the write group (it can mutate). REST GETs
+ * (session info, blob/doc downloads) are listed as read tools.
+ */
+export const affinePermissions: AppPermissionDefinition = {
+  provider: "affine",
+  groups: [
+    {
+      category: "read",
+      tools: [
+        {
+          id: "get_session",
+          name: "Get session",
+          description: "Retrieve the current auth session",
+          hostPattern: "*",
+          pathPattern: "/api/auth/session",
+          method: "GET",
+        },
+        {
+          id: "read_workspace_content",
+          name: "Read workspace content",
+          description: "Download docs and blobs from workspaces",
+          hostPattern: "*",
+          pathPattern: "/api/workspaces/*",
+          method: "GET",
+        },
+      ],
+    },
+    {
+      category: "write",
+      tools: [
+        {
+          id: "graphql",
+          name: "GraphQL API",
+          description:
+            "Queries and mutations: workspaces, docs, users, and sharing (read + write)",
+          hostPattern: "*",
+          pathPattern: "/graphql",
+          method: "POST",
+        },
+        {
+          id: "upload_workspace_content",
+          name: "Upload workspace content",
+          description: "Upload docs and blobs to workspaces",
+          hostPattern: "*",
+          pathPattern: "/api/workspaces/*",
+          methods: ["POST", "PUT"],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/api/src/apps/app-permissions/index.ts
+++ b/packages/api/src/apps/app-permissions/index.ts
@@ -43,6 +43,7 @@ import { linkedinPermissions } from "./linkedin";
 import { trelloPermissions } from "./trello";
 import { mondayPermissions } from "./monday";
 import { vercelPermissions } from "./vercel";
+import { affinePermissions } from "./affine";
 
 const permissionRegistry = new Map<string, AppPermissionDefinition>();
 
@@ -93,3 +94,4 @@ register(linkedinPermissions);
 register(trelloPermissions);
 register(mondayPermissions);
 register(vercelPermissions);
+register(affinePermissions);

--- a/packages/api/src/apps/registry.ts
+++ b/packages/api/src/apps/registry.ts
@@ -39,6 +39,7 @@ import { trello } from "./trello";
 import { monday } from "./monday";
 import { vercel } from "./vercel";
 import { jfrogArtifactory } from "./jfrog-artifactory";
+import { affine } from "./affine";
 
 const staticApps: AppDefinition[] = [
   gmail,
@@ -79,6 +80,7 @@ const staticApps: AppDefinition[] = [
   trello,
   vercel,
   jfrogArtifactory,
+  affine,
 ];
 
 const CLOUD_HIDDEN_APPS = new Set(["jfrog-artifactory"]);


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature — new app integration (AFFiNE) + supporting gateway change for self-hosted TLS.

## What is the current behavior?

There is no connector for [AFFiNE](https://affine.pro), a commonly self-hosted open-source workspace.

Closes #373.

## What is the new behavior?

Adds an AFFiNE connector for self-hosted instances:

- `api_key` connection: personal access token + instance host. AFFiNE uses GraphQL with personal access tokens rather than OAuth.
- The gateway matches the deployment host via `HostPattern::Env("AFFINE_HOST")`; the stored `host` credential field gates injection per-connection so a token never leaks if `AFFINE_HOST` is repointed.
- Bearer injection; the GraphQL endpoint (`/graphql`) is the write tool, REST GETs (session, workspace content) are read tools.
- `resolveMetadata` resolves the connected user via GraphQL, falling back to the host as the connection label.

### Gateway: trust an internal upstream CA (self-hosted TLS)

Real-world self-hosted AFFiNE (and any self-hosted host) usually presents a TLS
certificate from an **internal CA** (Smallstep, a corporate root, mkcert), not a
publicly-trusted one. The gateway's reqwest client uses the bundled public roots,
so forwarding fails the TLS handshake and surfaces as a gateway
`502 resolution_failed` — even though host-matching and injection succeed.

- Adds `GATEWAY_UPSTREAM_CA_CERT` (a PEM file path **or** inline PEM). Each cert
  is added **on top of** the public webpki roots, so internal hosts verify
  normally while SaaS hosts are unaffected. A bad path/PEM is logged and skipped
  rather than crashing the gateway. Unit test covers single / multiple / garbage.
- `docs/self-hosted-connectors.md` documents this (recommended) alongside the
  existing `GATEWAY_SKIP_VERIFY_HOSTS` escape hatch, for homelab/self-hosted
  deployments not using a top-tier CA.

## Additional context

> ⚠️ **Stacked on #374.** This PR builds on the `HostPattern::Env` mechanism from #374 and is its first consumer (it also removes the temporary `#[allow(dead_code)]` added there). Please review/merge #374 first — until it merges, the diff here includes that commit.

Local checks pass: `pnpm check` (lint + types + format, incl. `cargo fmt --check` and `cargo clippy -- -D warnings`) and the gateway test suite.
