### PR TITLE
fix(web): show the signed-in user in the sidebar instead of "User"

### DIFF
--- a/apps/web/src/lib/auth/auth-provider.tsx
+++ b/apps/web/src/lib/auth/auth-provider.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useCallback, useMemo, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   SessionProvider,
-  useSession,
   signIn as nextAuthSignIn,
   signOut as nextAuthSignOut,
 } from "next-auth/react";
 import { AuthContext } from "@/providers/auth-provider";
+import { apiFetch } from "@/lib/api-fetch";
 import type { AuthUser, AuthContextValue } from "@/lib/auth/types";
 import type { AuthMode } from "@/lib/auth/auth-mode";
 
@@ -33,16 +39,35 @@ const LocalAuthProvider = ({ children }: { children: ReactNode }) => {
 };
 
 const OAuthInner = ({ children }: { children: ReactNode }) => {
-  const { data: session, status } = useSession();
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  const user = useMemo<AuthUser | null>(() => {
-    if (!session?.user?.id || !session.user.email) return null;
-    return {
-      id: session.user.id,
-      email: session.user.email,
-      name: session.user.name ?? undefined,
+  // Read the signed-in user from /v1/auth/session — the same endpoint the
+  // dashboard layout uses. It returns the OneCLI profile directly
+  // (flat { id, email, name }), not NextAuth's { user } wrapper, so the
+  // identity must be read off the response root.
+  useEffect(() => {
+    let active = true;
+    apiFetch("/v1/auth/session")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { id?: string; email?: string; name?: string } | null) => {
+        if (!active) return;
+        setUser(
+          data?.id && data.email
+            ? { id: data.id, email: data.email, name: data.name ?? undefined }
+            : null,
+        );
+      })
+      .catch(() => {
+        if (active) setUser(null);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
     };
-  }, [session]);
+  }, []);
 
   const signIn = useCallback(async () => {
     await nextAuthSignIn("google");
@@ -54,13 +79,13 @@ const OAuthInner = ({ children }: { children: ReactNode }) => {
 
   const value = useMemo<AuthContextValue>(
     () => ({
-      isAuthenticated: status === "authenticated",
-      isLoading: status === "loading",
+      isAuthenticated: user !== null,
+      isLoading: loading,
       user,
       signIn,
       signOut,
     }),
-    [status, user, signIn, signOut],
+    [user, loading, signIn, signOut],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
Closes #390.

### Problem

The dashboard sidebar always shows the signed-in user as "User" with no email.

### Cause

The client auth provider reads the session via NextAuth `useSession()`, which
expects `{ user: { id, email } }`. But `/v1/auth/session` is served by the
OneCLI API and returns the profile flat (`{ id, email, name, projectId,
organizationId }`), so `session.user` is `undefined` and the user is treated as
anonymous.

### Fix

Read the session the same way the dashboard layout already does — fetch
`/v1/auth/session` via `apiFetch` and take `id`/`email`/`name` off the response
root. No dependency on NextAuth's client session shape.

Reproducible on a vanilla install (log in → the sidebar shows "User"); the fix
is independent of the basePath work in #362 / #380.
