### PR TITLE
fix(api-key): provision per-user keys on read; re-check access on use

### DIFF
--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -215,6 +215,55 @@ pub(crate) async fn user_can_access_project(
     Ok(row.is_some())
 }
 
+/// Whether a user may manage a project — its creator, or an admin/owner of the
+/// project's organization. Re-checked on every API-key auth so a key stops
+/// working once its user loses access (e.g. demotion or removal). Cloud-only.
+#[cfg(feature = "cloud")]
+pub(crate) async fn user_can_manage_project(
+    pool: &PgPool,
+    user_id: &str,
+    project_id: &str,
+) -> Result<bool> {
+    let row: Option<(String,)> = sqlx::query_as(
+        r#"SELECT p.id
+           FROM projects p
+           LEFT JOIN organization_members om
+             ON om.organization_id = p.organization_id AND om.user_id = $1
+           WHERE p.id = $2
+             AND (p.created_by_user_id = $1 OR om.role IN ('owner', 'admin'))
+           LIMIT 1"#,
+    )
+    .bind(user_id)
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await
+    .context("verifying user can manage project")?;
+    Ok(row.is_some())
+}
+
+/// Whether a user is an admin or owner of an organization. Re-checked on every
+/// org-scoped API-key auth so the key stops working after a demotion. Cloud-only.
+#[cfg(feature = "cloud")]
+pub(crate) async fn user_is_org_admin(
+    pool: &PgPool,
+    user_id: &str,
+    organization_id: &str,
+) -> Result<bool> {
+    let row: Option<(String,)> = sqlx::query_as(
+        r#"SELECT user_id
+           FROM organization_members
+           WHERE user_id = $1 AND organization_id = $2
+             AND role IN ('owner', 'admin')
+           LIMIT 1"#,
+    )
+    .bind(user_id)
+    .bind(organization_id)
+    .fetch_optional(pool)
+    .await
+    .context("verifying user is org admin")?;
+    Ok(row.is_some())
+}
+
 /// Look up an agent by its access token.
 pub(crate) async fn find_agent_by_token(
     pool: &PgPool,

--- a/apps/web/src/app/(dashboard)/overview/_components/api-key-card.tsx
+++ b/apps/web/src/app/(dashboard)/overview/_components/api-key-card.tsx
@@ -63,7 +63,7 @@ export const ApiKeyCard = () => {
       <CardHeader>
         <CardTitle>API Key</CardTitle>
         <CardDescription>
-          Your personal API key for OneCLI services.
+          Your personal API key for this project.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/apps/web/src/lib/actions/api-key.ts
+++ b/apps/web/src/lib/actions/api-key.ts
@@ -2,18 +2,30 @@
 
 import { resolveProjectContext } from "@/lib/actions/resolve-user";
 import {
-  getApiKey as getApiKeyService,
+  ensureApiKey as ensureApiKeyService,
   regenerateApiKey as regenerateApiKeyService,
 } from "@onecli/api/services/api-key-service";
 import {
   withAudit,
+  recordAuditEvent,
   AUDIT_ACTIONS,
   AUDIT_SERVICES,
 } from "@onecli/api/services/audit-service";
 
 export const getApiKey = async () => {
-  const { userId, projectId } = await resolveProjectContext();
-  return getApiKeyService(userId, { projectId });
+  const { userId, userEmail, projectId } = await resolveProjectContext();
+  const { apiKey, created } = await ensureApiKeyService(userId, { projectId });
+  if (created) {
+    await recordAuditEvent({
+      projectId,
+      userId,
+      userEmail,
+      action: AUDIT_ACTIONS.CREATE,
+      service: AUDIT_SERVICES.API_KEY,
+      metadata: { scope: "project", autoProvisioned: true },
+    });
+  }
+  return { apiKey };
 };
 
 export const regenerateApiKey = async () => {

--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -12,8 +12,10 @@ import {
   type CreateSecretInput,
   type UpdateSecretInput,
 } from "@onecli/api/services/secret-service";
+import { ensureApiKey } from "@onecli/api/services/api-key-service";
 import {
   withAudit,
+  recordAuditEvent,
   AUDIT_ACTIONS,
   AUDIT_SERVICES,
 } from "@onecli/api/services/audit-service";
@@ -57,21 +59,29 @@ export const deleteSecret = async (secretId: string): Promise<void> => {
 };
 
 export const getInstallInfo = async (options?: ResolveOptions) => {
-  const { projectId, userId } = await resolveProjectContext(options);
+  const { projectId, userId, userEmail } = await resolveProjectContext(options);
 
-  const [apiKey, agent] = await Promise.all([
-    db.apiKey.findFirst({
-      where: { userId, projectId },
-      select: { key: true },
-    }),
+  const [keyResult, agent] = await Promise.all([
+    ensureApiKey(userId, { projectId }),
     db.agent.findFirst({
       where: { projectId, isDefault: true },
       select: { accessToken: true },
     }),
   ]);
 
+  if (keyResult.created) {
+    await recordAuditEvent({
+      projectId,
+      userId,
+      userEmail,
+      action: AUDIT_ACTIONS.CREATE,
+      service: AUDIT_SERVICES.API_KEY,
+      metadata: { scope: "project", autoProvisioned: true },
+    });
+  }
+
   return {
-    apiKey: apiKey?.key ?? null,
+    apiKey: keyResult.apiKey,
     agentToken: agent?.accessToken ?? null,
     gatewayUrl: GATEWAY_BASE_URL,
     appUrl: APP_URL,

--- a/packages/api/src/middleware/auth/api-key.ts
+++ b/packages/api/src/middleware/auth/api-key.ts
@@ -1,6 +1,8 @@
 import { db } from "@onecli/db";
 import type { AuthContext } from "../../providers";
-import { resolveUserEmail, resolveOrganizationIdFromProject } from "./resolve";
+import { getRoleResolver, ROLE_HIERARCHY } from "../../providers";
+import { IS_CLOUD } from "../../lib/env";
+import { resolveUserEmail, canAccessProjectAsUser } from "./resolve";
 
 export const authenticateApiKey = async (
   request: Request,
@@ -20,6 +22,17 @@ export const authenticateApiKey = async (
     });
     if (!apiKey || apiKey.scope !== "organization" || !apiKey.organizationId)
       return null;
+
+    // Org keys are an admin capability — re-check the key's user still holds
+    // admin/owner in the org (cloud only; OSS has neither org keys nor a role
+    // resolver). Closes the gap where a key keeps working after a demotion.
+    if (IS_CLOUD) {
+      const resolver = getRoleResolver();
+      const role = resolver
+        ? await resolver.getUserRole(apiKey.userId, apiKey.organizationId)
+        : null;
+      if (!role || ROLE_HIERARCHY[role] < ROLE_HIERARCHY.admin) return null;
+    }
 
     const userEmail = await resolveUserEmail(apiKey.userId);
     const headerProjectId = request.headers.get("x-project-id");
@@ -59,10 +72,16 @@ export const authenticateApiKey = async (
   });
   if (!apiKey || !apiKey.projectId) return null;
 
-  const organizationId = await resolveOrganizationIdFromProject(
-    apiKey.projectId,
-  );
-  if (!organizationId) return null;
+  const project = await db.project.findUnique({
+    where: { id: apiKey.projectId },
+    select: { createdByUserId: true, organizationId: true },
+  });
+  if (!project) return null;
+
+  // Re-check access at request time: the key authenticates only while its user
+  // still has access to the project (creator, or org admin/owner). OSS is a
+  // no-op (single-user, no role resolver). Mirrors resolveProjectId.
+  if (!(await canAccessProjectAsUser(apiKey.userId, project))) return null;
 
   const userEmail = await resolveUserEmail(apiKey.userId);
 
@@ -70,6 +89,6 @@ export const authenticateApiKey = async (
     userId: apiKey.userId,
     userEmail,
     projectId: apiKey.projectId,
-    organizationId,
+    organizationId: project.organizationId,
   };
 };

--- a/packages/api/src/middleware/auth/resolve.ts
+++ b/packages/api/src/middleware/auth/resolve.ts
@@ -36,6 +36,26 @@ export const resolveOrganizationId = async (
   return membership?.organizationId ?? null;
 };
 
+/**
+ * Whether a user may access a project: its creator, or an admin/owner of the
+ * project's organization. OSS registers no role resolver and is single-user, so
+ * this is a no-op there (always allowed). Shared by `resolveProjectId` (session
+ * project resolution) and the API-key auth path so both gate access identically
+ * — and so a key keeps working only while its user still has access.
+ */
+export const canAccessProjectAsUser = async (
+  userId: string,
+  project: { createdByUserId: string | null; organizationId: string },
+): Promise<boolean> => {
+  if (!IS_CLOUD) return true;
+  if (project.createdByUserId === userId) return true;
+  const resolver = getRoleResolver();
+  const role = resolver
+    ? await resolver.getUserRole(userId, project.organizationId)
+    : null;
+  return !!role && ROLE_HIERARCHY[role] >= ROLE_HIERARCHY.admin;
+};
+
 export const resolveProjectId = async (
   request: Request,
   userId: string,
@@ -72,15 +92,7 @@ export const resolveProjectId = async (
   // may target any project in their org. OSS standalone registers no role
   // resolver, so this gate is skipped and any in-org project is accepted, as
   // before. Mirrors `canManageAllProjects` in the cloud authorization service.
-  if (IS_CLOUD && project.createdByUserId !== userId) {
-    const resolver = getRoleResolver();
-    const role = resolver
-      ? await resolver.getUserRole(userId, project.organizationId)
-      : null;
-    if (!role || ROLE_HIERARCHY[role] < ROLE_HIERARCHY.admin) {
-      return null;
-    }
-  }
+  if (!(await canAccessProjectAsUser(userId, project))) return null;
 
   return project.id;
 };

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -2,7 +2,13 @@ import { Hono } from "hono";
 import type { ApiEnv } from "../types";
 import { authMiddleware, requireProjectId } from "../middleware/auth";
 import { getUser, updateProfile } from "../services/user-service";
-import { getApiKey, regenerateApiKey } from "../services/api-key-service";
+import { ensureApiKey, regenerateApiKey } from "../services/api-key-service";
+import {
+  recordAuditEvent,
+  AUDIT_ACTIONS,
+  AUDIT_SERVICES,
+  AUDIT_SOURCE,
+} from "../services/audit-service";
 import { updateProfileSchema } from "../validations/user";
 
 export const userRoutes = () => {
@@ -35,10 +41,20 @@ export const userRoutes = () => {
   // GET /user/api-key
   app.get("/api-key", async (c) => {
     const auth = c.get("auth");
-    const result = await getApiKey(auth.userId, {
-      projectId: requireProjectId(auth),
-    });
-    return c.json(result);
+    const projectId = requireProjectId(auth);
+    const { apiKey, created } = await ensureApiKey(auth.userId, { projectId });
+    if (created) {
+      await recordAuditEvent({
+        projectId,
+        userId: auth.userId,
+        userEmail: auth.userEmail,
+        action: AUDIT_ACTIONS.CREATE,
+        service: AUDIT_SERVICES.API_KEY,
+        source: AUDIT_SOURCE.API,
+        metadata: { scope: "project", autoProvisioned: true },
+      });
+    }
+    return c.json({ apiKey });
   });
 
   // POST /user/api-key/regenerate

--- a/packages/api/src/services/api-key-service.ts
+++ b/packages/api/src/services/api-key-service.ts
@@ -8,18 +8,6 @@ export const generateApiKey = (scope?: ResourceScope) => {
   return `${prefix}${randomBytes(32).toString("hex")}`;
 };
 
-export const getApiKey = async (userId: string, scope: ResourceScope) => {
-  const apiKey = await db.apiKey.findFirst({
-    where: { userId, ...scopeWhere(scope) },
-    select: { key: true },
-  });
-
-  // Not having generated a key yet is a normal state, not an error — return
-  // null so callers can render an empty / "generate" affordance instead of a
-  // 404/500. (Consumers read `result.apiKey ?? ""`.)
-  return { apiKey: apiKey?.key ?? null };
-};
-
 export const regenerateApiKey = async (
   userId: string,
   scope: ResourceScope,
@@ -47,4 +35,38 @@ export const regenerateApiKey = async (
   }
 
   return { apiKey: key };
+};
+
+/**
+ * Return the user's API key for `scope`, creating one if none exists yet.
+ * Idempotent — a single call both reads and (lazily) provisions a key for any
+ * user authorized for the scope.
+ *
+ * The dashboard read paths use it so an admin/owner viewing a project they did
+ * not create still gets *their own* key instead of an empty "no key yet" state —
+ * keys are personal (they carry the user's identity for audit/attribution), so
+ * we never surface another user's.
+ *
+ * `created` is `true` only when a key was actually minted, letting callers audit
+ * the first provision without logging on every read.
+ */
+export const ensureApiKey = async (
+  userId: string,
+  scope: ResourceScope,
+): Promise<{ apiKey: string; created: boolean }> => {
+  const existing = await db.apiKey.findFirst({
+    where: { userId, ...scopeWhere(scope) },
+    select: { key: true },
+  });
+  if (existing) return { apiKey: existing.key, created: false };
+
+  const user = await db.user.findUniqueOrThrow({
+    where: { id: userId },
+    select: { email: true },
+  });
+  const key = generateApiKey(scope);
+  await db.apiKey.create({
+    data: { key, userId, userEmail: user.email, ...scopeCreate(scope) },
+  });
+  return { apiKey: key, created: true };
 };

--- a/packages/api/src/services/audit-service.ts
+++ b/packages/api/src/services/audit-service.ts
@@ -127,3 +127,19 @@ export const withAudit = async <T>(
     invalidateGatewayCacheForOrg(params.organizationId);
   return result;
 };
+
+/**
+ * Record a single audit event directly (status defaults to SUCCESS).
+ *
+ * Use when the audited state change is conditional or has already happened, so
+ * the `withAudit` HOF — which always logs and flushes the gateway cache around a
+ * wrapped call — doesn't fit. Example: auditing an API key only when it was
+ * actually minted during a read (`ensureApiKey`). Like `logAuditEvent`, it never
+ * throws — a failed audit write must not break the parent operation.
+ */
+export const recordAuditEvent = async (params: AuditParams): Promise<void> => {
+  await logAuditEvent({
+    ...params,
+    status: params.status ?? AUDIT_STATUS.SUCCESS,
+  });
+};


### PR DESCRIPTION
## What

- **Provision per-user API keys on read.** A new `ensureApiKey()` reads-or-creates a user's personal per-project key in one call (replacing `getApiKey()`). An admin/owner who opens a project they didn't create now gets *their own* key instead of an empty "no key yet" state. Keys are personal — they carry the user's identity for audit attribution — so another user's key is never surfaced.
- **Re-check access on every API-key authentication.** A key now authenticates only while its user still has access:
  - Project keys: the user must be the project creator, or an admin/owner of the project's organization.
  - Org keys: the user must still be an admin/owner of the organization.

  This closes the gap where a key kept working after its user was demoted or removed.
- **Shared access gate.** The project access check is extracted into `canAccessProjectAsUser()`, reused by both session project resolution (`resolveProjectId`) and the API-key auth path, so the two gate access identically.
- **Auditing.** First provision is recorded via a new `recordAuditEvent()` helper, which logs a single event only when a key is actually minted (not on every read).

## Notes

- The role-based access checks run only when a role resolver is registered. Standalone single-user setups register none, so the gates are a no-op there (any in-org project is accepted, as before).
- The gateway gains matching `user_can_manage_project` / `user_is_org_admin` queries behind the existing `cloud` feature flag.

## Verification

- `cargo clippy -- -D warnings` and `cargo fmt --check` (gateway) — clean.
- `pnpm check` (lint + types + format across the monorepo) — clean.
