### PR TITLE
feat(web): show build version on Overview and Settings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Resolve app version
+        id: appversion
+        run: echo "value=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -53,6 +57,8 @@ jobs:
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.appversion.outputs.value }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -308,8 +308,11 @@ impl GatewayServer {
 
 // ── Axum route handlers ─────────────────────────────────────────────────
 
-async fn healthz() -> StatusCode {
-    StatusCode::OK
+async fn healthz() -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({
+        "status": "ok",
+        "version": crate::version::app_version(),
+    }))
 }
 
 /// Protected: returns the authenticated user's ID.
@@ -928,6 +931,16 @@ pub(crate) fn strip_port(host: &str) -> &str {
 mod tests {
     use super::*;
     use std::net::TcpListener;
+
+    #[tokio::test]
+    async fn healthz_reports_status_and_version() {
+        let axum::Json(body) = healthz().await;
+        assert_eq!(body["status"], "ok");
+        assert!(
+            body["version"].as_str().is_some_and(|v| !v.is_empty()),
+            "healthz must report a non-empty version string",
+        );
+    }
 
     /// Verify that the production HTTP client does not follow redirects.
     /// A proxy must forward 3xx responses to the client so the client's HTTP

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -67,6 +67,7 @@ mod cloud_summary;
 
 mod telemetry_core;
 mod util;
+mod version;
 
 #[cfg(not(feature = "cloud"))]
 mod telemetry;

--- a/apps/gateway/src/version.rs
+++ b/apps/gateway/src/version.rs
@@ -1,0 +1,13 @@
+//! Resolve the running app/build version.
+//!
+//! Read from the `APP_VERSION` env var (stamped on the deployed image/task — cloud
+//! sets `<semver>+<short-sha>`, e.g. `1.38.0+f6cca6e5`), falling back to the
+//! compile-time crate version for local/unstamped builds.
+
+/// The app version reported by `/healthz` and telemetry.
+pub fn app_version() -> String {
+    std::env::var("APP_VERSION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,7 +1,27 @@
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const isCloud = process.env.NEXT_PUBLIC_EDITION === "cloud";
+
+// Build-time app version, exposed to the app as NEXT_PUBLIC_APP_VERSION (client +
+// server, inlined by Next). Cloud stamps APP_VERSION (semver + short git sha, e.g.
+// "1.38.0+f6cca6e5") as a build arg; OSS / self-host / local falls back to the
+// monorepo root package.json version, else "dev". process.cwd() is apps/web here.
+const resolveAppVersion = () => {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION;
+  try {
+    const pkg = JSON.parse(
+      readFileSync(
+        path.join(process.cwd(), "..", "..", "package.json"),
+        "utf8",
+      ),
+    );
+    return pkg.version || "dev";
+  } catch {
+    return "dev";
+  }
+};
+const appVersion = resolveAppVersion();
 
 // Dashboard paths that cloud intentionally serves at the SAME bare URL as OSS (shared).
 // Empty today: cloud namespaces every dashboard feature under /p, /org, /account, so no
@@ -33,6 +53,7 @@ const nextConfig = {
   serverExternalPackages: ["@onecli/db", "@1password/sdk"],
   env: {
     NEXT_PUBLIC_EDITION: process.env.NEXT_PUBLIC_EDITION || "oss",
+    NEXT_PUBLIC_APP_VERSION: appVersion,
     NEXT_PUBLIC_API_URL: process.env.API_DOMAIN
       ? `${isCloud && process.env.NODE_ENV !== "development" ? "https" : "http"}://${process.env.API_DOMAIN}`
       : "http://localhost:10255",

--- a/apps/web/src/app/(dashboard)/_components/nav-user.tsx
+++ b/apps/web/src/app/(dashboard)/_components/nav-user.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { ChevronsUpDown, Loader2, LogOut } from "lucide-react";
 
-import pkg from "../../../../../../package.json";
+import { APP_VERSION } from "@/lib/env";
 import { useAuth } from "@/providers/auth-provider";
 import { Avatar, AvatarFallback } from "@onecli/ui/components/avatar";
 import {
@@ -66,7 +66,7 @@ export const NavUser = () => {
                     {displayName}
                   </p>
                   <span className="text-muted-foreground text-[10px]">
-                    v{pkg.version}
+                    v{APP_VERSION}
                   </span>
                 </div>
                 <p className="text-muted-foreground text-xs leading-none">

--- a/apps/web/src/app/(dashboard)/settings/instance/_components/build-version-card.tsx
+++ b/apps/web/src/app/(dashboard)/settings/instance/_components/build-version-card.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@onecli/ui/components/card";
+import { APP_VERSION } from "@/lib/env";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+
+export const BuildVersionCard = () => {
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Build version</CardTitle>
+        <CardDescription>
+          The OneCLI version this instance is running. Include it when reporting
+          issues so behavior can be matched to a release.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center rounded-md border px-3 py-2">
+            <code className="min-w-0 flex-1 truncate font-mono text-sm">
+              v{APP_VERSION}
+            </code>
+          </div>
+          <button
+            type="button"
+            onClick={() => copy(APP_VERSION)}
+            aria-label="Copy version"
+            title="Copy version"
+            className="text-muted-foreground hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 shrink-0 rounded-md border p-2 outline-none transition-colors focus-visible:ring-[3px] motion-reduce:transition-none"
+          >
+            {copied ? (
+              <Check className="text-brand size-4" />
+            ) : (
+              <Copy className="size-4" />
+            )}
+          </button>
+        </div>
+        <span role="status" aria-live="polite" className="sr-only">
+          {copied ? "Version copied to clipboard" : ""}
+        </span>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/app/(dashboard)/settings/instance/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/instance/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { PageHeader } from "@dashboard/page-header";
 import { APP_URL } from "@/lib/env";
 import { PublicUrlCard } from "./_components/public-url-card";
+import { BuildVersionCard } from "./_components/build-version-card";
 
 export const metadata: Metadata = {
   title: "Instance",
@@ -15,6 +16,7 @@ export default function InstancePage() {
         description="Instance configuration for your self-hosted deployment."
       />
       <PublicUrlCard appUrl={APP_URL} />
+      <BuildVersionCard />
     </div>
   );
 }

--- a/apps/web/src/lib/api/app.ts
+++ b/apps/web/src/lib/api/app.ts
@@ -1,5 +1,9 @@
 import { createApiApp } from "@onecli/api";
 import { nextSessionProvider } from "./session-provider";
 import { cloudOverrides } from "@/lib/init/api";
+import { APP_VERSION } from "@/lib/env";
 
-export const app = createApiApp(nextSessionProvider, cloudOverrides);
+export const app = createApiApp(nextSessionProvider, {
+  ...cloudOverrides,
+  version: APP_VERSION,
+});

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -34,6 +34,15 @@ export const GATEWAY_API_URL =
 export const GATEWAY_BASE_URL =
   process.env.GATEWAY_BASE_URL ?? "host.docker.internal:10255";
 
+// ── Version ─────────────────────────────────────────────────────────────
+
+/**
+ * Build-time app version (e.g. `"1.38.0+f6cca6e5"`), shown in the UI and reported
+ * by `/v1/health`. Injected as `NEXT_PUBLIC_APP_VERSION` in `next.config.js`;
+ * `"dev"` for local/unstamped builds.
+ */
+export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "dev";
+
 // ── Edition ─────────────────────────────────────────────────────────────
 
 /** Build-time edition: `"cloud"` or `""` (OSS). */

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,11 @@ RUN pnpm install --frozen-lockfile
 FROM base AS builder
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# App version stamped into the web build (next.config.js reads APP_VERSION; falls
+# back to the root package.json version when unset).
+ARG APP_VERSION=""
+ENV APP_VERSION=${APP_VERSION}
+
 COPY --from=deps /app/ .
 COPY --from=pruner /app/out/full/ .
 RUN pnpm --filter @onecli/db generate
@@ -73,6 +78,11 @@ ENV PORT=10254
 ENV HOSTNAME="0.0.0.0"
 ENV AUTH_TRUST_HOST=true
 ENV NEXTAUTH_URL=http://localhost:10254
+
+# Build version read by the bundled gateway at runtime (empty → gateway falls back
+# to its compile-time crate version).
+ARG APP_VERSION=""
+ENV APP_VERSION=${APP_VERSION}
 
 # Gateway binary from Rust build
 COPY --from=gateway-builder /build/target/release/onecli-gateway /usr/local/bin/onecli-gateway

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://v2-7-6.turborepo.dev/schema.json",
   "ui": "tui",
-  "globalEnv": ["NODE_ENV", "NEXT_PUBLIC_EDITION"],
+  "globalEnv": ["NODE_ENV", "NEXT_PUBLIC_EDITION", "APP_VERSION"],
   "globalPassThroughEnv": [
     "DATABASE_URL",
     "EDITION",


### PR DESCRIPTION
Closes #388.

### What

Surfaces the running OneCLI build version in the dashboard and the API:

- **Overview** page: a small version line in the footer.
- **Settings → Instance**: a "Build version" card.
- `GET /api/health`: reports the version instead of `"unknown"`.

### How

- `next.config.js` resolves the version at build time and exposes it as
  `NEXT_PUBLIC_APP_VERSION`: `ONECLI_VERSION` / `APP_VERSION` env override when
  set (e.g. a tagged image), otherwise the monorepo `package.json` version;
  falls back to `"dev"`.
- A small `lib/version.ts` helper (`APP_VERSION`) is read by the UI and passed
  into `createApiApp` for `/api/health`.
- `docker/Dockerfile` takes an optional `--build-arg APP_VERSION` so a built
  image can report its actual tag.
- The two build-affecting env vars are declared in `turbo.json`.

### Notes

No new dependencies. Server- and client-side both read the same injected value,
so the dashboard and `/api/health` always agree.