### PR TITLE
feat: add "Hide AI" activity filter and tolerate missing API keys

### DIFF
--- a/apps/web/src/app/(dashboard)/activity/_components/activity-content.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-content.tsx
@@ -6,13 +6,21 @@ import { Button } from "@onecli/ui/components/button";
 import { PageHeader } from "@dashboard/page-header";
 import { getActivityPage } from "@/lib/actions/request-logs";
 import { ActivityTable } from "./activity-table";
+import { ActivityFilterControl } from "./activity-filter";
 import { ActivityDetailDialog } from "./activity-detail-dialog";
-import type { RequestLogEntry } from "@onecli/api/services/request-log-service";
+import type {
+  ActivityFilter,
+  RequestLogEntry,
+} from "@onecli/api/services/request-log-service";
 import { usePendingApprovals } from "@/hooks/use-approvals";
 import { ApprovalDetailsDialog } from "@/lib/components/approvals";
 import type { PendingApproval } from "@/lib/api/approvals";
 
-type StatusFilter = "all" | "errors";
+const EMPTY_MESSAGES: Record<ActivityFilter, string> = {
+  all: "No requests yet.",
+  "hide-llm": "No non-AI requests to show.",
+  blocked: "No blocked requests.",
+};
 
 export const ActivityContent = () => {
   const [logs, setLogs] = useState<RequestLogEntry[]>([]);
@@ -22,7 +30,7 @@ export const ActivityContent = () => {
   } | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [filter, setFilter] = useState<ActivityFilter>("all");
   const [liveMode, setLiveMode] = useState(true);
   const [selected, setSelected] = useState<RequestLogEntry | null>(null);
   const [approvalDetails, setApprovalDetails] =
@@ -35,10 +43,10 @@ export const ActivityContent = () => {
     [pendingApprovals],
   );
 
-  const loadInitial = useCallback(async (filter: StatusFilter) => {
+  const loadInitial = useCallback(async (nextFilter: ActivityFilter) => {
     setLoading(true);
     try {
-      const data = await getActivityPage({ statusFilter: filter });
+      const data = await getActivityPage({ filter: nextFilter });
       setLogs(data.logs);
       setNextCursor(data.nextCursor);
       initializedRef.current = true;
@@ -49,15 +57,15 @@ export const ActivityContent = () => {
 
   useEffect(() => {
     initializedRef.current = false;
-    loadInitial(statusFilter);
-  }, [statusFilter, loadInitial]);
+    loadInitial(filter);
+  }, [filter, loadInitial]);
 
   useEffect(() => {
     if (!liveMode || loading) return;
     const id = setInterval(async () => {
       if (!initializedRef.current) return;
       try {
-        const data = await getActivityPage({ statusFilter });
+        const data = await getActivityPage({ filter });
         setLogs((prev) => {
           if (
             prev.length === data.logs.length &&
@@ -72,14 +80,14 @@ export const ActivityContent = () => {
       }
     }, 3000);
     return () => clearInterval(id);
-  }, [liveMode, statusFilter, loading]);
+  }, [liveMode, filter, loading]);
 
   const loadMore = async () => {
     if (!nextCursor) return;
     setLiveMode(false);
     setLoadingMore(true);
     try {
-      const data = await getActivityPage({ cursor: nextCursor, statusFilter });
+      const data = await getActivityPage({ cursor: nextCursor, filter });
       setLogs((prev) => [...prev, ...data.logs]);
       setNextCursor(data.nextCursor);
     } finally {
@@ -94,30 +102,7 @@ export const ActivityContent = () => {
         description="Request logs from your gateway. Bodies and query strings are never recorded."
       />
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-1 rounded-lg border p-1">
-          <button
-            type="button"
-            onClick={() => setStatusFilter("all")}
-            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-              statusFilter === "all"
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            All
-          </button>
-          <button
-            type="button"
-            onClick={() => setStatusFilter("errors")}
-            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-              statusFilter === "errors"
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            Blocked
-          </button>
-        </div>
+        <ActivityFilterControl value={filter} onChange={setFilter} />
 
         <button
           type="button"
@@ -142,6 +127,7 @@ export const ActivityContent = () => {
             liveApprovals={liveApprovals}
             onRowClick={setSelected}
             onShowApproval={setApprovalDetails}
+            emptyMessage={EMPTY_MESSAGES[filter]}
           />
 
           {nextCursor && (

--- a/apps/web/src/app/(dashboard)/activity/_components/activity-filter.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-filter.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { cn } from "@onecli/ui/lib/utils";
+import type { ActivityFilter } from "@onecli/api/services/request-log-service";
+
+interface ActivityFilterOption {
+  value: ActivityFilter;
+  label: string;
+}
+
+const OPTIONS: ActivityFilterOption[] = [
+  { value: "all", label: "All" },
+  { value: "hide-llm", label: "Hide AI" },
+  { value: "blocked", label: "Blocked" },
+];
+
+interface ActivityFilterControlProps {
+  value: ActivityFilter;
+  onChange: (value: ActivityFilter) => void;
+}
+
+export const ActivityFilterControl = ({
+  value,
+  onChange,
+}: ActivityFilterControlProps) => (
+  <div
+    role="group"
+    aria-label="Filter activity"
+    className="flex items-center gap-1 rounded-lg border p-1"
+  >
+    {OPTIONS.map((option) => {
+      const selected = value === option.value;
+      return (
+        <button
+          key={option.value}
+          type="button"
+          aria-pressed={selected}
+          onClick={() => onChange(option.value)}
+          className={cn(
+            "rounded-md px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
+            selected
+              ? "bg-muted text-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {option.label}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/apps/web/src/app/(dashboard)/activity/_components/activity-table.tsx
+++ b/apps/web/src/app/(dashboard)/activity/_components/activity-table.tsx
@@ -56,6 +56,7 @@ interface ActivityTableProps {
   liveApprovals: Map<string, PendingApproval>;
   onRowClick: (log: RequestLogEntry) => void;
   onShowApproval: (approval: PendingApproval) => void;
+  emptyMessage?: string;
 }
 
 export const ActivityTable = ({
@@ -63,6 +64,7 @@ export const ActivityTable = ({
   liveApprovals,
   onRowClick,
   onShowApproval,
+  emptyMessage = "No requests yet.",
 }: ActivityTableProps) => (
   <div className="rounded-lg border overflow-hidden">
     <Table>
@@ -85,7 +87,7 @@ export const ActivityTable = ({
               colSpan={8}
               className="text-muted-foreground py-16 text-center text-sm"
             >
-              No requests yet.
+              {emptyMessage}
             </TableCell>
           </TableRow>
         ) : (

--- a/packages/api/src/lib/llm-hosts.ts
+++ b/packages/api/src/lib/llm-hosts.ts
@@ -1,0 +1,18 @@
+/**
+ * Hostname fragments for known AI/LLM providers.
+ *
+ * This is the TypeScript mirror of the gateway's `is_llm_host`
+ * (`apps/gateway/src/policy.rs`). A request whose host contains one of these
+ * fragments is treated as AI-provider traffic (model inference and the
+ * providers' own telemetry alike). **Keep the two lists in sync.**
+ */
+export const LLM_HOST_FRAGMENTS = [
+  "anthropic.com",
+  "openai.com",
+  "chatgpt.com",
+  "deepseek.com",
+  "groq.com",
+  "openrouter.ai",
+  "moonshot.cn",
+  "generativelanguage.googleapis.com",
+] as const;

--- a/packages/api/src/services/api-key-service.ts
+++ b/packages/api/src/services/api-key-service.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "crypto";
 import { db } from "@onecli/db";
-import { ServiceError } from "./errors";
 import type { ResourceScope } from "./resource-scope";
 import { scopeWhere, scopeCreate, isOrgScope } from "./resource-scope";
 
@@ -15,9 +14,10 @@ export const getApiKey = async (userId: string, scope: ResourceScope) => {
     select: { key: true },
   });
 
-  if (!apiKey) throw new ServiceError("NOT_FOUND", "API key not found");
-
-  return { apiKey: apiKey.key };
+  // Not having generated a key yet is a normal state, not an error — return
+  // null so callers can render an empty / "generate" affordance instead of a
+  // 404/500. (Consumers read `result.apiKey ?? ""`.)
+  return { apiKey: apiKey?.key ?? null };
 };
 
 export const regenerateApiKey = async (

--- a/packages/api/src/services/request-log-service.test.ts
+++ b/packages/api/src/services/request-log-service.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { LLM_HOST_FRAGMENTS } from "../lib/llm-hosts";
+import { buildActivityWhere } from "./request-log-service";
+
+const PROJECT_ID = "proj_activity_test";
+
+describe("buildActivityWhere", () => {
+  it("scopes to the project when given no filter or cursor", () => {
+    expect(buildActivityWhere(PROJECT_ID)).toEqual({ projectId: PROJECT_ID });
+  });
+
+  it('applies no extra constraints for the "all" filter', () => {
+    expect(buildActivityWhere(PROJECT_ID, { filter: "all" })).toEqual({
+      projectId: PROJECT_ID,
+    });
+  });
+
+  it('filters to status >= 400 for the "blocked" filter', () => {
+    expect(buildActivityWhere(PROJECT_ID, { filter: "blocked" })).toEqual({
+      projectId: PROJECT_ID,
+      status: { gte: 400 },
+    });
+  });
+
+  it('excludes every known AI host, case-insensitively, for "hide-llm"', () => {
+    expect(buildActivityWhere(PROJECT_ID, { filter: "hide-llm" })).toEqual({
+      projectId: PROJECT_ID,
+      NOT: {
+        OR: LLM_HOST_FRAGMENTS.map((fragment) => ({
+          host: { contains: fragment, mode: "insensitive" },
+        })),
+      },
+    });
+  });
+
+  it("classifies anthropic.com as AI but leaves non-AI hosts like github.com", () => {
+    const fragments: readonly string[] = LLM_HOST_FRAGMENTS;
+    expect(fragments).toContain("anthropic.com");
+    expect(fragments).not.toContain("github.com");
+  });
+
+  it('keeps the keyset cursor clauses alongside the "hide-llm" exclusion', () => {
+    const cursor = { createdAt: "2026-06-26T12:00:00.000Z", id: "log_42" };
+    const where = buildActivityWhere(PROJECT_ID, {
+      filter: "hide-llm",
+      cursor,
+    });
+
+    expect(where.NOT).toBeDefined();
+    expect(where.OR).toEqual([
+      { createdAt: { lt: new Date(cursor.createdAt) } },
+      { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
+    ]);
+  });
+});

--- a/packages/api/src/services/request-log-service.ts
+++ b/packages/api/src/services/request-log-service.ts
@@ -1,5 +1,7 @@
 import { db, Prisma } from "@onecli/db";
 
+import { LLM_HOST_FRAGMENTS } from "../lib/llm-hosts";
+
 export interface RequestLogEntry {
   id: string;
   agentId: string;
@@ -117,10 +119,12 @@ export interface RequestLogPage {
   nextCursor: { createdAt: string; id: string } | null;
 }
 
+export type ActivityFilter = "all" | "hide-llm" | "blocked";
+
 export interface ActivityPageParams {
   cursor?: { createdAt: string; id: string };
   limit?: number;
-  statusFilter?: "all" | "errors";
+  filter?: ActivityFilter;
 }
 
 const resolveAgentNames = async (
@@ -199,17 +203,30 @@ export const getRecentRequestLogs = async (
   return logs.map((l) => toEntry(l, agentMap, userMap));
 };
 
-export const getRequestLogs = async (
+/**
+ * Build the Prisma `where` for an activity query: project scope, the selected
+ * {@link ActivityFilter}, and the keyset-pagination cursor. Pure and synchronous
+ * so it can be unit-tested without a database.
+ */
+export const buildActivityWhere = (
   projectId: string,
-  params: ActivityPageParams = {},
-): Promise<RequestLogPage> => {
-  const limit = Math.min(params.limit ?? 50, 200);
-  const { cursor, statusFilter } = params;
-
+  params: Pick<ActivityPageParams, "cursor" | "filter"> = {},
+): Prisma.RequestLogWhereInput => {
+  const { cursor, filter = "all" } = params;
   const where: Prisma.RequestLogWhereInput = { projectId };
 
-  if (statusFilter === "errors") {
+  if (filter === "blocked") {
     where.status = { gte: 400 };
+  } else if (filter === "hide-llm") {
+    // Exclude AI-provider traffic: keep rows whose host contains none of the
+    // known LLM host fragments (mirrors the gateway's is_llm_host).
+    where.NOT = {
+      OR: LLM_HOST_FRAGMENTS.map(
+        (fragment): Prisma.RequestLogWhereInput => ({
+          host: { contains: fragment, mode: "insensitive" },
+        }),
+      ),
+    };
   }
 
   if (cursor) {
@@ -218,6 +235,16 @@ export const getRequestLogs = async (
       { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
     ];
   }
+
+  return where;
+};
+
+export const getRequestLogs = async (
+  projectId: string,
+  params: ActivityPageParams = {},
+): Promise<RequestLogPage> => {
+  const limit = Math.min(params.limit ?? 50, 200);
+  const where = buildActivityWhere(projectId, params);
 
   const logs = await db.requestLog.findMany({
     where,


### PR DESCRIPTION
## Activity log

- Replace the binary All/Blocked toggle with a three-way filter — **All / Hide AI / Blocked**. *Hide AI* excludes requests to known LLM provider hosts; *Blocked* keeps the existing `status >= 400` view.
- Add `LLM_HOST_FRAGMENTS` (`packages/api/src/lib/llm-hosts.ts`), a TypeScript mirror of the gateway's `is_llm_host`, and extract a pure, unit-tested `buildActivityWhere()` query builder.
- Extract the filter UI into an accessible `ActivityFilterControl` (`role="group"`, `aria-pressed`) with per-filter empty-state messages.

## API key

- `getApiKey()` now returns `{ apiKey: null }` instead of throwing `NOT_FOUND` when a user hasn't generated a key yet. Not-yet-generated is a normal state, not an error; consumers already read `result.apiKey ?? ""`.

## Tests

- New unit test covers `buildActivityWhere()` across all three filters.
