### PR TITLE
fix: allow editing existing Google Docs and Slides files

### DIFF
--- a/packages/api/src/apps/google-docs.ts
+++ b/packages/api/src/apps/google-docs.ts
@@ -17,7 +17,7 @@ export const googleDocs: AppDefinition = {
       "email",
       "profile",
       "https://www.googleapis.com/auth/drive.readonly",
-      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/documents",
     ],
     permissions: [
       {
@@ -27,9 +27,9 @@ export const googleDocs: AppDefinition = {
         access: "read",
       },
       {
-        scope: "https://www.googleapis.com/auth/drive.file",
-        name: "Manage app documents",
-        description: "Create and edit documents opened or created by OneCLI",
+        scope: "https://www.googleapis.com/auth/documents",
+        name: "Edit documents",
+        description: "Create and edit all your Google Docs documents",
         access: "write",
       },
       {

--- a/packages/api/src/apps/google-slides.ts
+++ b/packages/api/src/apps/google-slides.ts
@@ -17,7 +17,7 @@ export const googleSlides: AppDefinition = {
       "email",
       "profile",
       "https://www.googleapis.com/auth/drive.readonly",
-      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/presentations",
     ],
     permissions: [
       {
@@ -27,10 +27,9 @@ export const googleSlides: AppDefinition = {
         access: "read",
       },
       {
-        scope: "https://www.googleapis.com/auth/drive.file",
-        name: "Manage app presentations",
-        description:
-          "Create and edit presentations opened or created by OneCLI",
+        scope: "https://www.googleapis.com/auth/presentations",
+        name: "Edit presentations",
+        description: "Create and edit all your Google Slides presentations",
         access: "write",
       },
       {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Google Docs and Google Slides request `drive.file` for write access. That scope only covers files created by or explicitly opened with the OAuth app, so agents cannot edit existing documents and presentations the user already has access to.

This is the same failure mode fixed for Google Sheets in #319.

Fixes #335.

## What is the new behavior?

- Google Docs requests `documents`, allowing it to create and edit existing Google Docs documents.
- Google Slides requests `presentations`, allowing it to create and edit existing Google Slides presentations.
- Both providers retain `drive.readonly` for listing and discovery workflows.

Existing connections must reconnect to grant the new scopes.

## Additional context

This intentionally does not broaden the Google Drive provider's platform-managed OAuth scopes. BYOC-specific full Drive access is tracked separately in #376, and Google Chat Workspace Events routing is tracked in #377.

Verification completed:

- `pnpm check`
- `pnpm build`