### PR TITLE
fix(web): point client SessionProvider at /v1/auth basePath (#362)

### DIFF
--- a/apps/web/src/lib/auth/auth-provider.tsx
+++ b/apps/web/src/lib/auth/auth-provider.tsx
@@ -78,7 +78,11 @@ export const AuthProviderImpl = ({
   }
 
   return (
-    <SessionProvider>
+    // NextAuth route handlers are mounted at /v1/auth (not the default
+    // /api/auth), so the client must fetch the session from there too —
+    // otherwise getSession/useSession throw ClientFetchError in self-hosted
+    // OAuth deployments. See upstream issue #362.
+    <SessionProvider basePath="/v1/auth">
       <OAuthInner>{children}</OAuthInner>
     </SessionProvider>
   );


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In self-hosted **OAuth** mode, the NextAuth route handlers are mounted at **`/v1/auth`** (`app/v1/auth/[...nextauth]/route.ts`), but the client `<SessionProvider>` uses the default basePath `/api/auth`. So `getSession`/`useSession` fetch `/api/auth/session`, which doesn't exist, and throw `ClientFetchError` — the client-side session never establishes even though the cookie is valid server-side.

Closes #362.

## What is the new behavior?

Set the client SessionProvider's basePath to match where the handlers live:

```tsx
<SessionProvider basePath="/v1/auth">
```

The client now reads the session from `/v1/auth/session`; `ClientFetchError` is gone.

## Additional context

Found and confirmed on a self-hosted multi-user OAuth deployment (the configuration described in #362).
