### PR TITLE
feat: live approval notifications, gateway summaries, and fixes

### DIFF
--- a/apps/gateway/src/approval.rs
+++ b/apps/gateway/src/approval.rs
@@ -61,6 +61,18 @@ pub(crate) enum ApprovalDecision {
     Deny,
 }
 
+/// A submitted decision plus the identity that made it.
+///
+/// `approved_by` carries the deciding user (from the gateway `AuthUser`), or
+/// `None` for a system auto-deny on timeout/cleanup. It is delivered to the
+/// held request so it can be stamped onto the request log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DecisionOutcome {
+    pub decision: ApprovalDecision,
+    #[serde(default)]
+    pub approved_by: Option<String>,
+}
+
 // ── DecisionReceiver ───────────────────────────────────────────────────
 
 /// Opaque receiver returned by [`ApprovalStore::prepare_wait`].
@@ -68,15 +80,15 @@ pub(crate) enum ApprovalDecision {
 /// Must be created **before** calling `store()` to avoid a race where the
 /// SDK submits a decision before the gateway starts listening.
 pub(crate) struct DecisionReceiver {
-    rx: watch::Receiver<Option<ApprovalDecision>>,
+    rx: watch::Receiver<Option<DecisionOutcome>>,
 }
 
 impl DecisionReceiver {
     /// Wait for a decision with timeout. Returns `None` on timeout (= auto-deny).
-    pub async fn wait(mut self, timeout: Duration) -> Option<ApprovalDecision> {
+    pub async fn wait(mut self, timeout: Duration) -> Option<DecisionOutcome> {
         // Check if decision was already made (e.g., very fast SDK response).
-        if let Some(decision) = *self.rx.borrow() {
-            return Some(decision);
+        if let Some(outcome) = self.rx.borrow().clone() {
+            return Some(outcome);
         }
 
         // Wait for the value to change, with timeout.
@@ -86,8 +98,8 @@ impl DecisionReceiver {
                 if self.rx.changed().await.is_err() {
                     return None;
                 }
-                if let Some(decision) = *self.rx.borrow() {
-                    return Some(decision);
+                if let Some(outcome) = self.rx.borrow().clone() {
+                    return Some(outcome);
                 }
             }
         })
@@ -212,6 +224,7 @@ pub(crate) trait ApprovalStore: Send + Sync {
     async fn wait_for_new(&self, org_id: &str, project_id: &str, timeout: Duration) -> bool;
 
     /// Submit a decision for a pending approval. Wakes the held request.
+    /// `approved_by` is the deciding user, or `None` for a system auto-deny.
     /// Returns `true` if the approval was found and decision delivered.
     async fn submit_decision(
         &self,
@@ -219,6 +232,7 @@ pub(crate) trait ApprovalStore: Send + Sync {
         project_id: &str,
         id: &str,
         decision: ApprovalDecision,
+        approved_by: Option<String>,
     ) -> bool;
 }
 
@@ -231,8 +245,8 @@ struct InMemoryApprovalStore {
     /// Long-polling wake-up: project_id → broadcast::Sender<()>.
     new_notify: DashMap<String, broadcast::Sender<()>>,
 
-    /// Decision delivery: approval_id → watch::Sender<Option<ApprovalDecision>>.
-    decisions: DashMap<String, watch::Sender<Option<ApprovalDecision>>>,
+    /// Decision delivery: approval_id → watch::Sender<Option<DecisionOutcome>>.
+    decisions: DashMap<String, watch::Sender<Option<DecisionOutcome>>>,
 }
 
 impl InMemoryApprovalStore {
@@ -316,9 +330,13 @@ impl ApprovalStore for InMemoryApprovalStore {
         _project_id: &str,
         id: &str,
         decision: ApprovalDecision,
+        approved_by: Option<String>,
     ) -> bool {
         if let Some((_, tx)) = self.decisions.remove(id) {
-            let _ = tx.send(Some(decision));
+            let _ = tx.send(Some(DecisionOutcome {
+                decision,
+                approved_by,
+            }));
             self.pending.remove(id);
             true
         } else {
@@ -353,7 +371,10 @@ fn start_cleanup_task(store: Arc<InMemoryApprovalStore>) {
 
             for id in &expired {
                 if let Some((_, tx)) = store.decisions.remove(id) {
-                    let _ = tx.send(Some(ApprovalDecision::Deny));
+                    let _ = tx.send(Some(DecisionOutcome {
+                        decision: ApprovalDecision::Deny,
+                        approved_by: None,
+                    }));
                 }
                 store.pending.remove(id);
             }
@@ -499,12 +520,42 @@ mod tests {
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             store2
-                .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Approve)
+                .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Approve, None)
                 .await;
         });
 
         let decision = rx.wait(Duration::from_secs(5)).await;
-        assert_eq!(decision, Some(ApprovalDecision::Approve));
+        assert_eq!(
+            decision.map(|o| o.decision),
+            Some(ApprovalDecision::Approve)
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_decision_delivers_approver() {
+        let store = new_store().await;
+        let approval = make_approval("a1", "acc-1");
+
+        let rx = store.prepare_wait(TEST_ORG, "acc-1", "a1").await;
+        store.store(&approval).await.unwrap();
+        store
+            .submit_decision(
+                TEST_ORG,
+                "acc-1",
+                "a1",
+                ApprovalDecision::Approve,
+                Some("user-7".to_string()),
+            )
+            .await;
+
+        let outcome = rx.wait(Duration::from_secs(5)).await;
+        assert_eq!(
+            outcome,
+            Some(DecisionOutcome {
+                decision: ApprovalDecision::Approve,
+                approved_by: Some("user-7".to_string()),
+            })
+        );
     }
 
     #[tokio::test]
@@ -519,12 +570,12 @@ mod tests {
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;
             store2
-                .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Deny)
+                .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Deny, None)
                 .await;
         });
 
         let decision = rx.wait(Duration::from_secs(5)).await;
-        assert_eq!(decision, Some(ApprovalDecision::Deny));
+        assert_eq!(decision.map(|o| o.decision), Some(ApprovalDecision::Deny));
     }
 
     #[tokio::test]
@@ -583,7 +634,7 @@ mod tests {
         store.store(&approval).await.unwrap();
 
         store
-            .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Approve)
+            .submit_decision(TEST_ORG, "acc-1", "a1", ApprovalDecision::Approve, None)
             .await;
 
         assert!(store.get_pending(TEST_ORG, "acc-1", "a1").await.is_none());
@@ -593,7 +644,13 @@ mod tests {
     async fn submit_decision_nonexistent_returns_false() {
         let store = new_store().await;
         let result = store
-            .submit_decision(TEST_ORG, "acc-1", "nonexistent", ApprovalDecision::Approve)
+            .submit_decision(
+                TEST_ORG,
+                "acc-1",
+                "nonexistent",
+                ApprovalDecision::Approve,
+                None,
+            )
             .await;
         assert!(!result);
     }

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -1221,19 +1221,34 @@ fn credential_host_mismatch(
     stored.is_empty() || apps::normalize_host(hostname) != stored
 }
 
-/// Check if a requested hostname matches a secret's host pattern.
-/// Supports exact match and wildcard prefix (`*.example.com` matches `api.example.com`).
+/// Check if a requested hostname matches a secret or policy host pattern.
+///
+/// Supports an exact match, or a single `*` wildcard anywhere in the pattern:
+/// - leading — `*.example.com` matches `api.example.com` (but not the apex
+///   `example.com`),
+/// - mid-string — `s3.*.amazonaws.com` matches `s3.us-east-1.amazonaws.com`
+///   (the region label).
+///
+/// The length guard keeps the prefix and suffix from overlapping, so the `*`
+/// must stand in for at least one character: the apex is still excluded for
+/// `*.example.com`, and a region is still required for `s3.*.amazonaws.com`.
+///
+/// Matching is case-insensitive, since DNS host names are.
 fn host_matches(request_host: &str, pattern: &str) -> bool {
-    if request_host == pattern {
-        return true;
+    match pattern.split_once('*') {
+        None => request_host.eq_ignore_ascii_case(pattern),
+        Some((prefix, suffix)) => {
+            // `get(..)` keeps the slices on char boundaries, so a non-ASCII
+            // host can never panic — it just won't match an ASCII pattern.
+            request_host.len() >= prefix.len() + suffix.len()
+                && request_host
+                    .get(..prefix.len())
+                    .is_some_and(|p| p.eq_ignore_ascii_case(prefix))
+                && request_host
+                    .get(request_host.len() - suffix.len()..)
+                    .is_some_and(|s| s.eq_ignore_ascii_case(suffix))
+        }
     }
-
-    if let Some(suffix) = pattern.strip_prefix('*') {
-        // "*.example.com" → suffix = ".example.com"
-        return request_host.ends_with(suffix) && request_host.len() > suffix.len();
-    }
-
-    false
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -1388,6 +1403,41 @@ mod tests {
     #[test]
     fn host_wildcard_no_match_without_dot() {
         assert!(!host_matches("notexample.com", "*.example.com"));
+    }
+
+    #[test]
+    fn host_midstring_wildcard() {
+        // Mid-string wildcard: the region label in AWS regional endpoints.
+        assert!(host_matches(
+            "s3.us-east-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+        ));
+        assert!(host_matches(
+            "lambda.eu-west-1.amazonaws.com",
+            "lambda.*.amazonaws.com"
+        ));
+        // Wrong service prefix, or the apex with no region label, must not match.
+        assert!(!host_matches(
+            "ec2.us-east-1.amazonaws.com",
+            "s3.*.amazonaws.com"
+        ));
+        assert!(!host_matches("s3.amazonaws.com", "s3.*.amazonaws.com"));
+        // Exact patterns (no wildcard) still match only themselves.
+        assert!(host_matches("iam.amazonaws.com", "iam.amazonaws.com"));
+        assert!(!host_matches("s3.amazonaws.com", "iam.amazonaws.com"));
+    }
+
+    #[test]
+    fn host_matching_is_case_insensitive() {
+        // DNS host names are case-insensitive; a mixed-case CONNECT authority
+        // must still match a lowercase rule (exact, leading-*, and mid-string).
+        assert!(host_matches("API.GitHub.com", "api.github.com"));
+        assert!(host_matches("Api.Example.com", "*.example.com"));
+        assert!(host_matches(
+            "S3.US-EAST-1.AMAZONAWS.COM",
+            "s3.*.amazonaws.com"
+        ));
+        assert!(!host_matches("api.evil.com", "api.github.com"));
     }
 
     // ── credential_host_mismatch ─────────────────────────────────────────

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -485,7 +485,13 @@ async fn submit_approval_decision(
 
         let delivered = state
             .approval_store
-            .submit_decision(&org_id, &auth.project_id, &approval_id, body.decision)
+            .submit_decision(
+                &org_id,
+                &auth.project_id,
+                &approval_id,
+                body.decision,
+                Some(auth.user_id),
+            )
             .await;
 
         if delivered {

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -331,6 +331,9 @@ pub(crate) async fn forward_request(
     // Approval log_id + metadata are stored as locals so they can be
     // threaded to the telemetry section for the approved UPDATE.
 
+    // The deciding user (for the approved-path telemetry below) is captured
+    // here because the approve arm returns the body tuple, not the identity.
+    let mut approval_approved_by: Option<String> = None;
     let (forward_body, approval_log_id, approval_id_for_telemetry, approval_triggered_at) =
         if let PolicyDecision::ManualApproval { rule_id } = &decision {
             info!(method = %method, url = %url, rule_id = %rule_id, "MANUAL APPROVAL required");
@@ -493,19 +496,23 @@ pub(crate) async fn forward_request(
                 "holding request for approval"
             );
 
-            let approval_decision = decision_rx
+            let outcome = decision_rx
                 .wait(Duration::from_secs(APPROVAL_TIMEOUT_SECS))
                 .await;
 
             // Decision received (or timed out) — defuse guard, handle explicitly.
             guard.defuse();
 
-            match approval_decision {
+            let decision = outcome.as_ref().map(|o| o.decision);
+            let approved_by = outcome.and_then(|o| o.approved_by);
+
+            match decision {
                 Some(ApprovalDecision::Approve) => {
                     info!(url = %url, approval_id = %approval_id, "APPROVED — forwarding request");
                     approval_store
                         .remove(org_id, project_id, &approval_id)
                         .await;
+                    approval_approved_by = approved_by;
                     (
                         fwd_body,
                         Some(log_id),
@@ -537,6 +544,7 @@ pub(crate) async fn forward_request(
                             reason: reason.to_string(),
                             triggered_at,
                             resolved_at,
+                            approved_by,
                         },
                         None,
                         Some(log_id),
@@ -811,6 +819,7 @@ pub(crate) async fn forward_request(
                     approval_id: aid_val,
                     triggered_at: triggered,
                     resolved_at,
+                    approved_by: approval_approved_by,
                 })
             }
             _ => None,

--- a/apps/gateway/src/inject.rs
+++ b/apps/gateway/src/inject.rs
@@ -525,6 +525,109 @@ mod tests {
         ));
     }
 
+    /// Regression guard for app-permission catalog patterns: each pattern must
+    /// match the REAL request path its operation produces. A `*` matches exactly
+    /// one path segment, so a pattern with too few segments silently never
+    /// matches and the permission becomes a no-op. These cases encode endpoints
+    /// verified against official provider docs; see
+    /// `packages/api/src/apps/app-permissions/*`.
+    #[test]
+    fn app_permission_patterns_match_real_endpoints() {
+        // GitHub REST nests under /repos/{owner}/{repo}/... (two path params).
+        assert!(path_matches(
+            "/repos/octocat/hello/pulls",
+            "/repos/*/*/pulls"
+        ));
+        assert!(path_matches(
+            "/repos/octocat/hello/issues",
+            "/repos/*/*/issues"
+        ));
+        assert!(path_matches(
+            "/repos/octocat/hello/issues/42/comments",
+            "/repos/*/*/issues/*/comments"
+        ));
+        // Branch ref contains a slash (heads/<branch>); trailing * absorbs it.
+        assert!(path_matches(
+            "/repos/octocat/hello/git/refs/heads/main",
+            "/repos/*/*/git/refs/*"
+        ));
+        // The old one-param shapes must NOT match real two-param paths.
+        assert!(!path_matches(
+            "/repos/octocat/hello/pulls",
+            "/repos/*/pulls"
+        ));
+        assert!(!path_matches(
+            "/repos/octocat/hello/issues",
+            "/repos/*/issues"
+        ));
+        // GitHub git-over-HTTPS: POST to {owner}/{repo}.git/git-upload-pack.
+        assert!(path_matches(
+            "/octocat/hello.git/git-upload-pack",
+            "/*/*/git-upload-pack"
+        ));
+
+        // Confluence Cloud via OAuth 3LO is served under /ex/confluence/{cloudid}.
+        assert!(path_matches(
+            "/ex/confluence/abc123/wiki/api/v2/pages/77",
+            "/ex/confluence/*/wiki/api/v2/pages/*"
+        ));
+        assert!(path_matches(
+            "/ex/confluence/abc123/wiki/rest/api/search",
+            "/ex/confluence/*/wiki/rest/api/search"
+        ));
+        // Bare /wiki/... (missing the cloudid prefix) was the systemic bug.
+        assert!(!path_matches(
+            "/ex/confluence/abc123/wiki/api/v2/pages/77",
+            "/wiki/api/v2/pages/*"
+        ));
+
+        // Jira Cloud JQL search migrated from /search to /search/jql.
+        assert!(path_matches(
+            "/ex/jira/abc123/rest/api/3/search/jql",
+            "/ex/jira/*/rest/api/3/search/jql"
+        ));
+
+        // Sentry project issues nest under {org}/{project} (two slugs).
+        assert!(path_matches(
+            "/api/0/projects/acme/web/issues/",
+            "/api/0/projects/*/*/issues/"
+        ));
+        assert!(!path_matches(
+            "/api/0/projects/acme/web/issues/",
+            "/api/0/projects/*/issues/"
+        ));
+
+        // Docker Hub destructive ops live on /v2/repositories/{ns}/{repo}/.
+        assert!(path_matches(
+            "/v2/repositories/acme/app/",
+            "/v2/repositories/*/*"
+        ));
+        assert!(path_matches(
+            "/v2/repositories/acme/app/tags/latest/",
+            "/v2/repositories/*/*/tags/*"
+        ));
+
+        // Google Drive / YouTube media writes go to the /upload/... host path.
+        assert!(path_matches(
+            "/upload/drive/v3/files/file123",
+            "/upload/drive/v3/files/*"
+        ));
+        assert!(path_matches(
+            "/upload/youtube/v3/videos",
+            "/upload/youtube/v3/videos"
+        ));
+
+        // Todoist migrated to /api/v1/...; Outlook respond aliases.
+        assert!(path_matches(
+            "/api/v1/tasks/abc/close",
+            "/api/v1/tasks/*/close"
+        ));
+        assert!(path_matches(
+            "/v1.0/me/events/evt1/tentativelyAccept",
+            "/v1.0/me/events/*/tentativelyAccept"
+        ));
+    }
+
     #[test]
     fn path_matches_ignores_query_string() {
         assert!(path_matches("/v1/messages?api_key=sk-123", "/v1/messages"));

--- a/apps/gateway/src/summary/gmail.rs
+++ b/apps/gateway/src/summary/gmail.rs
@@ -86,6 +86,21 @@ impl RequestSummarizer for Gmail {
                 return Some(s);
             }
         }
+        if m == "GET" {
+            if base.ends_with("/profile") {
+                return Some(ApprovalSummary::new("Read profile"));
+            }
+            if base.ends_with("/messages") {
+                return Some(ApprovalSummary::new("List messages"));
+            }
+            if base.contains("/messages/") {
+                let mut s = ApprovalSummary::new("Read email");
+                if let Some(id) = last_segment(base) {
+                    s.push("Message", id);
+                }
+                return Some(s);
+            }
+        }
         None
     }
 }
@@ -256,6 +271,31 @@ iVBORw0KGgoAAAANSUhEUg==\r\n\
             "newlines should be preserved, got: {body_detail:?}"
         );
         assert!(s.render_text().contains("Body:\nHey Jonathan,"));
+    }
+
+    #[test]
+    fn get_messages_lists() {
+        let s = super::super::summarize_request(
+            "gmail",
+            "GET",
+            "/gmail/v1/users/me/messages",
+            None,
+            None,
+        );
+        assert_eq!(s.action, "List messages");
+    }
+
+    #[test]
+    fn get_message_by_id_reads() {
+        let s = super::super::summarize_request(
+            "gmail",
+            "GET",
+            "/gmail/v1/users/me/messages/18abc",
+            None,
+            None,
+        );
+        assert_eq!(s.action, "Read email");
+        assert_eq!(detail(&s, "Message"), Some("18abc"));
     }
 
     #[test]

--- a/apps/gateway/src/summary/google_calendar.rs
+++ b/apps/gateway/src/summary/google_calendar.rs
@@ -1,12 +1,16 @@
 //! Google Calendar — manual-approval summaries.
 //!
-//! Event create/update carry a JSON body (`summary`, `location`, `start`/`end`,
-//! `attendees`); delete carries the event id in the path. Registered as the
+//! Covers the major Calendar API v3 resources (events, calendars, calendarList,
+//! acl, freeBusy, settings, colors, channels) with a friendly action title and
+//! a few useful details lifted from the path / JSON body. Registered as the
 //! `"google-calendar"` summarizer in [`super::summarizer`].
 
 use serde_json::Value;
 
-use super::{last_segment, parse_json, ApprovalSummary, RequestSummarizer, SummaryRequest};
+use super::{
+    last_segment, parse_json, path_segment_before, ApprovalSummary, RequestSummarizer,
+    SummaryRequest,
+};
 
 pub(super) struct GoogleCalendar;
 
@@ -14,49 +18,243 @@ impl RequestSummarizer for GoogleCalendar {
     fn summarize(&self, req: &SummaryRequest<'_>) -> Option<ApprovalSummary> {
         let m = req.method_upper();
         let base = req.base_path();
-        if !base.contains("/calendar/v3/") || !base.contains("/events") {
-            return None;
-        }
-        let action = match m.as_str() {
-            "POST" => "Create calendar event",
-            "PUT" | "PATCH" => "Update calendar event",
-            "DELETE" => "Delete calendar event",
-            _ => return None,
-        };
-        let mut s = ApprovalSummary::new(action);
+        // Everything lives under `/calendar/v3/`; `rest` is the path after it.
+        let rest = base.split("/calendar/v3/").nth(1)?;
 
-        if m == "DELETE" {
-            if let Some(id) = last_segment(base) {
-                s.push("Event", id);
-            }
-            return Some(s);
+        // Route by resource (specific → general), then by method in the helper.
+        if rest.starts_with("freeBusy") {
+            return Some(ApprovalSummary::new("Query free/busy"));
         }
+        if rest.starts_with("colors") {
+            return Some(ApprovalSummary::new("Read calendar colors"));
+        }
+        if rest.starts_with("channels/stop") {
+            return Some(ApprovalSummary::new("Stop calendar notifications"));
+        }
+        if rest.starts_with("users/me/calendarList") {
+            return calendar_list(&m, base);
+        }
+        if rest.starts_with("users/me/settings") {
+            return settings(&m, base);
+        }
+        if rest.contains("/events") {
+            return events(&m, base, req);
+        }
+        if rest.contains("/acl") {
+            return acl(&m, base, req);
+        }
+        if base.ends_with("/clear") {
+            return Some(id_summary(
+                "Clear calendar",
+                "Calendar",
+                path_segment_before(base, "/clear"),
+            ));
+        }
+        if rest.starts_with("calendars") {
+            return calendars(&m, base, req);
+        }
+        None
+    }
+}
 
-        if let Some(v) = req.body.and_then(parse_json) {
-            if let Some(title) = v.get("summary").and_then(|x| x.as_str()) {
-                s.push("Title", title);
+// ── Resources ────────────────────────────────────────────────────────────────
+
+fn events(m: &str, base: &str, req: &SummaryRequest<'_>) -> Option<ApprovalSummary> {
+    // Action sub-paths win over the bare collection / item.
+    if base.ends_with("/events/watch") {
+        return Some(ApprovalSummary::new("Watch calendar events"));
+    }
+    if base.ends_with("/quickAdd") {
+        return Some(ApprovalSummary::new("Quick-add calendar event"));
+    }
+    if base.ends_with("/import") {
+        return Some(event_with_body("Import calendar event", req));
+    }
+    if base.ends_with("/move") {
+        return Some(id_summary(
+            "Move calendar event",
+            "Event",
+            path_segment_before(base, "/move"),
+        ));
+    }
+    if base.ends_with("/instances") {
+        return Some(id_summary(
+            "List event instances",
+            "Event",
+            path_segment_before(base, "/instances"),
+        ));
+    }
+
+    let is_collection = base.ends_with("/events");
+    match m {
+        "POST" => Some(event_with_body("Create calendar event", req)),
+        "GET" if is_collection => Some(ApprovalSummary::new("List calendar events")),
+        "GET" => Some(id_summary(
+            "Read calendar event",
+            "Event",
+            last_segment(base),
+        )),
+        "PUT" | "PATCH" => {
+            let mut s = id_summary("Update calendar event", "Event", last_segment(base));
+            if let Some(v) = req.body.and_then(parse_json) {
+                extract_event_fields(&mut s, &v);
             }
-            if let Some(loc) = v.get("location").and_then(|x| x.as_str()) {
-                s.push("Location", loc);
-            }
-            if let Some(start) = event_time(&v, "start") {
-                s.push("Start", start);
-            }
-            if let Some(end) = event_time(&v, "end") {
-                s.push("End", end);
-            }
-            if let Some(attendees) = v.get("attendees").and_then(|x| x.as_array()) {
-                let emails: Vec<String> = attendees
-                    .iter()
-                    .filter_map(|a| a.get("email").and_then(|e| e.as_str()).map(String::from))
-                    .take(10)
-                    .collect();
-                if !emails.is_empty() {
-                    s.push("Attendees", emails.join(", "));
-                }
-            }
+            Some(s)
         }
-        Some(s)
+        "DELETE" => Some(id_summary(
+            "Delete calendar event",
+            "Event",
+            last_segment(base),
+        )),
+        _ => None,
+    }
+}
+
+fn acl(m: &str, base: &str, req: &SummaryRequest<'_>) -> Option<ApprovalSummary> {
+    if base.ends_with("/acl/watch") {
+        return Some(ApprovalSummary::new("Watch calendar sharing"));
+    }
+    let is_collection = base.ends_with("/acl");
+    match m {
+        "GET" if is_collection => Some(ApprovalSummary::new("List calendar sharing rules")),
+        "GET" => Some(id_summary("Read sharing rule", "Rule", last_segment(base))),
+        "POST" => {
+            let mut s = ApprovalSummary::new("Share calendar");
+            extract_acl_fields(&mut s, req);
+            Some(s)
+        }
+        "PUT" | "PATCH" => {
+            let mut s = id_summary("Update sharing rule", "Rule", last_segment(base));
+            extract_acl_fields(&mut s, req);
+            Some(s)
+        }
+        "DELETE" => Some(id_summary(
+            "Remove sharing rule",
+            "Rule",
+            last_segment(base),
+        )),
+        _ => None,
+    }
+}
+
+fn calendar_list(m: &str, base: &str) -> Option<ApprovalSummary> {
+    if base.ends_with("/calendarList/watch") {
+        return Some(ApprovalSummary::new("Watch calendar list"));
+    }
+    let is_collection = base.ends_with("/calendarList");
+    Some(match m {
+        "GET" if is_collection => ApprovalSummary::new("List calendars"),
+        "GET" => id_summary("Read calendar list entry", "Calendar", last_segment(base)),
+        "POST" => ApprovalSummary::new("Add calendar to list"),
+        "PUT" | "PATCH" => id_summary("Update calendar list entry", "Calendar", last_segment(base)),
+        "DELETE" => id_summary("Remove calendar from list", "Calendar", last_segment(base)),
+        _ => return None,
+    })
+}
+
+fn settings(m: &str, base: &str) -> Option<ApprovalSummary> {
+    if base.ends_with("/settings/watch") {
+        return Some(ApprovalSummary::new("Watch calendar settings"));
+    }
+    if m != "GET" {
+        return None;
+    }
+    Some(if base.ends_with("/settings") {
+        ApprovalSummary::new("List calendar settings")
+    } else {
+        id_summary("Read calendar setting", "Setting", last_segment(base))
+    })
+}
+
+fn calendars(m: &str, base: &str, req: &SummaryRequest<'_>) -> Option<ApprovalSummary> {
+    match m {
+        "POST" => {
+            let mut s = ApprovalSummary::new("Create calendar");
+            push_body_str(&mut s, req, "summary", "Title");
+            Some(s)
+        }
+        "GET" => Some(id_summary("Read calendar", "Calendar", last_segment(base))),
+        "PUT" | "PATCH" => {
+            let mut s = id_summary("Update calendar", "Calendar", last_segment(base));
+            push_body_str(&mut s, req, "summary", "Title");
+            Some(s)
+        }
+        "DELETE" => Some(id_summary(
+            "Delete calendar",
+            "Calendar",
+            last_segment(base),
+        )),
+        _ => None,
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// A summary with one optional id detail (`label: id`).
+fn id_summary(action: &str, label: &str, id: Option<&str>) -> ApprovalSummary {
+    let mut s = ApprovalSummary::new(action);
+    if let Some(id) = id {
+        s.push(label, id);
+    }
+    s
+}
+
+/// A summary whose details come from an event JSON body (create/import).
+fn event_with_body(action: &str, req: &SummaryRequest<'_>) -> ApprovalSummary {
+    let mut s = ApprovalSummary::new(action);
+    if let Some(v) = req.body.and_then(parse_json) {
+        extract_event_fields(&mut s, &v);
+    }
+    s
+}
+
+/// Lift the human-relevant event fields onto the card.
+fn extract_event_fields(s: &mut ApprovalSummary, v: &Value) {
+    push_json_str(s, v, "summary", "Title");
+    push_json_str(s, v, "location", "Location");
+    if let Some(start) = event_time(v, "start") {
+        s.push("Start", start);
+    }
+    if let Some(end) = event_time(v, "end") {
+        s.push("End", end);
+    }
+    if let Some(attendees) = v.get("attendees").and_then(|x| x.as_array()) {
+        let emails: Vec<String> = attendees
+            .iter()
+            .filter_map(|a| a.get("email").and_then(|e| e.as_str()).map(String::from))
+            .take(10)
+            .collect();
+        if !emails.is_empty() {
+            s.push("Attendees", emails.join(", "));
+        }
+    }
+}
+
+/// Lift an ACL rule's `role` and `scope.value` (who it's shared with).
+fn extract_acl_fields(s: &mut ApprovalSummary, req: &SummaryRequest<'_>) {
+    if let Some(v) = req.body.and_then(parse_json) {
+        push_json_str(s, &v, "role", "Role");
+        if let Some(who) = v
+            .get("scope")
+            .and_then(|sc| sc.get("value"))
+            .and_then(|x| x.as_str())
+        {
+            s.push("Who", who);
+        }
+    }
+}
+
+/// Push `label: <v[key]>` when `key` is a present string.
+fn push_json_str(s: &mut ApprovalSummary, v: &Value, key: &str, label: &str) {
+    if let Some(val) = v.get(key).and_then(|x| x.as_str()) {
+        s.push(label, val);
+    }
+}
+
+/// Parse the body and push a single string field `label: <body[key]>`.
+fn push_body_str(s: &mut ApprovalSummary, req: &SummaryRequest<'_>, key: &str, label: &str) {
+    if let Some(v) = req.body.and_then(parse_json) {
+        push_json_str(s, &v, key, label);
     }
 }
 
@@ -91,10 +289,14 @@ mod tests {
             .map(|d| d.value.as_str())
     }
 
+    const EVENTS: &str = "/calendar/v3/calendars/primary/events";
+
+    // ── Events ──
+
     #[test]
     fn create_event_extracts_fields() {
         let body = br#"{"summary":"Team sync","location":"Room 4","start":{"dateTime":"2026-06-20T15:00:00Z"},"attendees":[{"email":"x@y.com"},{"email":"z@y.com"}]}"#;
-        let s = summarize("POST", "/calendar/v3/calendars/primary/events", Some(body));
+        let s = summarize("POST", EVENTS, Some(body));
         assert_eq!(s.action, "Create calendar event");
         assert_eq!(detail(&s, "Title"), Some("Team sync"));
         assert_eq!(detail(&s, "Location"), Some("Room 4"));
@@ -103,22 +305,107 @@ mod tests {
     }
 
     #[test]
+    fn all_day_event_uses_date() {
+        let body =
+            br#"{"summary":"Holiday","start":{"date":"2026-12-25"},"end":{"date":"2026-12-26"}}"#;
+        let s = summarize("POST", EVENTS, Some(body));
+        assert_eq!(detail(&s, "Start"), Some("2026-12-25"));
+        assert_eq!(detail(&s, "End"), Some("2026-12-26"));
+    }
+
+    #[test]
     fn delete_event_uses_path_id() {
-        let s = summarize(
-            "DELETE",
-            "/calendar/v3/calendars/primary/events/evt123",
-            None,
-        );
+        let s = summarize("DELETE", &format!("{EVENTS}/evt123"), None);
         assert_eq!(s.action, "Delete calendar event");
         assert_eq!(detail(&s, "Event"), Some("evt123"));
     }
 
     #[test]
-    fn all_day_event_uses_date() {
-        let body =
-            br#"{"summary":"Holiday","start":{"date":"2026-12-25"},"end":{"date":"2026-12-26"}}"#;
-        let s = summarize("POST", "/calendar/v3/calendars/primary/events", Some(body));
-        assert_eq!(detail(&s, "Start"), Some("2026-12-25"));
-        assert_eq!(detail(&s, "End"), Some("2026-12-26"));
+    fn list_events() {
+        let s = summarize("GET", EVENTS, None);
+        assert_eq!(s.action, "List calendar events");
+    }
+
+    #[test]
+    fn read_event_by_id() {
+        let s = summarize("GET", &format!("{EVENTS}/evt123"), None);
+        assert_eq!(s.action, "Read calendar event");
+        assert_eq!(detail(&s, "Event"), Some("evt123"));
+    }
+
+    #[test]
+    fn move_event_uses_path_id() {
+        let s = summarize("POST", &format!("{EVENTS}/evt123/move"), None);
+        assert_eq!(s.action, "Move calendar event");
+        assert_eq!(detail(&s, "Event"), Some("evt123"));
+    }
+
+    #[test]
+    fn quick_add_event() {
+        let s = summarize("POST", &format!("{EVENTS}/quickAdd"), None);
+        assert_eq!(s.action, "Quick-add calendar event");
+    }
+
+    #[test]
+    fn list_event_instances() {
+        let s = summarize("GET", &format!("{EVENTS}/evt123/instances"), None);
+        assert_eq!(s.action, "List event instances");
+        assert_eq!(detail(&s, "Event"), Some("evt123"));
+    }
+
+    // ── Calendars ──
+
+    #[test]
+    fn create_calendar_extracts_title() {
+        let body = br#"{"summary":"Project X"}"#;
+        let s = summarize("POST", "/calendar/v3/calendars", Some(body));
+        assert_eq!(s.action, "Create calendar");
+        assert_eq!(detail(&s, "Title"), Some("Project X"));
+    }
+
+    #[test]
+    fn clear_calendar_uses_path_id() {
+        let s = summarize("POST", "/calendar/v3/calendars/primary/clear", None);
+        assert_eq!(s.action, "Clear calendar");
+        assert_eq!(detail(&s, "Calendar"), Some("primary"));
+    }
+
+    // ── CalendarList ──
+
+    #[test]
+    fn list_calendars() {
+        let s = summarize("GET", "/calendar/v3/users/me/calendarList", None);
+        assert_eq!(s.action, "List calendars");
+    }
+
+    // ── Acl ──
+
+    #[test]
+    fn share_calendar_extracts_role_and_who() {
+        let body = br#"{"role":"reader","scope":{"type":"user","value":"a@b.com"}}"#;
+        let s = summarize("POST", "/calendar/v3/calendars/primary/acl", Some(body));
+        assert_eq!(s.action, "Share calendar");
+        assert_eq!(detail(&s, "Role"), Some("reader"));
+        assert_eq!(detail(&s, "Who"), Some("a@b.com"));
+    }
+
+    #[test]
+    fn list_acl_rules() {
+        let s = summarize("GET", "/calendar/v3/calendars/primary/acl", None);
+        assert_eq!(s.action, "List calendar sharing rules");
+    }
+
+    // ── FreeBusy / Colors ──
+
+    #[test]
+    fn freebusy_query() {
+        let s = summarize("POST", "/calendar/v3/freeBusy", Some(b"{}"));
+        assert_eq!(s.action, "Query free/busy");
+    }
+
+    #[test]
+    fn read_colors() {
+        let s = summarize("GET", "/calendar/v3/colors", None);
+        assert_eq!(s.action, "Read calendar colors");
     }
 }

--- a/apps/gateway/src/telemetry.rs
+++ b/apps/gateway/src/telemetry.rs
@@ -70,11 +70,13 @@ async fn update_batch(pool: &PgPool, events: &[RequestEvent]) {
                 approval_id,
                 triggered_at,
                 resolved_at,
+                approved_by,
             } => json!({
                 "decision": "approval_approved",
                 "approval_id": approval_id,
                 "triggered_at": triggered_at,
                 "resolved_at": resolved_at,
+                "approved_by": approved_by,
             })
             .to_string(),
             RequestDecision::ApprovalDenied {
@@ -82,12 +84,14 @@ async fn update_batch(pool: &PgPool, events: &[RequestEvent]) {
                 reason,
                 triggered_at,
                 resolved_at,
+                approved_by,
             } => json!({
                 "decision": "approval_denied",
                 "approval_id": approval_id,
                 "approval_reason": reason,
                 "triggered_at": triggered_at,
                 "resolved_at": resolved_at,
+                "approved_by": approved_by,
             })
             .to_string(),
             _ => "{}".to_string(),

--- a/apps/gateway/src/telemetry_core.rs
+++ b/apps/gateway/src/telemetry_core.rs
@@ -31,11 +31,15 @@ pub(crate) enum RequestDecision {
         reason: String,
         triggered_at: String,
         resolved_at: String,
+        /// The user who denied, or `None` for a system auto-deny (timeout).
+        approved_by: Option<String>,
     },
     ApprovalApproved {
         approval_id: String,
         triggered_at: String,
         resolved_at: String,
+        /// The user who approved the request.
+        approved_by: Option<String>,
     },
     BlockedByDefaultPolicy,
 }

--- a/apps/web/src/app/(dashboard)/_components/dashboard-header.tsx
+++ b/apps/web/src/app/(dashboard)/_components/dashboard-header.tsx
@@ -22,6 +22,7 @@ import {
 } from "@onecli/ui/components/breadcrumb";
 import { navItems } from "@/lib/nav-config";
 import { GetStartedButton } from "./get-started-button";
+import { ApprovalsBell } from "@/lib/components/approvals";
 
 const GitHubIcon = ({ className }: { className?: string }) => (
   <svg
@@ -168,6 +169,7 @@ export const DashboardHeader = () => {
           className="mx-1 hidden h-4 md:block"
         />
         <GetStartedButton />
+        <ApprovalsBell />
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/apps/web/src/app/(dashboard)/activity/_components/activity-content.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, Radio } from "lucide-react";
 import { Button } from "@onecli/ui/components/button";
 import { PageHeader } from "@dashboard/page-header";
@@ -8,6 +8,9 @@ import { getActivityPage } from "@/lib/actions/request-logs";
 import { ActivityTable } from "./activity-table";
 import { ActivityDetailDialog } from "./activity-detail-dialog";
 import type { RequestLogEntry } from "@onecli/api/services/request-log-service";
+import { usePendingApprovals } from "@/hooks/use-approvals";
+import { ApprovalDetailsDialog } from "@/lib/components/approvals";
+import type { PendingApproval } from "@/lib/api/approvals";
 
 type StatusFilter = "all" | "errors";
 
@@ -22,7 +25,15 @@ export const ActivityContent = () => {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [liveMode, setLiveMode] = useState(true);
   const [selected, setSelected] = useState<RequestLogEntry | null>(null);
+  const [approvalDetails, setApprovalDetails] =
+    useState<PendingApproval | null>(null);
   const initializedRef = useRef(false);
+
+  const { data: pendingApprovals = [] } = usePendingApprovals();
+  const liveApprovals = useMemo(
+    () => new Map(pendingApprovals.map((a) => [a.id, a])),
+    [pendingApprovals],
+  );
 
   const loadInitial = useCallback(async (filter: StatusFilter) => {
     setLoading(true);
@@ -126,7 +137,12 @@ export const ActivityContent = () => {
         </div>
       ) : (
         <>
-          <ActivityTable logs={logs} onRowClick={setSelected} />
+          <ActivityTable
+            logs={logs}
+            liveApprovals={liveApprovals}
+            onRowClick={setSelected}
+            onShowApproval={setApprovalDetails}
+          />
 
           {nextCursor && (
             <div className="flex justify-center">
@@ -145,6 +161,10 @@ export const ActivityContent = () => {
       )}
 
       <ActivityDetailDialog log={selected} onClose={() => setSelected(null)} />
+      <ApprovalDetailsDialog
+        approval={approvalDetails}
+        onClose={() => setApprovalDetails(null)}
+      />
     </div>
   );
 };

--- a/apps/web/src/app/(dashboard)/activity/_components/activity-detail-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-detail-dialog.tsx
@@ -141,6 +141,11 @@ export const ActivityDetailDialog = ({
             <Row label="Agent">
               <span>{log.agentName ?? log.agentId}</span>
             </Row>
+            {log.approvedBy && (
+              <Row label="Decided by">
+                <span>{log.approvedBy}</span>
+              </Row>
+            )}
             <Row label="Time">
               <span className="text-xs tabular-nums">
                 {new Date(log.createdAt).toLocaleString()}

--- a/apps/web/src/app/(dashboard)/activity/_components/activity-table.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-table.tsx
@@ -5,7 +5,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@onecli/ui/components/tooltip";
-import { KeyRound } from "lucide-react";
+import { Info, KeyRound } from "lucide-react";
+import { Button } from "@onecli/ui/components/button";
 import {
   Table,
   TableBody,
@@ -26,8 +27,11 @@ import {
   isOwnKey,
   isRateLimitedRequest,
   getApprovalDecision,
+  getApprovalId,
   type RequestLogEntry,
 } from "@onecli/api/services/request-log-service";
+import { ApprovalActions } from "@/lib/components/approvals";
+import type { PendingApproval } from "@/lib/api/approvals";
 
 const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
@@ -49,10 +53,17 @@ const DateCell = ({ dateStr }: { dateStr: string }) => (
 
 interface ActivityTableProps {
   logs: RequestLogEntry[];
+  liveApprovals: Map<string, PendingApproval>;
   onRowClick: (log: RequestLogEntry) => void;
+  onShowApproval: (approval: PendingApproval) => void;
 }
 
-export const ActivityTable = ({ logs, onRowClick }: ActivityTableProps) => (
+export const ActivityTable = ({
+  logs,
+  liveApprovals,
+  onRowClick,
+  onShowApproval,
+}: ActivityTableProps) => (
   <div className="rounded-lg border overflow-hidden">
     <Table>
       <TableHeader>
@@ -80,6 +91,11 @@ export const ActivityTable = ({ logs, onRowClick }: ActivityTableProps) => (
         ) : (
           logs.map((log) => {
             const providerInfo = getProviderIcon(log.provider);
+            const approvalId = getApprovalId(log);
+            const liveApproval = approvalId
+              ? liveApprovals.get(approvalId)
+              : undefined;
+            const decision = getApprovalDecision(log);
             return (
               <TableRow
                 key={log.id}
@@ -149,7 +165,43 @@ export const ActivityTable = ({ logs, onRowClick }: ActivityTableProps) => (
                   />
                 </TableCell>
                 <TableCell>
-                  <DecisionBadge decision={getApprovalDecision(log)} />
+                  {liveApproval ? (
+                    // Stop row-click (which opens the dialog) when acting here.
+                    <div
+                      onClick={(e) => e.stopPropagation()}
+                      className="flex items-center gap-1"
+                    >
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => onShowApproval(liveApproval)}
+                            className="text-muted-foreground hover:text-foreground"
+                          >
+                            <Info className="size-3.5" />
+                            <span className="sr-only">Details</span>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Details</TooltipContent>
+                      </Tooltip>
+                      <ApprovalActions approvalId={liveApproval.id} iconOnly />
+                    </div>
+                  ) : log.approvedBy ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex cursor-default">
+                          <DecisionBadge decision={decision} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {decision === "denied" ? "Denied" : "Approved"} by{" "}
+                        {log.approvedBy}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <DecisionBadge decision={decision} />
+                  )}
                 </TableCell>
                 <TableCell className="text-right">
                   <span className="text-muted-foreground font-mono text-xs tabular-nums">

--- a/apps/web/src/hooks/use-approvals.ts
+++ b/apps/web/src/hooks/use-approvals.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+import { toast } from "sonner";
+import {
+  decide,
+  listPending,
+  type ApprovalDecisionInput,
+  type PendingApproval,
+} from "@/lib/api/approvals";
+import { queryKeys } from "@/lib/api/keys";
+import { PROJECT_PATH_RE } from "@/lib/navigation";
+
+/**
+ * Live list of pending approvals for the active project.
+ *
+ * The gateway long-polls `GET /v1/approvals/pending` (holds ~30s while idle),
+ * so this is effectively a long-poll driven by React Query: a small
+ * `refetchInterval` re-issues the request shortly after each one settles, and
+ * React Query dedupes concurrent fetches so the held request is never doubled.
+ * Net result — idle pages hold one ~30s connection; while approvals are pending
+ * the gateway returns immediately and we poll ~1s (snappy add/remove). Only runs
+ * on project pages and pauses in background tabs.
+ */
+export const usePendingApprovals = () => {
+  const pathname = usePathname();
+  const onProjectPage = PROJECT_PATH_RE.test(pathname);
+
+  return useQuery({
+    queryKey: queryKeys.approvals.list(),
+    queryFn: ({ signal }) =>
+      listPending({
+        signal: AbortSignal.any([signal, AbortSignal.timeout(35_000)]),
+      }),
+    enabled: onProjectPage,
+    // When the list is empty the gateway holds the request ~30s and returns the
+    // instant a new approval appears — a true long-poll, so poll fast (1s). But
+    // while approvals are already pending the endpoint returns immediately, so
+    // back off to 5s to avoid ~1 req/s busy-polling. Own actions stay instant
+    // via optimistic updates; external changes reflect within ≤5s.
+    refetchInterval: (query) => (query.state.data?.length ? 5_000 : 1_000),
+    refetchIntervalInBackground: false,
+    staleTime: 0,
+    // Seed with an empty list so the popover shows its empty state instantly
+    // instead of a skeleton during the gateway's ~30s idle long-poll hold.
+    initialData: [],
+  });
+};
+
+export const usePendingApprovalCount = (): number => {
+  const { data } = usePendingApprovals();
+  return data?.length ?? 0;
+};
+
+/**
+ * Approve or deny a held request. Optimistically removes the item from the
+ * pending list, rolls back on error, and refreshes activity + counts on settle.
+ * No gateway-cache invalidation — a decision releases a held request, it does
+ * not change gateway config (rules/secrets).
+ */
+export const useDecideApproval = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      decision,
+    }: {
+      id: string;
+      decision: ApprovalDecisionInput;
+    }) => decide(id, decision),
+    onMutate: async ({ id }) => {
+      await qc.cancelQueries({ queryKey: queryKeys.approvals.all() });
+      const previous = qc.getQueryData<PendingApproval[]>(
+        queryKeys.approvals.list(),
+      );
+      qc.setQueryData<PendingApproval[]>(queryKeys.approvals.list(), (old) =>
+        old?.filter((a) => a.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        qc.setQueryData(queryKeys.approvals.list(), ctx.previous);
+      }
+      toast.error("Failed to submit decision");
+    },
+    onSuccess: (_data, { decision }) => {
+      toast.success(
+        decision === "approve" ? "Request approved" : "Request rejected",
+      );
+    },
+    onSettled: () => {
+      // Only the pending list is a React Query resource; the Activity screen
+      // refreshes via its own polling, and sidebar counts are unaffected.
+      qc.invalidateQueries({ queryKey: queryKeys.approvals.all() });
+    },
+  });
+};

--- a/apps/web/src/lib/api/approvals.ts
+++ b/apps/web/src/lib/api/approvals.ts
@@ -1,0 +1,93 @@
+// Pending-approval value picker — list and resolve held requests through the
+// gateway. Like the 1Password client, these hit the gateway directly (different
+// base URL + auth) rather than the typed JSON API, so they use
+// getGatewayApiUrl() + getGatewayFetchOptions() (edition-aware: Cognito Bearer +
+// X-Project-Id in cloud, cookie credentials in OSS).
+import { getGatewayApiUrl } from "@/hooks/use-vault-status";
+import { getGatewayFetchOptions } from "@/lib/gateway-auth";
+
+export interface ApprovalDetail {
+  label: string;
+  value: string;
+}
+
+/** Structured, human-readable description of what a held request will do. */
+export interface ApprovalSummary {
+  action: string;
+  details: ApprovalDetail[];
+}
+
+export interface PendingApprovalAgent {
+  id: string;
+  name: string;
+  externalId?: string;
+}
+
+export interface PendingApproval {
+  id: string;
+  method: string;
+  url: string;
+  host: string;
+  path: string;
+  headers: Record<string, string>;
+  bodyPreview?: string;
+  summary?: ApprovalSummary;
+  agent: PendingApprovalAgent;
+  /** RFC 3339 timestamp. */
+  createdAt: string;
+  /** RFC 3339 timestamp — the request is auto-denied at this time. */
+  expiresAt: string;
+}
+
+export type ApprovalDecisionInput = "approve" | "deny";
+
+const base = () => `${getGatewayApiUrl()}/v1/approvals`;
+
+const gatewayGet = async <T>(
+  path: string,
+  opts?: { signal?: AbortSignal },
+): Promise<T> => {
+  const { headers, credentials } = await getGatewayFetchOptions();
+  const resp = await fetch(`${base()}${path}`, {
+    headers,
+    credentials,
+    signal: opts?.signal,
+  });
+  if (!resp.ok) {
+    const data = (await resp.json().catch(() => ({}))) as { error?: string };
+    throw new Error(data.error ?? `Request failed (${resp.status})`);
+  }
+  return resp.json() as Promise<T>;
+};
+
+/**
+ * List currently-held approvals for the active project. The gateway long-polls
+ * this endpoint (holds up to ~30s when nothing is pending), so callers should
+ * pass an abort signal with a timeout slightly above that hold.
+ */
+export const listPending = (opts?: {
+  signal?: AbortSignal;
+}): Promise<PendingApproval[]> =>
+  gatewayGet<{ requests: PendingApproval[] }>("/pending", opts).then(
+    (r) => r.requests ?? [],
+  );
+
+/**
+ * Submit an approve/deny decision. HTTP 410 (already resolved or expired) is
+ * treated as success — the outcome the caller wanted has already happened.
+ */
+export const decide = async (
+  id: string,
+  decision: ApprovalDecisionInput,
+): Promise<void> => {
+  const { headers, credentials } = await getGatewayFetchOptions();
+  const resp = await fetch(`${base()}/${encodeURIComponent(id)}/decision`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    credentials,
+    body: JSON.stringify({ decision }),
+  });
+  if (resp.ok || resp.status === 410) return;
+  const data = (await resp.json().catch(() => ({}))) as { error?: string };
+  throw new Error(data.error ?? `Request failed (${resp.status})`);
+};

--- a/apps/web/src/lib/api/keys.ts
+++ b/apps/web/src/lib/api/keys.ts
@@ -40,6 +40,10 @@ export const queryKeys = {
     list: (filter?: string) =>
       [...queryKeys.activity.all(), "list", filter] as const,
   },
+  approvals: {
+    all: () => ["approvals", ...scope()] as const,
+    list: () => [...queryKeys.approvals.all(), "list"] as const,
+  },
   appBlocklist: {
     all: () => ["appBlocklist", ...scope()] as const,
     byProvider: (provider: string) =>

--- a/apps/web/src/lib/components/approvals/approval-actions.tsx
+++ b/apps/web/src/lib/components/approvals/approval-actions.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Check, X } from "lucide-react";
+import { Button } from "@onecli/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@onecli/ui/components/tooltip";
+import { cn } from "@onecli/ui/lib/utils";
+import { useDecideApproval } from "@/hooks/use-approvals";
+
+interface ApprovalActionsProps {
+  approvalId: string;
+  size?: "xs" | "sm" | "default";
+  /** Render compact icon-only buttons (for the Activity table's narrow cell). */
+  iconOnly?: boolean;
+  onResolved?: () => void;
+  className?: string;
+}
+
+/** Shared Approve / Reject control, wired to the decision mutation. */
+export const ApprovalActions = ({
+  approvalId,
+  size = "sm",
+  iconOnly = false,
+  onResolved,
+  className,
+}: ApprovalActionsProps) => {
+  const decideMutation = useDecideApproval();
+  const pending = decideMutation.isPending;
+  const denyLoading = pending && decideMutation.variables?.decision === "deny";
+  const approveLoading =
+    pending && decideMutation.variables?.decision === "approve";
+
+  const submit = (decision: "approve" | "deny") =>
+    decideMutation.mutate(
+      { id: approvalId, decision },
+      { onSuccess: () => onResolved?.() },
+    );
+
+  if (iconOnly) {
+    return (
+      <div className={cn("flex items-center gap-1", className)}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              disabled={pending}
+              loading={denyLoading}
+              onClick={() => submit("deny")}
+              className="text-destructive hover:text-destructive"
+            >
+              {!denyLoading && <X className="size-3.5" />}
+              <span className="sr-only">Reject</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Reject</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              disabled={pending}
+              loading={approveLoading}
+              onClick={() => submit("approve")}
+              className="text-emerald-600 hover:text-emerald-600 dark:text-emerald-500"
+            >
+              {!approveLoading && <Check className="size-3.5" />}
+              <span className="sr-only">Approve</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Approve</TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Button
+        variant="outline"
+        size={size}
+        disabled={pending}
+        loading={denyLoading}
+        onClick={() => submit("deny")}
+        className="text-destructive hover:text-destructive"
+      >
+        {!denyLoading && <X className="size-3.5" />}
+        Reject
+      </Button>
+      <Button
+        size={size}
+        disabled={pending}
+        loading={approveLoading}
+        onClick={() => submit("approve")}
+      >
+        {!approveLoading && <Check className="size-3.5" />}
+        Approve
+      </Button>
+    </div>
+  );
+};

--- a/apps/web/src/lib/components/approvals/approval-details-content.tsx
+++ b/apps/web/src/lib/components/approvals/approval-details-content.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@onecli/ui/components/dialog";
+import type { PendingApproval } from "@/lib/api/approvals";
+import { ApprovalSummaryView } from "./approval-summary-view";
+import { ApprovalActions } from "./approval-actions";
+import { useCountdown, formatCountdown } from "./use-countdown";
+
+interface ApprovalDetailsContentProps {
+  approval: PendingApproval;
+  onResolved: () => void;
+}
+
+/** Body of the approval details dialog. Rendered only when an approval is set
+ *  so the countdown hook never runs against a missing approval. */
+export const ApprovalDetailsContent = ({
+  approval,
+  onResolved,
+}: ApprovalDetailsContentProps) => {
+  const remaining = useCountdown(approval.expiresAt);
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {approval.summary?.action ?? "Approve request"}
+        </DialogTitle>
+        <DialogDescription>
+          {approval.agent.name} · {approval.host} · expires in{" "}
+          {formatCountdown(remaining)}
+        </DialogDescription>
+      </DialogHeader>
+      <ApprovalSummaryView approval={approval} />
+      <DialogFooter>
+        <ApprovalActions approvalId={approval.id} onResolved={onResolved} />
+      </DialogFooter>
+    </>
+  );
+};

--- a/apps/web/src/lib/components/approvals/approval-details-dialog.tsx
+++ b/apps/web/src/lib/components/approvals/approval-details-dialog.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Dialog, DialogContent } from "@onecli/ui/components/dialog";
+import type { PendingApproval } from "@/lib/api/approvals";
+import { ApprovalDetailsContent } from "./approval-details-content";
+
+interface ApprovalDetailsDialogProps {
+  approval: PendingApproval | null;
+  onClose: () => void;
+}
+
+/** Dialog showing a held request's full summary with Approve/Reject in the
+ *  footer. Reused by the header popover and the Activity screen. */
+export const ApprovalDetailsDialog = ({
+  approval,
+  onClose,
+}: ApprovalDetailsDialogProps) => (
+  <Dialog
+    open={!!approval}
+    onOpenChange={(open) => {
+      if (!open) onClose();
+    }}
+  >
+    <DialogContent className="max-h-[85vh] overflow-y-auto">
+      {approval && (
+        <ApprovalDetailsContent approval={approval} onResolved={onClose} />
+      )}
+    </DialogContent>
+  </Dialog>
+);

--- a/apps/web/src/lib/components/approvals/approval-list-item.tsx
+++ b/apps/web/src/lib/components/approvals/approval-list-item.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Button } from "@onecli/ui/components/button";
+import { cn } from "@onecli/ui/lib/utils";
+import type { PendingApproval } from "@/lib/api/approvals";
+import { ApprovalActions } from "./approval-actions";
+import { useCountdown, formatCountdown } from "./use-countdown";
+
+interface ApprovalListItemProps {
+  approval: PendingApproval;
+  onShowDetails: () => void;
+}
+
+export const ApprovalListItem = ({
+  approval,
+  onShowDetails,
+}: ApprovalListItemProps) => {
+  const remaining = useCountdown(approval.expiresAt);
+  const urgent = remaining <= 30;
+  const firstDetail = approval.summary?.details?.[0];
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">
+            {approval.summary?.action ?? `${approval.method} request`}
+          </p>
+          <p className="text-muted-foreground truncate text-xs">
+            {approval.agent.name} · {approval.host}
+          </p>
+        </div>
+        <span
+          className={cn(
+            "shrink-0 font-mono text-xs tabular-nums",
+            urgent
+              ? "text-amber-600 dark:text-amber-500"
+              : "text-muted-foreground",
+          )}
+        >
+          {formatCountdown(remaining)}
+        </span>
+      </div>
+      {firstDetail && (
+        <p className="text-muted-foreground truncate text-xs">
+          <span className="font-medium">{firstDetail.label}:</span>{" "}
+          {firstDetail.value}
+        </p>
+      )}
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={onShowDetails}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          Details
+        </Button>
+        <ApprovalActions approvalId={approval.id} size="xs" />
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/lib/components/approvals/approval-summary-view.tsx
+++ b/apps/web/src/lib/components/approvals/approval-summary-view.tsx
@@ -1,0 +1,62 @@
+import type { PendingApproval } from "@/lib/api/approvals";
+
+const Field = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="border-b border-border/50 py-2.5 last:border-b-0">
+    <div className="text-muted-foreground text-xs">{label}</div>
+    <div className="mt-1 text-sm break-words whitespace-pre-wrap">
+      {children}
+    </div>
+  </div>
+);
+
+/**
+ * Renders the gateway's structured approval summary (`{action, details}`) as a
+ * stacked field list — label above the value, value left-aligned and full
+ * width — so long fields like an email body read naturally. Falls back to the
+ * flat `bodyPreview` when no structured summary is present. With `showMeta`
+ * (default) it also appends method/host/path. Reused by the popover details
+ * dialog and the Activity detail dialog.
+ */
+export const ApprovalSummaryView = ({
+  approval,
+  showMeta = true,
+}: {
+  approval: PendingApproval;
+  showMeta?: boolean;
+}) => {
+  const details = approval.summary?.details ?? [];
+
+  return (
+    <div>
+      {details.map((d, i) => (
+        <Field key={`${d.label}-${i}`} label={d.label}>
+          {d.value}
+        </Field>
+      ))}
+      {details.length === 0 && approval.bodyPreview && (
+        <pre className="bg-muted my-2 overflow-x-auto rounded-md p-3 text-xs whitespace-pre-wrap">
+          {approval.bodyPreview}
+        </pre>
+      )}
+      {showMeta && (
+        <>
+          <Field label="Method">
+            <span className="font-mono text-xs">{approval.method}</span>
+          </Field>
+          <Field label="Host">
+            <span className="font-medium">{approval.host}</span>
+          </Field>
+          <Field label="Path">
+            <span className="font-mono text-xs">{approval.path || "/"}</span>
+          </Field>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/lib/components/approvals/approvals-bell.tsx
+++ b/apps/web/src/lib/components/approvals/approvals-bell.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname } from "next/navigation";
+import { Bell } from "lucide-react";
+import { Button } from "@onecli/ui/components/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@onecli/ui/components/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@onecli/ui/components/tooltip";
+import { PROJECT_PATH_RE } from "@/lib/navigation";
+import { usePendingApprovals } from "@/hooks/use-approvals";
+import type { PendingApproval } from "@/lib/api/approvals";
+import { ApprovalsPopover } from "./approvals-popover";
+import { ApprovalDetailsDialog } from "./approval-details-dialog";
+
+/**
+ * Header notification bell showing pending approvals for the active project,
+ * with a live count and a popover to approve/reject/inspect each held request.
+ * Renders nothing outside a project page. Self-contained — drop it into any
+ * header with no props.
+ */
+export const ApprovalsBell = () => {
+  const pathname = usePathname();
+  const onProjectPage = PROJECT_PATH_RE.test(pathname);
+  const { data: approvals = [] } = usePendingApprovals();
+  const [open, setOpen] = useState(false);
+  const [details, setDetails] = useState<PendingApproval | null>(null);
+
+  if (!onProjectPage) return null;
+
+  const count = approvals.length;
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="icon-sm" className="relative">
+                <Bell className="size-4" />
+                {count > 0 && (
+                  <span className="absolute -top-0.5 -right-0.5 flex size-4 items-center justify-center">
+                    <span className="bg-destructive/60 absolute inline-flex size-full animate-ping rounded-full opacity-75" />
+                    <span className="bg-destructive relative inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-semibold text-white tabular-nums">
+                      {count > 9 ? "9+" : count}
+                    </span>
+                  </span>
+                )}
+                <span className="sr-only">Pending approvals</span>
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Pending approvals</TooltipContent>
+        </Tooltip>
+        <PopoverContent align="end" className="w-96 p-0">
+          <ApprovalsPopover
+            onShowDetails={(approval) => {
+              setOpen(false);
+              setDetails(approval);
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+      <ApprovalDetailsDialog
+        approval={details}
+        onClose={() => setDetails(null)}
+      />
+    </>
+  );
+};

--- a/apps/web/src/lib/components/approvals/approvals-popover.tsx
+++ b/apps/web/src/lib/components/approvals/approvals-popover.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Inbox } from "lucide-react";
+import { ScrollArea } from "@onecli/ui/components/scroll-area";
+import { usePendingApprovals } from "@/hooks/use-approvals";
+import type { PendingApproval } from "@/lib/api/approvals";
+import { ApprovalListItem } from "./approval-list-item";
+
+interface ApprovalsPopoverProps {
+  onShowDetails: (approval: PendingApproval) => void;
+}
+
+export const ApprovalsPopover = ({ onShowDetails }: ApprovalsPopoverProps) => {
+  const { data: approvals = [] } = usePendingApprovals();
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <span className="text-sm font-medium">Pending approvals</span>
+        <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
+          <span className="size-1.5 animate-pulse rounded-full bg-green-500" />
+          Live
+        </span>
+      </div>
+
+      {approvals.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-center">
+          <div className="bg-muted flex size-10 items-center justify-center rounded-full">
+            <Inbox className="text-muted-foreground size-5" />
+          </div>
+          <p className="text-sm font-medium">No pending approvals</p>
+          <p className="text-muted-foreground text-xs">
+            You&apos;re all caught up.
+          </p>
+        </div>
+      ) : (
+        <ScrollArea className="max-h-96">
+          <div className="divide-y">
+            {approvals.map((approval) => (
+              <ApprovalListItem
+                key={approval.id}
+                approval={approval}
+                onShowDetails={() => onShowDetails(approval)}
+              />
+            ))}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/lib/components/approvals/index.ts
+++ b/apps/web/src/lib/components/approvals/index.ts
@@ -1,0 +1,8 @@
+export { ApprovalsBell } from "./approvals-bell";
+export { ApprovalsPopover } from "./approvals-popover";
+export { ApprovalListItem } from "./approval-list-item";
+export { ApprovalDetailsDialog } from "./approval-details-dialog";
+export { ApprovalDetailsContent } from "./approval-details-content";
+export { ApprovalSummaryView } from "./approval-summary-view";
+export { ApprovalActions } from "./approval-actions";
+export { useCountdown, formatCountdown } from "./use-countdown";

--- a/apps/web/src/lib/components/approvals/use-countdown.ts
+++ b/apps/web/src/lib/components/approvals/use-countdown.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Whole seconds remaining until an RFC 3339 timestamp, clamped at 0. */
+const secondsUntil = (iso: string): number => {
+  const ms = new Date(iso).getTime();
+  return Number.isNaN(ms)
+    ? 0
+    : Math.max(0, Math.round((ms - Date.now()) / 1000));
+};
+
+/** Seconds remaining until `expiresAt` (RFC 3339), clamped at 0, ticking every second. */
+export const useCountdown = (expiresAt: string): number => {
+  const [remaining, setRemaining] = useState(() => secondsUntil(expiresAt));
+
+  useEffect(() => {
+    const tick = () => setRemaining(secondsUntil(expiresAt));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  return remaining;
+};
+
+/** Format a seconds count as `m:ss`. */
+export const formatCountdown = (seconds: number): string => {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "check-types": "tsc --noEmit",
     "lint": "eslint --max-warnings 0",
-    "lint:fix": "eslint --fix --max-warnings 0"
+    "lint:fix": "eslint --fix --max-warnings 0",
+    "test": "vitest run"
   },
   "dependencies": {
     "@1password/sdk": "^0.4.0",
@@ -40,6 +41,7 @@
     "nanoid": "^5.1.9",
     "pino": "^10.3.1",
     "stripe": "^20.4.0",
+    "tldts": "^7.4.4",
     "undici": "^8.0.0",
     "zod": "^4.3.6"
   },
@@ -48,6 +50,7 @@
     "@onecli/typescript-config": "workspace:*",
     "@types/node": "^22.15.3",
     "pino-pretty": "^13.1.3",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "vitest": "^3.2.6"
   }
 }

--- a/packages/api/src/apps/app-permissions/confluence.ts
+++ b/packages/api/src/apps/app-permissions/confluence.ts
@@ -11,7 +11,7 @@ export const confluencePermissions: AppPermissionDefinition = {
         description:
           "Search, read, and list pages, spaces, comments, and attachments",
         hostPattern: "api.atlassian.com",
-        pathPattern: "/wiki/api/v2/*",
+        pathPattern: "/ex/confluence/*/wiki/api/v2/*",
         method: "GET",
       },
       tools: [
@@ -20,7 +20,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "Get page",
           description: "Retrieve a specific Confluence page",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/pages/*",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/pages/*",
           method: "GET",
         },
         {
@@ -28,7 +28,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "Search content",
           description: "Search for content using CQL",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/search",
+          pathPattern: "/ex/confluence/*/wiki/rest/api/search",
           method: "GET",
         },
         {
@@ -36,7 +36,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "List spaces",
           description: "List all spaces in Confluence",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/spaces",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/spaces",
           method: "GET",
         },
         {
@@ -44,7 +44,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "Get space",
           description: "Retrieve a specific space's details",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/spaces/*",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/spaces/*",
           method: "GET",
         },
         {
@@ -52,7 +52,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "List pages",
           description: "List pages in a space",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/spaces/*/pages",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/spaces/*/pages",
           method: "GET",
         },
       ],
@@ -64,7 +64,7 @@ export const confluencePermissions: AppPermissionDefinition = {
         name: "All write operations",
         description: "Create, update, delete pages, and add comments",
         hostPattern: "api.atlassian.com",
-        pathPattern: "/wiki/api/v2/*",
+        pathPattern: "/ex/confluence/*/wiki/api/v2/*",
         methods: ["POST", "PUT", "PATCH", "DELETE"],
       },
       tools: [
@@ -73,7 +73,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "Create page",
           description: "Create a new Confluence page",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/pages",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/pages",
           method: "POST",
         },
         {
@@ -81,7 +81,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "Update page",
           description: "Update an existing Confluence page",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/pages/*",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/pages/*",
           method: "PUT",
         },
         {
@@ -89,7 +89,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "Delete page",
           description: "Delete a Confluence page",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/pages/*",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/pages/*",
           method: "DELETE",
         },
         {
@@ -97,7 +97,7 @@ export const confluencePermissions: AppPermissionDefinition = {
           name: "Add comment",
           description: "Add a comment to a Confluence page",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/wiki/api/v2/pages/*/footer-comments",
+          pathPattern: "/ex/confluence/*/wiki/api/v2/pages/*/footer-comments",
           method: "POST",
         },
       ],

--- a/packages/api/src/apps/app-permissions/docker.ts
+++ b/packages/api/src/apps/app-permissions/docker.ts
@@ -72,7 +72,7 @@ export const dockerPermissions: AppPermissionDefinition = {
           name: "Update repository",
           description: "Update repository settings",
           hostPattern: "hub.docker.com",
-          pathPattern: "/v2/namespaces/*/repositories/*",
+          pathPattern: "/v2/repositories/*/*",
           method: "PATCH",
         },
         {
@@ -80,7 +80,7 @@ export const dockerPermissions: AppPermissionDefinition = {
           name: "Delete repository",
           description: "Delete a repository",
           hostPattern: "hub.docker.com",
-          pathPattern: "/v2/namespaces/*/repositories/*",
+          pathPattern: "/v2/repositories/*/*",
           method: "DELETE",
         },
         {
@@ -88,7 +88,7 @@ export const dockerPermissions: AppPermissionDefinition = {
           name: "Delete tag",
           description: "Delete a tag from a repository",
           hostPattern: "hub.docker.com",
-          pathPattern: "/v2/namespaces/*/repositories/*/tags/*",
+          pathPattern: "/v2/repositories/*/*/tags/*",
           method: "DELETE",
         },
       ],

--- a/packages/api/src/apps/app-permissions/github.ts
+++ b/packages/api/src/apps/app-permissions/github.ts
@@ -33,7 +33,7 @@ const githubGroups: AppToolGroup[] = [
         name: "List pull requests",
         description: "List pull requests in a repository",
         hostPattern: "api.github.com",
-        pathPattern: "/repos/*/pulls",
+        pathPattern: "/repos/*/*/pulls",
         method: "GET",
       },
       {
@@ -41,7 +41,7 @@ const githubGroups: AppToolGroup[] = [
         name: "List issues",
         description: "List issues in a repository",
         hostPattern: "api.github.com",
-        pathPattern: "/repos/*/issues",
+        pathPattern: "/repos/*/*/issues",
         method: "GET",
       },
       {
@@ -71,7 +71,7 @@ const githubGroups: AppToolGroup[] = [
         name: "Create pull request",
         description: "Create a new pull request",
         hostPattern: "api.github.com",
-        pathPattern: "/repos/*/pulls",
+        pathPattern: "/repos/*/*/pulls",
         method: "POST",
       },
       {
@@ -79,7 +79,7 @@ const githubGroups: AppToolGroup[] = [
         name: "Create comment",
         description: "Comment on an issue or pull request",
         hostPattern: "api.github.com",
-        pathPattern: "/repos/*/issues/*/comments",
+        pathPattern: "/repos/*/*/issues/*/comments",
         method: "POST",
       },
       {
@@ -87,7 +87,7 @@ const githubGroups: AppToolGroup[] = [
         name: "Create issue",
         description: "Create a new issue in a repository",
         hostPattern: "api.github.com",
-        pathPattern: "/repos/*/issues",
+        pathPattern: "/repos/*/*/issues",
         method: "POST",
       },
       {
@@ -104,7 +104,7 @@ const githubGroups: AppToolGroup[] = [
         name: "Delete branch",
         description: "Delete a git branch reference",
         hostPattern: "api.github.com",
-        pathPattern: "/repos/*/git/refs/*",
+        pathPattern: "/repos/*/*/git/refs/*",
         method: "DELETE",
       },
     ],

--- a/packages/api/src/apps/app-permissions/google-calendar.ts
+++ b/packages/api/src/apps/app-permissions/google-calendar.ts
@@ -65,7 +65,7 @@ export const googleCalendarPermissions: AppPermissionDefinition = {
           description: "Update an existing calendar event",
           hostPattern: "www.googleapis.com",
           pathPattern: "/calendar/v3/calendars/*/events/*",
-          method: "PATCH",
+          methods: ["PUT", "PATCH"],
         },
         {
           id: "delete_event",

--- a/packages/api/src/apps/app-permissions/google-drive.ts
+++ b/packages/api/src/apps/app-permissions/google-drive.ts
@@ -49,6 +49,7 @@ export const googleDrivePermissions: AppPermissionDefinition = {
           description: "Upload a new file to Google Drive",
           hostPattern: "www.googleapis.com",
           pathPattern: "/drive/v3/files",
+          aliasPatterns: ["/upload/drive/v3/files"],
           method: "POST",
         },
         {
@@ -57,6 +58,7 @@ export const googleDrivePermissions: AppPermissionDefinition = {
           description: "Update an existing file in Google Drive",
           hostPattern: "www.googleapis.com",
           pathPattern: "/drive/v3/files/*",
+          aliasPatterns: ["/upload/drive/v3/files/*"],
           method: "PATCH",
         },
         {

--- a/packages/api/src/apps/app-permissions/google-forms.ts
+++ b/packages/api/src/apps/app-permissions/google-forms.ts
@@ -36,14 +36,6 @@ export const googleFormsPermissions: AppPermissionDefinition = {
           method: "POST",
         },
         {
-          id: "update_form",
-          name: "Update form",
-          description: "Update form info such as title and description",
-          hostPattern: "forms.googleapis.com",
-          pathPattern: "/v1/forms/*",
-          method: "PATCH",
-        },
-        {
           id: "batch_update_form",
           name: "Batch update form",
           description: "Apply a batch of updates to a form",

--- a/packages/api/src/apps/app-permissions/google-tasks.ts
+++ b/packages/api/src/apps/app-permissions/google-tasks.ts
@@ -49,7 +49,7 @@ export const googleTasksPermissions: AppPermissionDefinition = {
           description: "Update an existing task",
           hostPattern: "tasks.googleapis.com",
           pathPattern: "/tasks/v1/lists/*/tasks/*",
-          method: "PATCH",
+          methods: ["PUT", "PATCH"],
         },
         {
           id: "delete_task",

--- a/packages/api/src/apps/app-permissions/jira.ts
+++ b/packages/api/src/apps/app-permissions/jira.ts
@@ -20,8 +20,8 @@ export const jiraPermissions: AppPermissionDefinition = {
           name: "Search issues",
           description: "Search for issues using JQL",
           hostPattern: "api.atlassian.com",
-          pathPattern: "/ex/jira/*/rest/api/3/search",
-          method: "GET",
+          pathPattern: "/ex/jira/*/rest/api/3/search/jql",
+          methods: ["GET", "POST"],
         },
         {
           id: "get_issue",

--- a/packages/api/src/apps/app-permissions/supabase.ts
+++ b/packages/api/src/apps/app-permissions/supabase.ts
@@ -35,7 +35,7 @@ export const supabasePermissions: AppPermissionDefinition = {
           name: "Get database config",
           description: "View database and pooler configuration",
           hostPattern: "api.supabase.com",
-          pathPattern: "/v1/projects/*/config/database",
+          pathPattern: "/v1/projects/*/config/database/*",
           method: "GET",
         },
         {
@@ -51,7 +51,7 @@ export const supabasePermissions: AppPermissionDefinition = {
           name: "Get PostgREST config",
           description: "View PostgREST API configuration",
           hostPattern: "api.supabase.com",
-          pathPattern: "/v1/projects/*/config/postgrest",
+          pathPattern: "/v1/projects/*/postgrest",
           method: "GET",
         },
         {

--- a/packages/api/src/apps/app-permissions/todoist.ts
+++ b/packages/api/src/apps/app-permissions/todoist.ts
@@ -11,7 +11,7 @@ export const todoistPermissions: AppPermissionDefinition = {
           name: "List tasks",
           description: "List active tasks",
           hostPattern: "api.todoist.com",
-          pathPattern: "/rest/v2/tasks",
+          pathPattern: "/api/v1/tasks",
           method: "GET",
         },
         {
@@ -19,7 +19,7 @@ export const todoistPermissions: AppPermissionDefinition = {
           name: "Get task",
           description: "Retrieve a specific task",
           hostPattern: "api.todoist.com",
-          pathPattern: "/rest/v2/tasks/*",
+          pathPattern: "/api/v1/tasks/*",
           method: "GET",
         },
         {
@@ -27,7 +27,7 @@ export const todoistPermissions: AppPermissionDefinition = {
           name: "List projects",
           description: "List all projects",
           hostPattern: "api.todoist.com",
-          pathPattern: "/rest/v2/projects",
+          pathPattern: "/api/v1/projects",
           method: "GET",
         },
       ],
@@ -40,7 +40,7 @@ export const todoistPermissions: AppPermissionDefinition = {
           name: "Create task",
           description: "Create a new task",
           hostPattern: "api.todoist.com",
-          pathPattern: "/rest/v2/tasks",
+          pathPattern: "/api/v1/tasks",
           method: "POST",
         },
         {
@@ -48,7 +48,7 @@ export const todoistPermissions: AppPermissionDefinition = {
           name: "Update task",
           description: "Update an existing task",
           hostPattern: "api.todoist.com",
-          pathPattern: "/rest/v2/tasks/*",
+          pathPattern: "/api/v1/tasks/*",
           method: "POST",
         },
         {
@@ -56,7 +56,7 @@ export const todoistPermissions: AppPermissionDefinition = {
           name: "Close task",
           description: "Mark a task as complete",
           hostPattern: "api.todoist.com",
-          pathPattern: "/rest/v2/tasks/*/close",
+          pathPattern: "/api/v1/tasks/*/close",
           method: "POST",
         },
         {
@@ -64,7 +64,7 @@ export const todoistPermissions: AppPermissionDefinition = {
           name: "Delete task",
           description: "Delete a task",
           hostPattern: "api.todoist.com",
-          pathPattern: "/rest/v2/tasks/*",
+          pathPattern: "/api/v1/tasks/*",
           method: "DELETE",
         },
       ],

--- a/packages/api/src/apps/app-permissions/youtube.ts
+++ b/packages/api/src/apps/app-permissions/youtube.ts
@@ -48,7 +48,7 @@ export const youtubePermissions: AppPermissionDefinition = {
           name: "Insert video",
           description: "Upload a new video to YouTube",
           hostPattern: "www.googleapis.com",
-          pathPattern: "/youtube/v3/videos",
+          pathPattern: "/upload/youtube/v3/videos",
           method: "POST",
         },
         {

--- a/packages/api/src/lib/gateway-invalidate.ts
+++ b/packages/api/src/lib/gateway-invalidate.ts
@@ -22,15 +22,26 @@ export const invalidateGatewayCache = (request: Request) => {
   }).catch(() => {});
 };
 
+/**
+ * Flush the gateway's cached config for specific API keys directly. Use this
+ * when the keys are about to be — or have just been — deleted, so they can no
+ * longer be looked up from the database: capture them first, then flush.
+ */
+export const invalidateGatewayCacheForKeys = (keys: string[]) => {
+  for (const key of keys) {
+    fetch(`${GATEWAY_API_URL}/v1/cache/invalidate`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${key}` },
+    }).catch(() => {});
+  }
+};
+
 export const invalidateGatewayCacheForAccount = (projectId: string) => {
   db.apiKey
     .findFirst({ where: { projectId }, select: { key: true } })
     .then((apiKey) => {
       if (!apiKey) return;
-      fetch(`${GATEWAY_API_URL}/v1/cache/invalidate`, {
-        method: "POST",
-        headers: { authorization: `Bearer ${apiKey.key}` },
-      }).catch(() => {});
+      invalidateGatewayCacheForKeys([apiKey.key]);
     })
     .catch(() => {});
 };
@@ -42,13 +53,6 @@ export const invalidateGatewayCacheForOrg = (organizationId: string) => {
       select: { key: true },
       distinct: ["projectId"],
     })
-    .then((keys) => {
-      for (const { key } of keys) {
-        fetch(`${GATEWAY_API_URL}/v1/cache/invalidate`, {
-          method: "POST",
-          headers: { authorization: `Bearer ${key}` },
-        }).catch(() => {});
-      }
-    })
+    .then((keys) => invalidateGatewayCacheForKeys(keys.map((k) => k.key)))
     .catch(() => {});
 };

--- a/packages/api/src/middleware/auth/resolve.ts
+++ b/packages/api/src/middleware/auth/resolve.ts
@@ -1,6 +1,7 @@
 import { db } from "@onecli/db";
 import { IS_CLOUD } from "../../lib/env";
 import { findUserDefaultProject } from "../../services/organization-service";
+import { getRoleResolver, ROLE_HIERARCHY } from "../../providers";
 
 export const resolveUserEmail = async (userId: string): Promise<string> => {
   const user = await db.user.findUnique({
@@ -62,8 +63,24 @@ export const resolveProjectId = async (
       id: headerProjectId,
       organizationId: { in: memberOrgIds },
     },
-    select: { id: true },
+    select: { id: true, organizationId: true, createdByUserId: true },
   });
 
-  return project?.id ?? null;
+  if (!project) return null;
+
+  // Cloud: a member may only target projects they created; admins and owners
+  // may target any project in their org. OSS standalone registers no role
+  // resolver, so this gate is skipped and any in-org project is accepted, as
+  // before. Mirrors `canManageAllProjects` in the cloud authorization service.
+  if (IS_CLOUD && project.createdByUserId !== userId) {
+    const resolver = getRoleResolver();
+    const role = resolver
+      ? await resolver.getUserRole(userId, project.organizationId)
+      : null;
+    if (!role || ROLE_HIERARCHY[role] < ROLE_HIERARCHY.admin) {
+      return null;
+    }
+  }
+
+  return project.id;
 };

--- a/packages/api/src/services/request-log-service.ts
+++ b/packages/api/src/services/request-log-service.ts
@@ -12,6 +12,8 @@ export interface RequestLogEntry {
   latencyMs: number;
   injectionCount: number;
   extraData: unknown;
+  /** Display name of the user who approved/denied this request, if resolved. */
+  approvedBy: string | null;
   createdAt: string;
 }
 
@@ -90,6 +92,20 @@ export const getApprovalReason = (log: RequestLogEntry): string | null => {
   return typeof reason === "string" ? reason : null;
 };
 
+/** The gateway-assigned approval id linking a request log to its held approval. */
+export const getApprovalId = (log: RequestLogEntry): string | null => {
+  const data = log.extraData as Record<string, unknown> | null;
+  const id = data?.approval_id;
+  return typeof id === "string" ? id : null;
+};
+
+/** The user id the gateway stamped on a resolved approval (`approved_by`). */
+const approvedByUserId = (extraData: unknown): string | null => {
+  const data = extraData as Record<string, unknown> | null;
+  const by = data?.approved_by;
+  return typeof by === "string" ? by : null;
+};
+
 export const getConnectionLabel = (log: RequestLogEntry): string | null => {
   const data = log.extraData as Record<string, unknown> | null;
   const label = data?.connection_label;
@@ -119,25 +135,50 @@ const resolveAgentNames = async (
   return new Map(agents.map((a) => [a.id, a.name]));
 };
 
+/** Resolve approver user ids → a display name (name, falling back to email). */
+const resolveUserNames = async (
+  userIds: string[],
+): Promise<Map<string, string>> => {
+  if (userIds.length === 0) return new Map();
+  const users = await db.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, name: true, email: true },
+  });
+  return new Map(users.map((u) => [u.id, u.name ?? u.email]));
+};
+
+const collectApproverIds = (rows: { extraData: unknown }[]): string[] => [
+  ...new Set(
+    rows
+      .map((r) => approvedByUserId(r.extraData))
+      .filter((id): id is string => id !== null),
+  ),
+];
+
 type RequestLogRow = Prisma.RequestLogGetPayload<object>;
 
 const toEntry = (
   log: RequestLogRow,
   agentMap: Map<string, string>,
-): RequestLogEntry => ({
-  id: log.id,
-  agentId: log.agentId,
-  agentName: agentMap.get(log.agentId) ?? null,
-  method: log.method,
-  host: log.host,
-  path: log.path,
-  provider: log.provider,
-  status: log.status,
-  latencyMs: log.latencyMs,
-  injectionCount: log.injectionCount,
-  extraData: log.extraData,
-  createdAt: log.createdAt.toISOString(),
-});
+  userMap: Map<string, string>,
+): RequestLogEntry => {
+  const approverId = approvedByUserId(log.extraData);
+  return {
+    id: log.id,
+    agentId: log.agentId,
+    agentName: agentMap.get(log.agentId) ?? null,
+    method: log.method,
+    host: log.host,
+    path: log.path,
+    provider: log.provider,
+    status: log.status,
+    latencyMs: log.latencyMs,
+    injectionCount: log.injectionCount,
+    extraData: log.extraData,
+    approvedBy: approverId ? (userMap.get(approverId) ?? null) : null,
+    createdAt: log.createdAt.toISOString(),
+  };
+};
 
 export const getRecentRequestLogs = async (
   projectId: string,
@@ -150,9 +191,12 @@ export const getRecentRequestLogs = async (
   });
 
   const agentIds = [...new Set(logs.map((l) => l.agentId))];
-  const agentMap = await resolveAgentNames(projectId, agentIds);
+  const [agentMap, userMap] = await Promise.all([
+    resolveAgentNames(projectId, agentIds),
+    resolveUserNames(collectApproverIds(logs)),
+  ]);
 
-  return logs.map((l) => toEntry(l, agentMap));
+  return logs.map((l) => toEntry(l, agentMap, userMap));
 };
 
 export const getRequestLogs = async (
@@ -185,7 +229,10 @@ export const getRequestLogs = async (
   const page = hasMore ? logs.slice(0, limit) : logs;
 
   const agentIds = [...new Set(page.map((l) => l.agentId))];
-  const agentMap = await resolveAgentNames(projectId, agentIds);
+  const [agentMap, userMap] = await Promise.all([
+    resolveAgentNames(projectId, agentIds),
+    resolveUserNames(collectApproverIds(page)),
+  ]);
 
   const lastLog = page[page.length - 1];
   const nextCursor =
@@ -194,7 +241,7 @@ export const getRequestLogs = async (
       : null;
 
   return {
-    logs: page.map((l) => toEntry(l, agentMap)),
+    logs: page.map((l) => toEntry(l, agentMap, userMap)),
     nextCursor,
   };
 };

--- a/packages/api/src/validations/secret.test.ts
+++ b/packages/api/src/validations/secret.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { hostPatternSchema, wildcardCoversPublicSuffix } from "./secret";
+
+const accepts = (host: string) => hostPatternSchema.safeParse(host).success;
+
+// Unicode whitespace that String.prototype.trim() strips but that is NOT the
+// ASCII space the schema rejects: a non-breaking space and an ideographic space.
+const NBSP = String.fromCharCode(0xa0);
+const IDEOGRAPHIC_SPACE = String.fromCharCode(0x3000);
+
+describe("secret host pattern validation", () => {
+  // Exact hosts, and a wildcard over a single registrable domain, are fine.
+  it.each([
+    "api.github.com",
+    "*.example.com",
+    "*.amazonaws.com",
+    "*.internal", // unknown/custom TLD — left to the operator
+  ])("accepts %s", (host) => {
+    expect(accepts(host)).toBe(true);
+  });
+
+  // A wildcard that spans a public suffix would inject the credential across
+  // many unrelated owners — ICANN suffixes and PSL private-section (per-tenant)
+  // suffixes alike — so it is rejected.
+  it.each(["*.com", "*.io", "*.co.uk", "*.s3.amazonaws.com", "*.github.io"])(
+    "rejects public-suffix wildcard %s",
+    (host) => {
+      expect(accepts(host)).toBe(false);
+    },
+  );
+
+  // Validation runs on the trimmed value (the service trims on save), so
+  // trailing Unicode whitespace must not smuggle a public-suffix wildcard past
+  // the check, nor reject an otherwise-valid pattern.
+  it("validates the trimmed host pattern", () => {
+    expect(accepts("*.com" + NBSP)).toBe(false); // trims to "*.com"
+    expect(accepts("*.s3.amazonaws.com" + IDEOGRAPHIC_SPACE)).toBe(false);
+    expect(accepts("*.example.com" + NBSP)).toBe(true); // trims to "*.example.com"
+  });
+
+  // Malformed wildcard shapes stay rejected (bare, mid-string, multiple).
+  it.each(["*", "api.*.com", "*.*.com"])(
+    "rejects malformed wildcard %s",
+    (host) => {
+      expect(accepts(host)).toBe(false);
+    },
+  );
+});
+
+describe("wildcardCoversPublicSuffix", () => {
+  it("is true only for a wildcard spanning a public suffix", () => {
+    expect(wildcardCoversPublicSuffix("*.com")).toBe(true);
+    expect(wildcardCoversPublicSuffix("*.s3.amazonaws.com")).toBe(true);
+    expect(wildcardCoversPublicSuffix("*.example.com")).toBe(false);
+    expect(wildcardCoversPublicSuffix("*.amazonaws.com")).toBe(false);
+    expect(wildcardCoversPublicSuffix("api.github.com")).toBe(false);
+  });
+});

--- a/packages/api/src/validations/secret.ts
+++ b/packages/api/src/validations/secret.ts
@@ -1,3 +1,4 @@
+import { parse } from "tldts";
 import { z } from "zod";
 
 const headerInjectionSchema = z
@@ -39,8 +40,24 @@ export const isParamInjection = (
   "paramName" in config &&
   typeof (config as Record<string, unknown>).paramName === "string";
 
-const hostPatternSchema = z
+// A secret's host pattern decides which hosts its credential is injected into.
+// A "*.X" wildcard is safe only when X is a single registrable domain; a wildcard
+// over a public suffix ("*.com", "*.s3.amazonaws.com") would inject the credential
+// across many unrelated owners. Returns true for that over-broad case.
+export const wildcardCoversPublicSuffix = (hostPattern: string): boolean => {
+  if (!hostPattern.startsWith("*.")) return false;
+  const { domain, isIcann, isPrivate } = parse(hostPattern.slice(2), {
+    allowPrivateDomains: true,
+  });
+  return domain === null && (isIcann === true || isPrivate === true);
+};
+
+export const hostPatternSchema = z
   .string()
+  // Trim before validating so the refines see exactly what gets stored: the
+  // service also trims on save, so trailing Unicode whitespace must not smuggle
+  // a public-suffix wildcard ("*.com " -> stored "*.com") past the checks.
+  .trim()
   .min(1, "Host pattern is required")
   .max(1000)
   .refine((v) => !v.includes("://"), {
@@ -52,6 +69,19 @@ const hostPatternSchema = z
   })
   .refine((v) => !v.includes(" "), {
     message: "Host pattern must not contain spaces",
+  })
+  // A credential is injected into every host its pattern matches, so only allow
+  // a single leading-subdomain wildcard ("*.example.com"). Reject mid-string
+  // ("api.*.com") and bare ("*") wildcards, which would inject into unintended
+  // hosts now that the gateway matches a `*` anywhere in the pattern.
+  .refine((v) => !v.includes("*") || /^\*\.[a-z0-9.-]+$/i.test(v), {
+    message:
+      "Wildcards are only allowed as a leading subdomain, e.g. *.example.com",
+  })
+  // ...and that wildcard must not cover a whole public suffix (see helper above).
+  .refine((v) => !wildcardCoversPublicSuffix(v), {
+    message:
+      "A wildcard can't cover a public suffix like *.com; use a specific domain, e.g. *.example.com",
   });
 
 export const valueSources = ["inline", "onepassword"] as const;

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@onecli/ui/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       stripe:
         specifier: ^20.4.0
         version: 20.4.0(@types/node@22.19.11)
+      tldts:
+        specifier: ^7.4.4
+        version: 7.4.4
       undici:
         specifier: ^8.0.0
         version: 8.5.0
@@ -192,6 +195,9 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   packages/db:
     dependencies:
@@ -837,6 +843,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -2043,6 +2205,131 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2661,8 +2948,17 @@ packages:
   '@types/aws-lambda@8.10.160':
     resolution: {integrity: sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2844,6 +3140,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2920,6 +3245,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -2995,6 +3324,10 @@ packages:
       magicast:
         optional: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3018,9 +3351,17 @@ packages:
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -3138,6 +3479,10 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -3250,6 +3595,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3265,6 +3613,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -3406,12 +3759,19 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -3505,6 +3865,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3816,6 +4181,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -3970,6 +4338,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -4189,6 +4560,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -4476,6 +4851,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4556,6 +4936,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4588,8 +4971,14 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4654,6 +5043,9 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   stripe@20.4.0:
     resolution: {integrity: sha512-F/aN1IQ9vHmlyLNi3DkiIbyzQb6gyBG0uYFd/VrEVQSc9BLtlgknPUx0EvzZdBMRLFuRaPFIFd7Mxwtg7Pbwzw==}
     engines: {node: '>=16'}
@@ -4707,6 +5099,12 @@ packages:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -4714,6 +5112,25 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.4:
+    resolution: {integrity: sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==}
+
+  tldts@7.4.4:
+    resolution: {integrity: sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==}
+    hasBin: true
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4862,6 +5279,79 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
@@ -4887,6 +5377,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -6227,6 +6722,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.3(jiti@2.6.1)
@@ -7414,6 +7987,81 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@smithy/abort-controller@4.2.10':
@@ -8331,7 +8979,16 @@ snapshots:
 
   '@types/aws-lambda@8.10.160': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -8508,6 +9165,48 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -8610,6 +9309,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -8692,6 +9393,8 @@ snapshots:
       pkg-types: 2.3.0
       rc9: 2.1.2
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -8715,10 +9418,20 @@ snapshots:
 
   caniuse-lite@1.0.30001774: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -8816,6 +9529,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -8982,6 +9697,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -9002,6 +9719,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -9222,9 +9968,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -9320,6 +10072,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -9625,6 +10380,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -9761,6 +10518,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9962,6 +10721,8 @@ snapshots:
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -10280,6 +11041,37 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -10407,6 +11199,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@7.1.2:
@@ -10434,7 +11228,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -10524,6 +11322,10 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   stripe@20.4.0(@types/node@22.19.11):
     optionalDependencies:
       '@types/node': 22.19.11
@@ -10555,12 +11357,28 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@7.4.4: {}
+
+  tldts@7.4.4:
+    dependencies:
+      tldts-core: 7.4.4
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10735,6 +11553,83 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vite-node@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.62.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.11
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      yaml: 2.8.2
+
+  vitest@3.2.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   web-vitals@5.2.0: {}
 
   which-boxed-primitive@1.1.1:
@@ -10783,6 +11678,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Approvals

- **Live pending-approval notifications** — a header bell + popover surface the requests the gateway is currently holding, each with a per-request countdown to auto-deny.
- **Approver audit** — who approved or denied a request is now surfaced in the activity table and detail dialog.
- **Gateway approval summaries** — pluggable, per-app human-readable summaries of what a held request will actually do, including friendly titles for all major Gmail and Google Calendar APIs.

## Fixes

- **App-permission catalogs** — correct several permission patterns that silently never matched (too-few path segments, mid-string wildcards).
- **Secret host patterns** — reject public-suffix wildcards (e.g. `*.com`) in host match patterns; adds `tldts` for public-suffix detection.
- **Project access** — scope project access by the user's organization role.
- **Gateway cache** — flush the gateway cache on bulk/cascade delete paths so stale rules don't linger.

## Misc

- Add a shadcn `popover` UI component.
- Add a `vitest` suite covering secret host-pattern validation (14 cases).
