### PR TITLE
fix(web): redirect /settings at the routing layer to avoid React #310

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -28,6 +28,22 @@ const getOssDashboardSegments = () => {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  // `/settings` has no page of its own — it redirects to the first settings
+  // section. Do it at the routing layer instead of an in-render server
+  // `redirect()` in the page, which throws during render and can trip a React
+  // hook-count mismatch (#310) in Next's AppRouter on client soft-navigation.
+  // Cloud namespaces settings under /org/<id>, so this is OSS-only.
+  async redirects() {
+    return isCloud
+      ? []
+      : [
+          {
+            source: "/settings",
+            destination: "/settings/instance",
+            permanent: false,
+          },
+        ];
+  },
   poweredByHeader: false,
   compress: !isCloud, // Cloud: CloudFront handles compression at the edge; OSS: Next.js compresses
   serverExternalPackages: ["@onecli/db", "@1password/sdk"],


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Navigating to `/settings` white-screens in production with a client-side exception — **Minified React error #310** ("Rendered more hooks than during the previous render").

`/settings` has no page of its own: `app/(dashboard)/settings/page.tsx` calls an **in-render server `redirect()`** to the first settings section. `redirect()` throws `NEXT_REDIRECT` during render, which trips a hook-count mismatch in Next's internal **AppRouter** (de-minified, the throwing `useMemo` is AppRouter's `{ searchParams, pathname }` computation) during client-side **soft-navigation**. It's the only dashboard route doing an in-render redirect, which is why only `/settings` crashed.

## What is the new behavior?

Move the redirect to the **routing layer** via `next.config` `redirects()` (OSS-only; cloud namespaces settings under `/org/<id>`):

```js
async redirects() {
  return isCloud ? [] : [
    { source: "/settings", destination: "/settings/instance", permanent: false },
  ];
}
```

`/settings` now redirects before any page renders, so the in-render `redirect()` is bypassed entirely. Verified: `/settings` no longer white-screens on soft-navigation, and normal navigation (hard load 307 + soft-nav) lands on `/settings/instance` as before.

## Additional context

Found and confirmed on a self-hosted deployment. Affects any OSS/self-hosted user who soft-navigates to `/settings`.
