### PR TITLE
feat/google-service-account

### DIFF
--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -2302,6 +2302,96 @@ pub(crate) async fn refresh_via_service_account(
     Ok((access_token, now + expires_in))
 }
 
+/// JWT claims for Google SA secrets — no `sub` claim (unlike
+/// `ServiceAccountClaims` used by the Vertex AI app-connection path).
+///
+/// The `sub` claim triggers domain-wide delegation. Without DWD configured,
+/// including `sub` causes `invalid_grant` errors. The Vertex AI path
+/// tolerates it because it uses `cloud-platform` scope on GCP projects,
+/// but the generic SA secret type must omit it.
+#[derive(serde::Serialize)]
+struct GoogleSaSecretClaims<'a> {
+    iss: &'a str,
+    aud: &'static str,
+    scope: &'a str,
+    iat: i64,
+    exp: i64,
+}
+
+/// Default OAuth scope for Google SA secrets that have no explicit
+/// `metadata.scope` (covers secrets created before scope became editable).
+/// Kept in sync with the API's `GOOGLE_SA_DEFAULT_SCOPE`.
+pub(crate) const GOOGLE_SA_DEFAULT_SCOPE: &str = "https://www.googleapis.com/auth/drive";
+
+/// Refresh an access token for a Google SA *secret* (not app-connection).
+///
+/// Differs from `refresh_via_service_account`:
+/// - No `sub` claim (avoids DWD / `invalid_grant` issues)
+/// - Uses the caller-supplied `scope` (from `metadata.scope`, defaulting to the
+///   Drive scope), not `cloud-platform`. A space-separated list is supported.
+pub(crate) async fn refresh_google_sa_secret_token(
+    private_key_pem: &str,
+    client_email: &str,
+    scope: String,
+) -> anyhow::Result<(String, i64)> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs() as i64;
+
+    let claims = GoogleSaSecretClaims {
+        iss: client_email,
+        aud: "https://oauth2.googleapis.com/token",
+        scope: &scope,
+        iat: now,
+        exp: now + 3600,
+    };
+
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_pem.as_bytes())
+        .map_err(|e| anyhow::anyhow!("invalid RSA private key: {e}"))?;
+
+    let assertion = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+        &claims,
+        &key,
+    )
+    .map_err(|e| anyhow::anyhow!("JWT signing failed: {e}"))?;
+
+    let resp = reqwest::Client::new()
+        .post("https://oauth2.googleapis.com/token")
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", assertion.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("service account token request failed: {e}"))?;
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("service account token response parse failed: {e}"))?;
+
+    let access_token = body
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            let error = body
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            anyhow::anyhow!("service account token exchange failed: {error}")
+        })?
+        .to_string();
+
+    let expires_in = body
+        .get("expires_in")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(3600);
+
+    Ok((access_token, now + expires_in))
+}
+
 /// Refresh an access token using the OAuth 2.0 client_credentials grant.
 /// Used by providers like MongoDB Atlas Service Accounts that store a
 /// client_id/client_secret pair and exchange them for short-lived Bearer tokens.

--- a/apps/gateway/src/cache.rs
+++ b/apps/gateway/src/cache.rs
@@ -109,7 +109,7 @@ struct CachedEntry {
 /// Expired entries are evicted lazily on read — no background reaper.
 /// Acceptable for the gateway's bounded key space (one entry per
 /// agent×host pair), but not suitable for unbounded key sets.
-struct InMemoryCacheStore {
+pub(crate) struct InMemoryCacheStore {
     map: DashMap<String, CachedEntry>,
 }
 

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -301,6 +301,10 @@ pub(crate) struct PolicyEngine {
     /// The same `Arc` is also registered as a `VaultService` provider (where it
     /// acts only as a connection holder — it never races on hostname).
     pub onepassword: Arc<OnePasswordVaultProvider>,
+    /// Shared cache for SA token caching and other in-flight state. The same
+    /// `Arc` backs the top-level connect-response cache; holding it here lets
+    /// `resolve_secret_injections` cache SA access tokens with their own TTL.
+    pub cache: Arc<dyn CacheStore>,
 }
 
 impl PolicyEngine {
@@ -444,6 +448,20 @@ impl PolicyEngine {
 
         let mut rules = Vec::with_capacity(matching.len());
         for secret in &matching {
+            // Guard: never inject SA credentials on the token exchange endpoint.
+            // This prevents circular injection if a user sets a broad hostPattern
+            // (e.g. `*.googleapis.com`).
+            if secret.type_ == "google_service_account" {
+                let h = hostname.split(':').next().unwrap_or(hostname);
+                if h == "oauth2.googleapis.com" {
+                    debug!(
+                        secret_id = %secret.id,
+                        "skipping google_service_account injection for oauth2.googleapis.com"
+                    );
+                    continue;
+                }
+            }
+
             // Resolve the value from its source (inline column or live 1Password
             // reference); a failure skips the secret, exactly as a decrypt
             // failure always has.
@@ -462,6 +480,8 @@ impl PolicyEngine {
                     .and_then(|v| v.as_str())
                     == Some("oauth");
 
+            let is_google_sa = secret.type_ == "google_service_account";
+
             let effective_value = if is_openai_oauth {
                 match secret_inject::refresh_openai_oauth_if_expired(
                     &self.crypto,
@@ -473,6 +493,31 @@ impl PolicyEngine {
                 {
                     Some(refreshed) => refreshed,
                     None => value,
+                }
+            } else if is_google_sa {
+                // Scope is configured per-secret in metadata.scope; secrets
+                // created before it was editable have none, so fall back to the
+                // default Drive scope.
+                let scope = secret
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("scope"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.trim().is_empty())
+                    .unwrap_or(apps::GOOGLE_SA_DEFAULT_SCOPE)
+                    .to_string();
+
+                // Resolve SA JSON → access token via JWT exchange + cache.
+                match secret_inject::resolve_google_sa_token(
+                    self.cache.as_ref(),
+                    &value,
+                    &secret.id,
+                    scope,
+                )
+                .await
+                {
+                    Some(token) => token,
+                    None => continue,
                 }
             } else {
                 value

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -220,6 +220,11 @@ async fn main() -> Result<()> {
     let crypto = Arc::new(crypto::CryptoService::from_env().await?);
     info!("crypto service initialized");
 
+    // Initialize cache store (before PolicyEngine — SA token resolution needs it).
+    // OSS: in-memory DashMap. Cloud: Redis (ElastiCache with TLS + AUTH).
+    let cache = cache::create_store().await?;
+    info!("cache store created");
+
     // Build the 1Password provider once and share the Arc: the PolicyEngine
     // resolves `op://` secret values through it, and the VaultService registers
     // it as a provider (connection holder for pair/status/picker).
@@ -232,6 +237,7 @@ async fn main() -> Result<()> {
         pool,
         crypto: Arc::clone(&crypto),
         onepassword: Arc::clone(&onepassword),
+        cache: Arc::clone(&cache),
     });
 
     let proxy_url = std::env::var("BITWARDEN_PROXY_URL")
@@ -245,11 +251,8 @@ async fn main() -> Result<()> {
     let vault_service = Arc::new(VaultService::new(providers, policy_engine.pool.clone()));
     info!("vault service initialized");
 
-    // Redis (ElastiCache with TLS + AUTH) when REDIS_HOST is set, else in-memory.
-    let cache = cache::create_store().await?;
-    info!("cache store created");
-
-    // Redis + BLPOP when REDIS_HOST is set, else in-memory DashMap + channels.
+    // Initialize approval store for manual approval policy action
+    // OSS: in-memory DashMap + tokio channels. Cloud: Redis + BLPOP.
     let approval_store = approval::create_store().await?;
     info!("approval store created");
 

--- a/apps/gateway/src/secret_inject.rs
+++ b/apps/gateway/src/secret_inject.rs
@@ -1,12 +1,15 @@
-//! Secret-to-injection mapping and OpenAI OAuth token refresh.
+//! Secret-to-injection mapping, OpenAI OAuth token refresh, and Google
+//! Service Account token resolution.
 //!
 //! Converts decrypted secret values into injection instructions based on the
-//! secret type (anthropic, openai, generic). OpenAI supports both API keys
-//! (plain string) and OAuth credentials (JSON with tokens). Also handles
-//! OpenAI OAuth token refresh and credential persistence.
+//! secret type (anthropic, openai, google_service_account, generic). Also
+//! handles OpenAI OAuth token refresh, Google SA JWT→access_token exchange
+//! with in-memory caching, and credential persistence.
 
 use tracing::{debug, warn};
 
+use crate::apps;
+use crate::cache::CacheStore;
 use crate::crypto::CryptoService;
 use crate::db;
 use crate::inject::Injection;
@@ -84,6 +87,19 @@ pub(crate) fn build_injections(
                     value: format!("Bearer {decrypted_value}"),
                 }]
             }
+        }
+
+        // The effective value is already the resolved access token (not the
+        // SA JSON key) — token resolution happens in resolve_secret_injections().
+        "google_service_account" => {
+            if decrypted_value.is_empty() {
+                warn!("google_service_account secret: empty access token");
+                return vec![];
+            }
+            vec![Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: format!("Bearer {decrypted_value}"),
+            }]
         }
 
         "generic" => {
@@ -260,6 +276,153 @@ fn refresh_token_form(refresh_token: &str) -> [(&'static str, &str); 3] {
         ("grant_type", "refresh_token"),
         ("refresh_token", refresh_token),
     ]
+}
+
+/// Maximum TTL for cached Google SA access tokens (50 minutes).
+/// The actual TTL is derived from the token's `expires_at`, capped at this
+/// value with a 10-minute safety margin subtracted.
+const SA_TOKEN_MAX_CACHE_TTL_SECS: u64 = 3000;
+
+/// Safety margin subtracted from the token lifetime before caching.
+/// Ensures the cached token is still valid when eventually used.
+const SA_TOKEN_CACHE_MARGIN_SECS: u64 = 600;
+
+/// Resolve a Google Service Account secret into an access token.
+///
+/// Parses the decrypted SA JSON key, checks the in-memory cache for a valid
+/// token, and exchanges a new JWT→access_token if needed. The cache key
+/// includes a hash of the decrypted JSON so that key rotation immediately
+/// invalidates the cached token (works for both inline and 1Password sources).
+///
+/// Returns `Some(access_token)` on success, or `None` (after logging) on
+/// failure so the caller can skip the secret.
+pub(crate) async fn resolve_google_sa_token(
+    cache: &dyn CacheStore,
+    decrypted_json: &str,
+    secret_id: &str,
+    scope: String,
+) -> Option<String> {
+    // Clone for the fetcher (moved into the exchange future); the borrow is used
+    // for the cache key so a scope change immediately misses the cache.
+    let scope_for_fetch = scope.clone();
+    resolve_google_sa_token_with(cache, decrypted_json, secret_id, &scope, move |pk, ce| {
+        Box::pin(apps::refresh_google_sa_secret_token(
+            pk,
+            ce,
+            scope_for_fetch,
+        ))
+    })
+    .await
+}
+
+/// Inner implementation that accepts a token-fetcher for testability.
+async fn resolve_google_sa_token_with<F>(
+    cache: &dyn CacheStore,
+    decrypted_json: &str,
+    secret_id: &str,
+    scope: &str,
+    fetch_token: F,
+) -> Option<String>
+where
+    F: for<'a> FnOnce(
+        &'a str,
+        &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = anyhow::Result<(String, i64)>> + Send + 'a>,
+    >,
+{
+    let sa: serde_json::Value = serde_json::from_str(decrypted_json)
+        .map_err(|e| {
+            warn!(secret_id, error = %e, "google_service_account: failed to parse SA JSON");
+        })
+        .ok()?;
+
+    let private_key = sa.get("private_key").and_then(|v| v.as_str());
+    let client_email = sa.get("client_email").and_then(|v| v.as_str());
+
+    let (private_key, client_email) = match (private_key, client_email) {
+        (Some(pk), Some(ce)) => (pk, ce),
+        _ => {
+            warn!(
+                secret_id,
+                "google_service_account: missing private_key or client_email"
+            );
+            return None;
+        }
+    };
+
+    // Cache key includes a short hash of the decrypted JSON so that key
+    // rotation invalidates the cache entry. This works for both inline
+    // secrets (where encrypted_value changes) and 1Password-sourced secrets
+    // (where encrypted_value is None but the decrypted content changes).
+    // The scope is also hashed in so that editing a secret's scope immediately
+    // invalidates the cached token (which was minted for the old scope).
+    let value_hash = &sha256_hex(decrypted_json)[..16];
+    let scope_hash = &sha256_hex(scope)[..8];
+    let cache_key = format!("sa_token:{secret_id}:{value_hash}:{scope_hash}");
+
+    if let Some(token) = cache.get_raw(&cache_key).await {
+        debug!(secret_id, "google_service_account: cache hit");
+        return Some(token);
+    }
+
+    debug!(
+        secret_id,
+        "google_service_account: cache miss, exchanging JWT"
+    );
+
+    match fetch_token(private_key, client_email).await {
+        Ok((access_token, expires_at)) => {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock")
+                .as_secs() as i64;
+            let remaining = expires_at - now; // signed: can be negative
+
+            if remaining <= 0 {
+                // Token is already expired (clock skew or bad response).
+                // Do not return or cache it.
+                warn!(
+                    secret_id,
+                    remaining, "google_service_account: received already-expired token"
+                );
+                return None;
+            }
+
+            let remaining_u = remaining as u64;
+
+            if remaining_u <= SA_TOKEN_CACHE_MARGIN_SECS {
+                // Token expires soon — return it for this request but
+                // don't cache a value that will be stale shortly.
+                warn!(
+                    secret_id,
+                    remaining, "google_service_account: token lifetime too short to cache"
+                );
+                return Some(access_token);
+            }
+
+            let ttl = (remaining_u - SA_TOKEN_CACHE_MARGIN_SECS).min(SA_TOKEN_MAX_CACHE_TTL_SECS);
+            cache.set_raw(&cache_key, &access_token, ttl).await;
+            Some(access_token)
+        }
+        Err(e) => {
+            warn!(secret_id, error = ?e, "google_service_account: token exchange failed");
+            None
+        }
+    }
+}
+
+/// Compute a hex-encoded SHA-256 digest (used for cache key versioning).
+fn sha256_hex(input: &str) -> String {
+    use ring::digest;
+    let hash = digest::digest(&digest::SHA256, input.as_bytes());
+    hash.as_ref()
+        .iter()
+        .fold(String::with_capacity(64), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{b:02x}");
+            s
+        })
 }
 
 /// Refresh an OpenAI OAuth access_token using the refresh_token.
@@ -552,6 +715,32 @@ mod tests {
         assert!(injections.is_empty());
     }
 
+    // ── build_injections: google_service_account ─────────────────────
+
+    #[test]
+    fn build_injections_google_sa_bearer_token() {
+        let injections = build_injections(
+            "google_service_account",
+            "ya29.test-access-token",
+            None,
+            None,
+        );
+        assert_eq!(injections.len(), 1);
+        assert_eq!(
+            injections[0],
+            Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: "Bearer ya29.test-access-token".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn build_injections_google_sa_empty_token() {
+        let injections = build_injections("google_service_account", "", None, None);
+        assert!(injections.is_empty());
+    }
+
     // ── build_injections: unknown ──────────────────────────────────────
 
     #[test]
@@ -602,5 +791,265 @@ mod tests {
             secret_host_patterns("generic", "internal.example.com"),
             vec!["internal.example.com".to_string()]
         );
+    }
+
+    // ── resolve_google_sa_token: cache behavior ────────────────────────
+
+    /// Valid SA JSON used across resolve tests.
+    const TEST_SA_JSON: &str = r#"{"type":"service_account","private_key":"pk","client_email":"test@test.iam.gserviceaccount.com"}"#;
+
+    /// Scope passed through resolve tests.
+    const TEST_SCOPE: &str = "https://www.googleapis.com/auth/drive";
+
+    /// Expected cache key for TEST_SA_JSON + TEST_SCOPE
+    /// (mirrors resolve_google_sa_token_with's key derivation).
+    fn test_cache_key(secret_id: &str) -> String {
+        let value_hash = &sha256_hex(TEST_SA_JSON)[..16];
+        let scope_hash = &sha256_hex(TEST_SCOPE)[..8];
+        format!("sa_token:{secret_id}:{value_hash}:{scope_hash}")
+    }
+
+    /// Helper: returns a fetcher that succeeds with the given token and
+    /// an expires_at of now + `lifetime_secs`.
+    fn ok_fetcher(
+        token: &str,
+        lifetime_secs: i64,
+    ) -> impl for<'a> FnOnce(
+        &'a str,
+        &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = anyhow::Result<(String, i64)>> + Send + 'a>,
+    > {
+        let token = token.to_string();
+        move |_pk, _ce| {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_secs() as i64;
+            Box::pin(async move { Ok((token, now + lifetime_secs)) })
+        }
+    }
+
+    /// Helper: returns a fetcher that always fails.
+    fn err_fetcher() -> impl for<'a> FnOnce(
+        &'a str,
+        &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = anyhow::Result<(String, i64)>> + Send + 'a>,
+    > {
+        |_pk, _ce| Box::pin(async { Err(anyhow::anyhow!("exchange failed")) })
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_cache_hit() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let secret_id = "secret_123";
+
+        // Pre-populate cache
+        let cache_key = test_cache_key(secret_id);
+        cache.set_raw(&cache_key, "ya29.cached-token", 3000).await;
+
+        // The fetcher should NOT be called (cache hit).
+        let result = resolve_google_sa_token_with(
+            &cache,
+            TEST_SA_JSON,
+            secret_id,
+            TEST_SCOPE,
+            |_pk, _ce| Box::pin(async { panic!("fetcher should not be called on cache hit") }),
+        )
+        .await;
+        assert_eq!(result.as_deref(), Some("ya29.cached-token"));
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_cache_miss_exchanges_and_caches() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let secret_id = "s1";
+
+        let result = resolve_google_sa_token_with(
+            &cache,
+            TEST_SA_JSON,
+            secret_id,
+            TEST_SCOPE,
+            ok_fetcher("ya29.fresh-token", 3600),
+        )
+        .await;
+
+        // Token returned
+        assert_eq!(result.as_deref(), Some("ya29.fresh-token"));
+
+        // Token was cached
+        let cache_key = test_cache_key(secret_id);
+        let cached = cache.get_raw(&cache_key).await;
+        assert_eq!(cached.as_deref(), Some("ya29.fresh-token"));
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_exchange_failure_not_cached() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let secret_id = "s1";
+
+        let result = resolve_google_sa_token_with(
+            &cache,
+            TEST_SA_JSON,
+            secret_id,
+            TEST_SCOPE,
+            err_fetcher(),
+        )
+        .await;
+
+        // Returns None on failure
+        assert!(result.is_none());
+
+        // Nothing cached
+        let cache_key = test_cache_key(secret_id);
+        assert!(cache.get_raw(&cache_key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_nearly_expired_not_cached() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let secret_id = "s1";
+
+        // Token expires in 5 minutes — less than the 10-minute margin
+        let result = resolve_google_sa_token_with(
+            &cache,
+            TEST_SA_JSON,
+            secret_id,
+            TEST_SCOPE,
+            ok_fetcher("ya29.short-lived", 300),
+        )
+        .await;
+
+        // Token still returned for this request
+        assert_eq!(result.as_deref(), Some("ya29.short-lived"));
+
+        // But NOT cached (lifetime too short)
+        let cache_key = test_cache_key(secret_id);
+        assert!(cache.get_raw(&cache_key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_expired_entry_triggers_exchange() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let secret_id = "s1";
+
+        // Insert an already-expired cache entry (TTL=0)
+        let cache_key = test_cache_key(secret_id);
+        cache.set_raw(&cache_key, "ya29.stale", 0).await;
+
+        // Should trigger a fresh exchange (cache miss due to expiry)
+        let result = resolve_google_sa_token_with(
+            &cache,
+            TEST_SA_JSON,
+            secret_id,
+            TEST_SCOPE,
+            ok_fetcher("ya29.refreshed", 3600),
+        )
+        .await;
+
+        assert_eq!(result.as_deref(), Some("ya29.refreshed"));
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_already_expired_fetch_result() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let secret_id = "s1";
+
+        // Exchange returns a token whose expires_at is already in the past
+        let result = resolve_google_sa_token_with(
+            &cache,
+            TEST_SA_JSON,
+            secret_id,
+            TEST_SCOPE,
+            ok_fetcher("ya29.already-expired", -60), // expired 60s ago
+        )
+        .await;
+
+        // Must NOT return or cache the expired token
+        assert!(result.is_none(), "expired token must not be returned");
+
+        let cache_key = test_cache_key(secret_id);
+        assert!(
+            cache.get_raw(&cache_key).await.is_none(),
+            "expired token must not be cached"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_invalid_json() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let result =
+            resolve_google_sa_token_with(&cache, "not-json", "s1", TEST_SCOPE, |_pk, _ce| {
+                Box::pin(async { panic!("should not reach fetcher") })
+            })
+            .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_missing_fields() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        // Missing private_key
+        let sa_json =
+            r#"{"type":"service_account","client_email":"test@test.iam.gserviceaccount.com"}"#;
+        let result = resolve_google_sa_token_with(&cache, sa_json, "s1", TEST_SCOPE, |_pk, _ce| {
+            Box::pin(async { panic!("should not reach fetcher") })
+        })
+        .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_cache_key_changes_on_rotation() {
+        // Verify that different decrypted JSON produces a different cache key,
+        // ensuring key rotation invalidates the cache for both inline and
+        // 1Password-sourced secrets.
+        let json_v1 = r#"{"type":"service_account","private_key":"pk_v1","client_email":"a@test.iam.gserviceaccount.com"}"#;
+        let json_v2 = r#"{"type":"service_account","private_key":"pk_v2","client_email":"a@test.iam.gserviceaccount.com"}"#;
+        let hash1 = &sha256_hex(json_v1)[..16];
+        let hash2 = &sha256_hex(json_v2)[..16];
+        assert_ne!(
+            hash1, hash2,
+            "different decrypted JSON must produce different cache keys"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_google_sa_token_scope_change_misses_cached_token() {
+        let cache = crate::cache::InMemoryCacheStore::new();
+        let secret_id = "s1";
+
+        // Token cached under the default scope.
+        let cache_key = test_cache_key(secret_id);
+        cache.set_raw(&cache_key, "ya29.drive-scoped", 3000).await;
+
+        // Resolving with a different scope must NOT hit that entry — it mints a
+        // fresh token for the new scope instead.
+        let result = resolve_google_sa_token_with(
+            &cache,
+            TEST_SA_JSON,
+            secret_id,
+            "https://www.googleapis.com/auth/spreadsheets",
+            ok_fetcher("ya29.sheets-scoped", 3600),
+        )
+        .await;
+
+        assert_eq!(result.as_deref(), Some("ya29.sheets-scoped"));
+    }
+
+    // ── sha256_hex ─────────────────────────────────────────────────────
+
+    #[test]
+    fn sha256_hex_deterministic() {
+        let h1 = sha256_hex("hello");
+        let h2 = sha256_hex("hello");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64); // 32 bytes = 64 hex chars
+    }
+
+    #[test]
+    fn sha256_hex_different_inputs() {
+        assert_ne!(sha256_hex("a"), sha256_hex("b"));
     }
 }

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/connections/_components/secret-card.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/connections/_components/secret-card.tsx
@@ -30,6 +30,7 @@ import {
   isParamInjection,
   isPathRegexInjection,
   isPathTemplateInjection,
+  parseGoogleServiceAccountMetadata,
 } from "@onecli/api/validations/secret";
 import { SecretDialog } from "./secret-dialog";
 
@@ -88,6 +89,10 @@ export const SecretCard = ({
           | { vault: string; item: string; field: string }
           | undefined)
       : undefined;
+  const saMeta =
+    secret.type === "google_service_account"
+      ? parseGoogleServiceAccountMetadata(secret.metadata)
+      : null;
 
   return (
     <>
@@ -129,6 +134,14 @@ export const SecretCard = ({
                   Value:{" "}
                   <code className="bg-muted rounded px-1 py-0.5 font-mono">
                     {opDisplay.vault} › {opDisplay.item} › {opDisplay.field}
+                  </code>
+                </span>
+              )}
+              {saMeta && (
+                <span className="text-muted-foreground">
+                  Email:{" "}
+                  <code className="bg-muted rounded px-1 py-0.5 font-mono">
+                    {saMeta.clientEmail}
                   </code>
                 </span>
               )}

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/connections/_components/secret-dialog.tsx
@@ -46,6 +46,8 @@ import { useOnePasswordReady } from "@/hooks/use-onepassword-picker";
 import { validateDisplayName } from "@onecli/api/validations/display-name";
 import {
   type InjectionConfig,
+  GOOGLE_SA_DEFAULT_HOST,
+  GOOGLE_SA_DEFAULT_SCOPE,
   detectAnthropicAuthMode,
   isHeaderInjection,
   isParamInjection,
@@ -53,10 +55,11 @@ import {
   isPathTemplateInjection,
   looksLikeAnthropicKey,
   looksLikeOpenaiKey,
+  parseGoogleServiceAccountJson,
   parseOpenaiAuthJson,
 } from "@onecli/api/validations/secret";
 
-type SecretType = "anthropic" | "openai" | "generic";
+type SecretType = "anthropic" | "openai" | "generic" | "google_service_account";
 
 interface SecretTypeOption {
   value: SecretType;
@@ -90,6 +93,20 @@ const OpenAIIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+const GoogleIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+  >
+    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+  </svg>
+);
+
 const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
   {
     value: "anthropic",
@@ -107,6 +124,15 @@ const SECRET_TYPE_OPTIONS: SecretTypeOption[] = [
     icon: <OpenAIIcon className="size-5" />,
     hostDefault: "api.openai.com",
     nameDefault: "OpenAI Token",
+  },
+  {
+    value: "google_service_account",
+    label: "Google Service Account",
+    description:
+      "Inject a Google SA Bearer token into requests to googleapis.com",
+    icon: <GoogleIcon className="size-5" />,
+    hostDefault: GOOGLE_SA_DEFAULT_HOST,
+    nameDefault: "Google Service Account",
   },
   {
     value: "generic",
@@ -227,10 +253,13 @@ export const SecretDialog = ({
   const [type, setType] = useState<SecretType>("anthropic");
   const [openaiMode, setOpenaiMode] = useState<"api-key" | "codex">("api-key");
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const saFileInputRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState("");
   const [nameTouched, setNameTouched] = useState(false);
   const [value, setValue] = useState("");
   const [hostPattern, setHostPattern] = useState("api.anthropic.com");
+  // OAuth scope for Google Service Account secrets; space-separated list allowed.
+  const [scope, setScope] = useState(GOOGLE_SA_DEFAULT_SCOPE);
   const [pathPattern, setPathPattern] = useState("");
   const [injectionTarget, setInjectionTarget] = useState<
     "header" | "param" | "path"
@@ -257,6 +286,15 @@ export const SecretDialog = ({
   const fromOnePassword = !!opSelection;
   const isOAuthMode =
     type === "openai" && openaiMode === "codex" && !fromOnePassword;
+
+  const isGoogleSA = type === "google_service_account";
+  const parsedSA = useMemo(
+    () =>
+      isGoogleSA && value.trim()
+        ? parseGoogleServiceAccountJson(value.trim())
+        : null,
+    [isGoogleSA, value],
+  );
 
   const nameError = useMemo(() => validateDisplayName(name), [name]);
   const showNameError = nameTouched && nameError !== null;
@@ -288,6 +326,7 @@ export const SecretDialog = ({
       setPathTemplate("");
       setPathRegex("");
       setPathReplacement("");
+      setScope(GOOGLE_SA_DEFAULT_SCOPE);
       if (secret) {
         const config = secret.injectionConfig as InjectionConfig | null;
         setStep("form");
@@ -303,6 +342,14 @@ export const SecretDialog = ({
         setName(secret.name);
         setValue("");
         setHostPattern(secret.hostPattern);
+        if (secret.type === "google_service_account") {
+          const savedScope = secret.metadata?.scope;
+          setScope(
+            typeof savedScope === "string" && savedScope.trim()
+              ? savedScope
+              : GOOGLE_SA_DEFAULT_SCOPE,
+          );
+        }
         setPathPattern(secret.pathPattern ?? "");
         if (isParamInjection(config)) {
           setInjectionTarget("param");
@@ -389,6 +436,11 @@ export const SecretDialog = ({
     const option = SECRET_TYPE_OPTIONS.find((o) => o.value === selected);
     setHostPattern(option?.hostDefault ?? "");
     setName(option?.nameDefault ?? "");
+    if (selected === "google_service_account") {
+      setOpSelection(null);
+      setValue("");
+      setScope(GOOGLE_SA_DEFAULT_SCOPE);
+    }
     setStep("form");
   };
 
@@ -406,6 +458,11 @@ export const SecretDialog = ({
         ? paramName.trim().length > 0
         : hasPathTarget);
 
+  const saValueValid = !isGoogleSA || !value.trim() || !!parsedSA;
+
+  // Google rejects an empty `scope` claim, so require a non-empty scope for SA.
+  const scopeValid = !isGoogleSA || scope.trim().length > 0;
+
   const pathPreview = useMemo(
     () =>
       injectionTarget === "path"
@@ -415,19 +472,25 @@ export const SecretDialog = ({
   );
 
   const isValid = isEdit
-    ? hostPattern.trim() && !hostPatternError && hasInjectionTarget
+    ? hostPattern.trim() &&
+      !hostPatternError &&
+      hasInjectionTarget &&
+      saValueValid &&
+      scopeValid
     : isNameValid &&
-      (fromOnePassword || !!value.trim()) &&
+      ((!isGoogleSA && fromOnePassword) || !!value.trim()) &&
       hostPattern.trim() &&
       !hostPatternError &&
-      hasInjectionTarget;
+      hasInjectionTarget &&
+      saValueValid &&
+      scopeValid;
 
   const handleSave = async () => {
     if (!isValid) return;
     setSaving(true);
     try {
       const buildInjectionConfig = () => {
-        if (type !== "generic") return undefined;
+        if (type !== "generic") return null;
         if (injectionTarget === "param") {
           return { paramName, paramFormat: paramFormat || "{value}" };
         }
@@ -459,6 +522,7 @@ export const SecretDialog = ({
           hostPattern,
           pathPattern: pathPattern || null,
           injectionConfig: buildInjectionConfig() ?? undefined,
+          ...(isGoogleSA ? { scope: scope.trim() } : {}),
         });
         toast.success("Secret updated");
       } else {
@@ -473,6 +537,7 @@ export const SecretDialog = ({
                 hostPattern,
                 pathPattern: pathPattern || undefined,
                 injectionConfig: buildInjectionConfig() ?? null,
+                ...(isGoogleSA ? { scope: scope.trim() } : {}),
               }
             : {
                 name,
@@ -481,6 +546,7 @@ export const SecretDialog = ({
                 hostPattern,
                 pathPattern: pathPattern || undefined,
                 injectionConfig: buildInjectionConfig() ?? null,
+                ...(isGoogleSA ? { scope: scope.trim() } : {}),
               },
         );
         toast.success("Secret created");
@@ -541,6 +607,26 @@ export const SecretDialog = ({
     e.target.value = "";
   };
 
+  const handleSaFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const contents = (ev.target?.result as string)?.trim();
+      if (!contents) return;
+      const sa = parseGoogleServiceAccountJson(contents);
+      if (!sa) {
+        toast.error(
+          'Invalid service account JSON — must contain type "service_account", private_key, and client_email',
+        );
+        return;
+      }
+      setValue(contents);
+    };
+    reader.readAsText(file);
+    e.target.value = "";
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg max-h-[calc(100dvh-2rem)] grid-rows-[auto_1fr_auto]">
@@ -569,7 +655,9 @@ export const SecretDialog = ({
                     ? "Your key will be encrypted and injected into requests to api.anthropic.com."
                     : type === "openai"
                       ? `Inject credentials into requests to ${openaiMode === "codex" ? "chatgpt.com" : "api.openai.com"}.`
-                      : "Configure a custom secret to inject as a header, URL parameter, or URL path into matching requests."}
+                      : isGoogleSA
+                        ? "Upload a service account JSON key. The gateway will sign JWTs and inject Bearer tokens automatically."
+                        : "Configure a custom secret to inject as a header, URL parameter, or URL path into matching requests."}
               </DialogDescription>
               {type === "generic" && !isEdit && !prefill && (
                 <div className="flex items-center gap-2 pt-1">
@@ -758,7 +846,9 @@ export const SecretDialog = ({
 
               <div className="space-y-2">
                 <Label htmlFor="secret-value">
-                  {isOAuthMode ? (
+                  {isGoogleSA ? (
+                    "Service account JSON key"
+                  ) : isOAuthMode ? (
                     <>
                       Token file{" "}
                       <code className="bg-muted text-muted-foreground ml-1 select-all rounded px-1.5 py-0.5 text-xs font-normal">
@@ -770,11 +860,14 @@ export const SecretDialog = ({
                   ) : (
                     "Secret value"
                   )}{" "}
-                  {isEdit && !isOAuthMode && !fromOnePassword && (
-                    <span className="text-muted-foreground font-normal">
-                      (leave empty to keep current)
-                    </span>
-                  )}
+                  {isEdit &&
+                    !isGoogleSA &&
+                    !isOAuthMode &&
+                    !fromOnePassword && (
+                      <span className="text-muted-foreground font-normal">
+                        (leave empty to keep current)
+                      </span>
+                    )}
                 </Label>
 
                 <input
@@ -784,6 +877,13 @@ export const SecretDialog = ({
                   className="hidden"
                   onChange={handleFileUpload}
                 />
+                <input
+                  ref={saFileInputRef}
+                  type="file"
+                  accept=".json,application/json"
+                  className="hidden"
+                  onChange={handleSaFileUpload}
+                />
 
                 {opSelection ? (
                   <OnePasswordSelectedField
@@ -791,6 +891,93 @@ export const SecretDialog = ({
                     onChange={() => setPickerOpen(true)}
                     onClear={() => setOpSelection(null)}
                   />
+                ) : isGoogleSA ? (
+                  <>
+                    <textarea
+                      id="secret-value"
+                      className={cn(
+                        "border-input bg-background placeholder:text-muted-foreground flex min-h-[120px] w-full rounded-md border px-3 py-2 font-mono text-xs shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                        value.trim() && !parsedSA && "border-destructive",
+                      )}
+                      placeholder="Paste your service account JSON key or upload the .json file..."
+                      value={value}
+                      onChange={(e) => setValue(e.target.value)}
+                    />
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-xs transition-colors"
+                        onClick={() => saFileInputRef.current?.click()}
+                      >
+                        <Upload className="size-3" />
+                        Upload .json file
+                      </button>
+                    </div>
+                    {value.trim() && !parsedSA && (
+                      <p className="text-xs text-red-500">
+                        Invalid JSON — must contain{" "}
+                        <code className="text-[11px]">
+                          type: &quot;service_account&quot;
+                        </code>
+                        , <code className="text-[11px]">private_key</code>, and{" "}
+                        <code className="text-[11px]">client_email</code>.
+                      </p>
+                    )}
+                    {parsedSA && (
+                      <div className="bg-muted/40 space-y-1 rounded-md border p-3">
+                        <span className="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
+                          Detected
+                        </span>
+                        <div className="space-y-0.5 text-xs">
+                          <div>
+                            <span className="text-muted-foreground">
+                              Email:{" "}
+                            </span>
+                            <code className="text-foreground">
+                              {parsedSA.client_email}
+                            </code>
+                          </div>
+                          {parsedSA.project_id && (
+                            <div>
+                              <span className="text-muted-foreground">
+                                Project:{" "}
+                              </span>
+                              <code className="text-foreground">
+                                {parsedSA.project_id}
+                              </code>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                    <div className="space-y-1.5">
+                      <Label htmlFor="sa-scope">OAuth scope</Label>
+                      <Input
+                        id="sa-scope"
+                        value={scope}
+                        onChange={(e) => setScope(e.target.value)}
+                        placeholder={GOOGLE_SA_DEFAULT_SCOPE}
+                        className={cn(
+                          "font-mono text-xs",
+                          !scope.trim() && "border-destructive",
+                        )}
+                      />
+                      {!scope.trim() ? (
+                        <p className="text-xs text-red-500">
+                          Scope is required.
+                        </p>
+                      ) : (
+                        <p className="text-muted-foreground text-xs">
+                          Access token is minted for this scope. Separate
+                          multiple scopes with spaces (e.g.{" "}
+                          <code className="text-[11px]">
+                            .../auth/drive .../auth/spreadsheets
+                          </code>
+                          ).
+                        </p>
+                      )}
+                    </div>
+                  </>
                 ) : isOAuthMode ? (
                   <>
                     {value ? (

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/connections/_components/secrets-content.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/connections/_components/secrets-content.tsx
@@ -55,8 +55,9 @@ export const SecretsContent = ({
   const [prefill, setPrefill] = useState<SecretPrefill | undefined>();
   const paramHandled = useRef(false);
 
+  const LLM_TYPES = new Set(["anthropic", "openai"]);
   const allFiltered = secrets.filter((s: Secret) =>
-    typeFilter === "generic" ? s.type === "generic" : s.type !== "generic",
+    typeFilter === "llm" ? LLM_TYPES.has(s.type) : !LLM_TYPES.has(s.type),
   );
   const ownSecrets = allFiltered.filter(
     (s: Secret) => s.scope === pageScope || !s.scope,
@@ -194,9 +195,11 @@ export const SecretsContent = ({
           if (!open) setPrefill(undefined);
         }}
         prefill={prefill}
-        defaultType={typeFilter === "generic" ? "generic" : undefined}
+        defaultType={undefined}
         allowedTypes={
-          typeFilter === "llm" ? ["anthropic", "openai"] : undefined
+          typeFilter === "llm"
+            ? ["anthropic", "openai"]
+            : ["generic", "google_service_account"]
         }
         secretActions={secretActions}
       />

--- a/docs/issues-google-service-account.md
+++ b/docs/issues-google-service-account.md
@@ -1,0 +1,323 @@
+# Google Service Account Support — Issue Plan
+
+> Generated from codebase analysis on 2026-07-06
+> Updated: 2026-07-06 — review round 1 (sub claim, hostPattern, async strategy, cache strategy)
+> Updated: 2026-07-06 — review round 2 (restore integration tests, cache key versioning, scope/hostPattern UX hint)
+
+## Architecture Overview
+
+The system currently supports 3 secret types (`anthropic`, `openai`, `generic`). Adding `google_service_account` follows the existing Secret flow:
+
+1. **Web UI** → secret-dialog.tsx accepts SA JSON key
+2. **Service layer** → validates JSON, encrypts with AES-256-GCM, stores in `Secret.encryptedValue`
+3. **Gateway (Rust)** → `connect.rs` resolves SA token (JWT sign + exchange), `secret_inject.rs` injects Bearer token
+
+**Key reuse:** The Vertex AI provider already implements the exact JWT→access_token exchange in `apps/gateway/src/apps.rs:1541-1615` (`refresh_via_service_account()`). The new secret type reuses this signing logic but from the Secret path (not AppConnection).
+
+### Key Files
+
+| Component                   | File                                                                       |
+| --------------------------- | -------------------------------------------------------------------------- |
+| Zod validation              | `packages/api/src/validations/secret.ts`                                   |
+| Service layer               | `packages/api/src/services/secret-service.ts`                              |
+| Encryption                  | `packages/api/src/lib/crypto.ts`                                           |
+| Gateway secret resolution   | `apps/gateway/src/connect.rs` (L242-346, L948-1057)                        |
+| Gateway injection builder   | `apps/gateway/src/secret_inject.rs`                                        |
+| Gateway JWT signing (reuse) | `apps/gateway/src/apps.rs` (L1541-1615)                                    |
+| Web UI dialog               | `apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx`   |
+| Web UI card                 | `apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx`     |
+| Web UI content              | `apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx` |
+| Validation tests            | `packages/api/src/validations/secret.test.ts`                              |
+
+---
+
+## Issue #1: feat(api): add `google_service_account` secret type — validation & service layer
+
+### Summary
+
+Add `google_service_account` as a new secret type alongside `anthropic`, `openai`, and `generic`. This is the data-layer foundation for Google Service Account credential support.
+
+### Context
+
+- `Secret.type` is already a free-form `String` in Prisma — no migration needed
+- SA JSON keys contain `private_key`, `client_email`, `project_id`, `type: "service_account"`
+- These are stored encrypted (AES-256-GCM) in `Secret.encryptedValue`
+
+### Requirements
+
+#### Zod Validation (`packages/api/src/validations/secret.ts`)
+
+- Add `"google_service_account"` to `z.enum` for `type` (~line 204)
+- Add value validation: parse JSON, require `type === "service_account"`, `private_key`, `client_email`
+- Default `hostPattern` to `www.googleapis.com` (NOT `*.googleapis.com` — see note below)
+- `injectionConfig` should be `null` (gateway handles injection internally)
+
+#### Service Layer (`packages/api/src/services/secret-service.ts`)
+
+- Add label: `google_service_account: "Google Service Account"` (~line 34)
+- Add metadata extraction: `{ projectId, clientEmail }` (non-sensitive fields only)
+- Value normalization: validate JSON structure on create/update, similar to OpenAI OAuth JSON handling
+
+#### No Prisma Migration
+
+- `Secret.type` is `String` — no enum change needed
+- **Important:** Verify existing queries don't hard-code only the 3 current types. Known hard-coded locations:
+  - `apps/web/src/lib/actions/secrets.ts:97,106` — queries filtering by `type: "anthropic"` / `type: "openai"`
+  - `apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx:59` — `type SecretType = "anthropic" | "openai" | "generic"`
+  - `apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx:61` — filter logic uses `s.type === "generic"` vs not (SA will correctly fall into "not generic")
+  - `apps/web/src/app/(dashboard)/connections/_components/secrets-content.tsx:201` — `["anthropic", "openai"]` limits type dropdown in LLM view
+
+#### hostPattern: why `www.googleapis.com` not `*.googleapis.com`
+
+- `*.googleapis.com` would match `oauth2.googleapis.com`, which is the token exchange endpoint. This risks circular injection (inject → exchange → inject).
+- It also collides with existing Vertex AI app connections (`*-aiplatform.googleapis.com`).
+- Users can override to a broader pattern if needed, but the safe default is `www.googleapis.com`.
+
+### Done When
+
+- `google_service_account` accepted as valid secret type in create/update APIs
+- SA JSON key validated (required fields: `type`, `private_key`, `client_email`)
+- Default hostPattern is `www.googleapis.com`
+- Existing tests pass
+- New validation tests added for the new type
+
+---
+
+## Issue #2: feat(web): SA JSON key upload UI in secret dialog
+
+### Summary
+
+Add `google_service_account` option to the secret creation dialog with JSON key file upload/paste support.
+
+### Context
+
+- Secret dialog at `apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx`
+- Secret card at `apps/web/src/app/(dashboard)/connections/_components/secret-card.tsx`
+- Follows existing patterns: type selector dropdown, value input, host pattern auto-fill
+
+### Requirements
+
+#### Secret Dialog (`secret-dialog.tsx`)
+
+- Update `SecretType` union type (line 59) to include `"google_service_account"`
+- Add "Google Service Account" to type selector options array (~line 95)
+- When selected:
+  - Show textarea/file-upload for SA JSON key (similar to OpenAI OAuth JSON input)
+  - Auto-fill `hostPattern` to `www.googleapis.com`
+  - Hide injection config section (not user-configurable for this type)
+  - Validate JSON on paste/upload: check `type === "service_account"`, `private_key`, `client_email` present
+  - Show extracted `client_email` and `project_id` as read-only metadata preview
+  - Display scope hint: e.g. "MVP: Drive read-only access (drive.readonly). Broader scopes coming soon." — this prevents user confusion when they widen hostPattern but hit 403s due to insufficient scope.
+- File upload: accept `.json` files, read and populate textarea
+
+#### Secret Card (`secret-card.tsx`)
+
+- Display "Google Service Account" badge for `google_service_account` type
+- Show `client_email` from metadata (if available)
+
+#### Secrets Content (`secrets-content.tsx`)
+
+- `google_service_account` is NOT an LLM type — the existing filter `s.type === "generic" ? ... : s.type !== "generic"` correctly places it in the non-generic (i.e. "connections") tab. Verify this works correctly.
+- Consider whether SA secrets should appear in the "Custom" tab (generic filter) or a new category. For MVP, they should appear alongside apps/connections.
+
+#### Host Pattern
+
+- Default to `www.googleapis.com` when type is selected
+- Allow user override (some users may want broader patterns for specific APIs)
+
+### Done When
+
+- User can create a `google_service_account` secret via UI
+- JSON key is validated before submission
+- Metadata (clientEmail, projectId) displayed on card
+- Default hostPattern is `www.googleapis.com`
+- Existing secret types unaffected
+
+---
+
+## Issue #3: feat(gateway): JWT signing & Bearer token injection for `google_service_account` secrets
+
+### Summary
+
+Add gateway-side JWT signing, token exchange, in-memory caching, and Bearer injection for `google_service_account` secrets targeting `www.googleapis.com` requests.
+
+### Context
+
+The Vertex AI provider already implements the JWT→access_token pattern in `apps/gateway/src/apps.rs:1541-1615`:
+
+- `refresh_via_service_account()` — signs JWT with RS256, exchanges at `oauth2.googleapis.com/token`
+- Uses `jsonwebtoken` crate for signing
+
+The new secret type needs a similar flow but triggered from the **Secret** path (not AppConnection).
+
+### Requirements
+
+#### Architecture: Follow existing async token resolution pattern (Option 2)
+
+The existing code resolves tokens in the **connect phase** (`resolve_secret_injections()` at `connect.rs:242-346`), then passes the resolved value to the sync `build_injections()`. Evidence:
+
+- OpenAI OAuth: `refresh_openai_oauth_if_expired()` is called at `connect.rs:307-318` **before** `build_injections()` at line 323
+- AppConnection tokens: `resolve_access_token()` at `connect.rs:948-1057` handles token refresh in the connect phase
+
+**Do NOT make `build_injections()` async.** Instead, add a new `resolve_google_sa_token()` async function called from `resolve_secret_injections()`, following the exact same pattern as OpenAI OAuth refresh.
+
+#### Token Resolution (`apps/gateway/src/connect.rs`)
+
+- In `resolve_secret_injections()`, after value resolution (~line 296):
+  - If `secret.type_ == "google_service_account"`: call `resolve_google_sa_token()`
+  - Parse decrypted JSON to extract `private_key` and `client_email`
+  - Check in-memory cache for a valid (non-expired) access token
+  - If cache miss or expired: call `refresh_via_service_account()` (reuse from `apps.rs`)
+  - Store result in in-memory cache
+  - Return the access token as the effective value
+
+#### JWT Claims (NO `sub` claim)
+
+- `iss`: client_email
+- `aud`: `https://oauth2.googleapis.com/token`
+- `scope`: `https://www.googleapis.com/auth/drive.readonly`
+- `iat`: now
+- `exp`: now + 3600
+
+**Do NOT include `sub`.** The `sub` claim is for domain-wide delegation (impersonating a user). Without DWD, `sub` is unnecessary and can cause `invalid_grant` errors. The existing Vertex AI code (`apps.rs:1565`) does include `sub: client_email`, but that's for GCP cloud-platform scope where it's tolerated. For the new generic SA secret type, omit it. Note: this means we need a new JWT claims struct (or make `sub` optional in the existing one) rather than reusing `ServiceAccountClaims` directly.
+
+#### Secret Injection (`apps/gateway/src/secret_inject.rs`)
+
+- Add `"google_service_account"` match arm in `build_injections()`
+- The effective value passed in will already be the resolved access token (not the SA JSON)
+- Return `SetHeader("authorization", "Bearer {access_token}")`
+
+#### Token Caching: In-Memory TTL (NOT DB write-back)
+
+- Use in-memory cache with ~50 minute TTL (3000 seconds)
+- **Cache key:** `sa_token:{secret_id}:{hash_of_encrypted_value}` (or use `updatedAt` timestamp). Including a value-version component ensures that when a user rotates the SA key via the dashboard, the cache is immediately invalidated rather than serving a stale token for up to 50 minutes. The existing injection rules cache (`connect.rs:636-650`) uses a fixed key per connection and relies on short TTL (60s) — our longer TTL requires explicit version-awareness.
+- **Do NOT write back to `encryptedValue`** — mixing immutable SA keys with volatile cache tokens creates write contention and complicates key rotation
+- Gateway restart = token re-exchange (negligible cost: one HTTP round-trip per SA)
+
+#### Safety: Guard against `oauth2.googleapis.com` injection
+
+- In `resolve_secret_injections()` or `build_injections()`, explicitly skip injection when hostname is `oauth2.googleapis.com`
+- This prevents circular injection if a user sets a broader hostPattern
+
+### Done When
+
+- Agent request to `www.googleapis.com` with an assigned `google_service_account` secret gets Bearer token injected
+- Token is refreshed automatically when expired (~50 min cache)
+- JWT does not contain `sub` claim
+- In-memory cache, no DB write-back for access tokens
+- `oauth2.googleapis.com` requests are explicitly excluded from injection
+- `build_injections()` remains synchronous
+- Gateway compiles and existing tests pass
+
+---
+
+## Issue #4: test: unit & integration tests for `google_service_account` flow
+
+### Summary
+
+Add tests covering the full SA secret flow: validation, service layer, and gateway injection.
+
+### Context
+
+- Validation tests: `packages/api/src/validations/secret.test.ts` (Vitest, `describe`/`it.each` patterns)
+- Service tests: `packages/api/src/services/api-key-service.test.ts` (mock DB pattern)
+- Gateway inline tests: `apps/gateway/src/secret_inject.rs` (`#[cfg(test)]` module)
+- Gateway integration tests: `apps/gateway/tests/integration.rs`
+
+### Requirements
+
+#### Validation Tests (`packages/api/src/validations/secret.test.ts`)
+
+- Valid SA JSON key accepted
+- Missing `private_key` rejected
+- Missing `client_email` rejected
+- Wrong `type` field rejected (e.g., `type: "authorized_user"`)
+- Non-JSON value rejected
+- Default hostPattern set to `www.googleapis.com`
+
+#### Service Layer Tests
+
+- Create google_service_account secret — metadata extracted correctly
+- Update — re-validates JSON
+- Metadata contains `projectId` and `clientEmail` (not `private_key`)
+
+#### Gateway Inline Tests (`apps/gateway/src/secret_inject.rs` — `#[cfg(test)]`)
+
+- `build_injections("google_service_account", ...)` returns correct `SetHeader("authorization", "Bearer {token}")`
+- Unknown/malformed effective value returns empty injections
+
+#### Gateway Token Resolution Tests (`resolve_google_sa_token`)
+
+**This is the most critical test surface — the core logic lives here.**
+
+- Cache hit: returns cached token without calling `refresh_via_service_account()` (no HTTP exchange)
+- Cache miss: calls `refresh_via_service_account()`, stores result in cache, returns token
+- Expired cache entry: triggers re-exchange via `refresh_via_service_account()`
+- Token exchange failure: returns error, does not cache a failed result
+- Cache key versioning: after SA key rotation (changed `encryptedValue`), old cache entry is not used
+- Determine test approach at implementation time: check if `apps/gateway/tests/integration.rs` has existing patterns for mocking HTTP (e.g., mock server for `oauth2.googleapis.com/token`) or if unit tests with dependency injection are more appropriate
+
+#### Security Tests (important)
+
+- SA JSON `private_key` never appears in log output, error messages, or traces
+- Metadata extraction excludes `private_key` from stored metadata
+- Token exchange errors don't leak the private key in error strings
+
+### Done When
+
+- All new tests pass
+- Existing tests unaffected
+- Coverage for happy path + key error cases
+- `resolve_google_sa_token` cache behavior tested (hit, miss, expiry, rotation)
+- Security: private key never leaks into logs/metadata
+
+---
+
+## Review Corrections Applied
+
+| #   | Original                                                 | Corrected                                   | Rationale                                                                                                           |
+| --- | -------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 1   | JWT includes `sub: client_email`                         | **Remove `sub` claim**                      | `sub` is for domain-wide delegation impersonation; unnecessary without DWD and can cause `invalid_grant`            |
+| 2   | Default hostPattern `*.googleapis.com`                   | **Default `www.googleapis.com`**            | Prevents circular injection on `oauth2.googleapis.com` and collision with Vertex AI `*-aiplatform.googleapis.com`   |
+| 3   | Async option 1 preferred (make `build_injections` async) | **Option 2: pre-resolve in connect phase**  | Matches existing OpenAI OAuth pattern (`connect.rs:307-318`); keeps `build_injections()` sync; smaller blast radius |
+| 4   | Cache via DB write-back to `encryptedValue`              | **In-memory TTL cache**                     | Separates immutable credentials from volatile tokens; avoids write contention; simpler key rotation                 |
+| 5   | —                                                        | **Guard `oauth2.googleapis.com`**           | Explicit skip to prevent injection on token exchange endpoint                                                       |
+| 6   | —                                                        | **Security test: private key not in logs**  | Added to Issue #4 test requirements                                                                                 |
+| 7   | Issue #4 only had `secret_inject.rs` inline tests        | **Restore `resolve_google_sa_token` tests** | Token resolution is the core logic; cache hit/miss/expiry/rotation must be tested                                   |
+| 8   | Cache key: secret ID only                                | **Cache key: `secret_id + value_version`**  | 50-min TTL + key rotation = stale tokens; adding encrypted value hash gives instant invalidation at near-zero cost  |
+| 9   | —                                                        | **Scope hint in secret dialog UI**          | Prevents user confusion when broadening hostPattern but hitting 403 due to `drive.readonly` scope limitation        |
+
+---
+
+## Issues Created (Local)
+
+| #   | Title                                                                                    | Priority  |
+| --- | ---------------------------------------------------------------------------------------- | --------- |
+| 1   | feat(api): add `google_service_account` secret type — validation & service layer         | IMMEDIATE |
+| 2   | feat(web): SA JSON key upload UI in secret dialog                                        | IMMEDIATE |
+| 3   | feat(gateway): JWT signing & Bearer token injection for `google_service_account` secrets | IMMEDIATE |
+| 4   | test: unit & integration tests for `google_service_account` flow                         | QUICK WIN |
+
+**Total: 4 issues**
+
+### Execution Strategy
+
+**IMMEDIATE VALUE (Start Here)**
+
+- Issue #1 — Data layer foundation (no dependencies)
+- Issue #2 — Web UI (depends on #1 for type validation, but can be developed in parallel)
+
+**PARALLEL WORK**
+
+- Issue #3 — Gateway injection (depends on #1 for type definition, can start skeleton in parallel)
+
+**AFTER CORE IS WORKING**
+
+- Issue #4 — Tests (can start early for validation tests, gateway tests after #3)
+
+### Future Iterations (Not in scope, but noted)
+
+- **Configurable scopes** (currently hardcoded to `drive.readonly`) — will be needed soon for shared Drive write access (Phase 0 contributor permissions)
+- Token interception for Google SDK stub credentials (like Vertex AI pattern)
+- Multiple SA secrets per agent with scope-based routing
+- SA key rotation support

--- a/docs/review-google-sa-round3.md
+++ b/docs/review-google-sa-round3.md
@@ -1,0 +1,169 @@
+# Google Service Account — Review Round 3
+
+> Date: 2026-07-06
+
+## Review Item 1: キャッシュキーのハッシュ対象を `encrypted_value` → `decrypted_json` に変更
+
+### 指摘
+
+1Passwordソースの SA シークレットは `encrypted_value` が `None`（→ `""` にフォールバック）。全OP SA秘密で `sha256("")` が同一定数になり、1Password側でキーをローテーションしてもキャッシュが最大50分失効しない。
+
+### 検証結果: **バグ確認 — 修正必要**
+
+#### 現状のフロー
+
+```
+connect.rs:341  let encrypted = secret.encrypted_value.as_deref().unwrap_or("");
+connect.rs:342  resolve_google_sa_token(cache, &value, &secret.id, encrypted)
+                                                                     ^^^^^^^^^ 1Passwordソースでは常に ""
+
+secret_inject.rs:299  let value_hash = &sha256_hex(encrypted_value)[..16];
+                                                   ^^^^^^^^^^^^^^^^ sha256("") = 固定値
+```
+
+- `secret_id` が異なるので **異なるSA間での衝突はない**
+- しかし **同一SA秘密** の1Password側でのキーローテーション時に、キャッシュキーが変わらず **最大50分古いトークンが使われる**
+
+#### 修正方針
+
+`sha256_hex(encrypted_value)` → `sha256_hex(decrypted_json)` に変更する。
+
+- `decrypted_json` は既に `resolve_google_sa_token()` の引数に存在する
+- SHA-256は不可逆なのでキー素材の漏洩リスクなし
+- inline/1Passwordどちらのソースでもローテーション即失効になる
+
+#### 必要な変更
+
+**`apps/gateway/src/secret_inject.rs`:**
+
+```rust
+// Before:
+pub(crate) async fn resolve_google_sa_token(
+    cache: &dyn CacheStore,
+    decrypted_json: &str,
+    secret_id: &str,
+    encrypted_value: &str,      // ← 削除
+) -> Option<String> {
+
+// After:
+pub(crate) async fn resolve_google_sa_token(
+    cache: &dyn CacheStore,
+    decrypted_json: &str,
+    secret_id: &str,
+) -> Option<String> {
+```
+
+```rust
+// Before (line 299):
+let value_hash = &sha256_hex(encrypted_value)[..16];
+
+// After:
+let value_hash = &sha256_hex(decrypted_json)[..16];
+```
+
+**`apps/gateway/src/connect.rs`:**
+
+```rust
+// Before (lines 341-346):
+let encrypted = secret.encrypted_value.as_deref().unwrap_or("");
+match secret_inject::resolve_google_sa_token(
+    self.cache.as_ref(),
+    &value,
+    &secret.id,
+    encrypted,
+)
+
+// After:
+match secret_inject::resolve_google_sa_token(
+    self.cache.as_ref(),
+    &value,
+    &secret.id,
+)
+```
+
+#### テストへの影響
+
+`secret_inject.rs` のテストで `encrypted_value` パラメータを使用している箇所を更新:
+
+- `resolve_google_sa_token_with()` のシグネチャから `encrypted_value` を削除
+- テストケース `resolve_google_sa_token_cache_key_changes_on_rotation` を `decrypted_json` の変更でキーが変わることの検証に修正
+
+---
+
+## Review Item 2: `updateSecret` の 1Password 切り替え時に SA の hostPattern を上書き
+
+### 指摘
+
+`secret-service.ts:352-353` で 1Password ソースに切り替えた際、`data.hostPattern = "www.googleapis.com"` とハードコードで上書きしている。2つの問題:
+
+1. `GOOGLE_SA_DEFAULT_HOST` 定数を使わずハードコード文字列
+2. ユーザーが設定済みのカスタム hostPattern（例: `storage.googleapis.com`）を黙って上書き
+
+### 検証結果: **バグ確認 — 修正必要**
+
+#### 現状のコード
+
+```typescript
+// secret-service.ts:350-353
+if (secret.type === "anthropic") data.hostPattern = "api.anthropic.com";
+if (secret.type === "openai") data.hostPattern = "api.openai.com";
+if (secret.type === "google_service_account")
+  data.hostPattern = "www.googleapis.com"; // ← 問題
+```
+
+#### anthropic/openai と SA の違い
+
+- **anthropic**: ホストは常に `api.anthropic.com` — 固定。上書きが正当。
+- **openai**: ホストは常に `api.openai.com` — 固定。上書きが正当。
+- **SA**: ユーザーが `storage.googleapis.com` や `sheets.googleapis.com` など **カスタム設定可能な設計**。上書きは意図に反する。
+
+#### シナリオ
+
+1. ユーザーが SA シークレットを `hostPattern: "storage.googleapis.com"` で作成
+2. 後から値のソースを 1Password に切り替え
+3. → `hostPattern` が黙って `www.googleapis.com` にリセットされる
+4. → `storage.googleapis.com` へのリクエストにトークンが注入されなくなる
+
+#### 修正方針
+
+SA の場合、1Password 切り替え時に `hostPattern` を上書きしない（既存値を保持する）。
+
+**`packages/api/src/services/secret-service.ts`:**
+
+```typescript
+// Before:
+if (secret.type === "google_service_account")
+  data.hostPattern = "www.googleapis.com";
+
+// After: SA では既存の hostPattern を保持（上書きしない）
+// anthropic/openai は固定ホストなので上書きが正当だが、
+// SA はユーザーがカスタム hostPattern を設定可能な設計。
+// 削除するだけでよい。
+```
+
+注: `input.hostPattern` が明示的に渡された場合は、後続の `if (input.hostPattern !== undefined)` ブロック（line 383-388）で正しく処理される。
+
+#### テストへの影響
+
+```typescript
+// Before (secret-service.test.ts:279-289):
+it("defaults hostPattern to www.googleapis.com when switching to 1Password", ...)
+  expect(data.hostPattern).toBe("www.googleapis.com");
+
+// After:
+it("preserves existing hostPattern when switching to 1Password", ...)
+  expect(data.hostPattern).toBeUndefined(); // 既存値を保持（上書きしない）
+```
+
+#### 補足: ハードコード文字列
+
+仮に上書き動作を残す場合でも、`"www.googleapis.com"` → `GOOGLE_SA_DEFAULT_HOST` 定数に置き換えるべき。validation 層（`secret.ts:257`）は既に定数を使用している。
+
+---
+
+## Summary
+
+| #   | 指摘                                              | 判定     | アクション |
+| --- | ------------------------------------------------- | -------- | ---------- |
+| 1   | キャッシュキー `encrypted_value`→`decrypted_json` | バグ確認 | 修正必要   |
+| 2   | 1Password切替時のSA hostPattern上書き             | バグ確認 | 修正必要   |

--- a/packages/api/src/services/secret-service.test.ts
+++ b/packages/api/src/services/secret-service.test.ts
@@ -6,13 +6,30 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // probe must degrade that host's badge to null — never fail the list itself.
 
 const dbMock = vi.hoisted(() => ({
-  secret: { findMany: vi.fn() },
+  secret: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+  },
   requestLog: { findFirst: vi.fn() },
 }));
 
-vi.mock("@onecli/db", () => ({ db: dbMock, Prisma: { JsonNull: null } }));
+vi.mock("@onecli/db", () => ({
+  db: dbMock,
+  Prisma: { JsonNull: "JsonNull" },
+}));
 
-import { listSecrets } from "./secret-service";
+vi.mock("../providers", () => ({
+  getCrypto: () => ({
+    encrypt: (v: string) => Promise.resolve(`encrypted:${v}`),
+    decrypt: (v: string) => Promise.resolve(v.replace("encrypted:", "")),
+  }),
+}));
+
+import { createSecret, listSecrets, updateSecret } from "./secret-service";
+import { GOOGLE_SA_DEFAULT_SCOPE } from "../validations/secret";
+import type { ResourceScope } from "./resource-scope";
 
 const anthropicKey = {
   id: "sec-1",
@@ -56,5 +73,382 @@ describe("listSecrets key-health degradation", () => {
     const rows = await listSecrets(SCOPE);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.lastError).toBeNull();
+  });
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper
+const callData = (mock: ReturnType<typeof vi.fn>): any =>
+  mock.mock.calls[0]![0].data;
+
+const projectScope: ResourceScope = { workspaceId: "ws-2" };
+
+const validSaJson = JSON.stringify({
+  type: "service_account",
+  project_id: "my-project",
+  private_key:
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+  client_email: "test@my-project.iam.gserviceaccount.com",
+  client_id: "123456789",
+});
+
+describe("createSecret — google_service_account", () => {
+  beforeEach(() => {
+    dbMock.secret.create.mockReset();
+    dbMock.secret.create.mockResolvedValue({
+      id: "sec-1",
+      name: "Google SA",
+      type: "google_service_account",
+      valueSource: "inline",
+      opRef: null,
+      hostPattern: "www.googleapis.com",
+      pathPattern: null,
+      createdAt: new Date(),
+    });
+  });
+
+  it("stores metadata with clientEmail and projectId", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "www.googleapis.com",
+      value: validSaJson,
+    });
+
+    const data = callData(dbMock.secret.create);
+    expect(data.metadata).toEqual({
+      clientEmail: "test@my-project.iam.gserviceaccount.com",
+      projectId: "my-project",
+      scope: GOOGLE_SA_DEFAULT_SCOPE,
+    });
+  });
+
+  it("defaults scope to the Drive scope when omitted", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "www.googleapis.com",
+      value: validSaJson,
+    });
+
+    const data = callData(mockCreate);
+    expect(data.metadata.scope).toBe(GOOGLE_SA_DEFAULT_SCOPE);
+  });
+
+  it("persists an explicit scope into metadata", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "www.googleapis.com",
+      value: validSaJson,
+      scope: "https://www.googleapis.com/auth/spreadsheets",
+    });
+
+    const data = callData(mockCreate);
+    expect(data.metadata.scope).toBe(
+      "https://www.googleapis.com/auth/spreadsheets",
+    );
+  });
+
+  it("persists scope for a 1Password-sourced SA secret", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "www.googleapis.com",
+      valueSource: "onepassword",
+      opRef: "op://vault/item/field",
+      scope: "https://www.googleapis.com/auth/calendar",
+    });
+
+    const data = callData(mockCreate);
+    expect(data.metadata.scope).toBe(
+      "https://www.googleapis.com/auth/calendar",
+    );
+  });
+
+  it("metadata excludes private_key", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "www.googleapis.com",
+      value: validSaJson,
+    });
+
+    const data = callData(dbMock.secret.create);
+    expect(data.metadata).not.toHaveProperty("private_key");
+    expect(data.metadata).not.toHaveProperty("privateKey");
+  });
+
+  it("stores injectionConfig as null", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "www.googleapis.com",
+      value: validSaJson,
+    });
+
+    const data = callData(dbMock.secret.create);
+    expect(data.injectionConfig).toBe("JsonNull");
+  });
+
+  it("preserves caller-supplied hostPattern", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "storage.googleapis.com",
+      value: validSaJson,
+    });
+
+    const data = callData(dbMock.secret.create);
+    expect(data.hostPattern).toBe("storage.googleapis.com");
+  });
+
+  it("preserves explicit hostPattern for 1Password source", async () => {
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "storage.googleapis.com",
+      valueSource: "onepassword",
+      opRef: "op://vault/item/field",
+    });
+
+    const data = callData(dbMock.secret.create);
+    expect(data.hostPattern).toBe("storage.googleapis.com");
+  });
+
+  it("rejects invalid SA JSON", async () => {
+    await expect(
+      createSecret(projectScope, {
+        name: "Google SA",
+        type: "google_service_account",
+        hostPattern: "www.googleapis.com",
+        value: "not-valid-json",
+      }),
+    ).rejects.toThrow(/service account JSON/);
+  });
+
+  it("rejects SA JSON with wrong type field", async () => {
+    const wrongType = JSON.stringify({
+      ...JSON.parse(validSaJson),
+      type: "authorized_user",
+    });
+    await expect(
+      createSecret(projectScope, {
+        name: "Google SA",
+        type: "google_service_account",
+        hostPattern: "www.googleapis.com",
+        value: wrongType,
+      }),
+    ).rejects.toThrow(/service account JSON/);
+  });
+
+  it("stores metadata with clientEmail only when project_id is absent", async () => {
+    const saWithoutProject = JSON.stringify({
+      type: "service_account",
+      private_key:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+      client_email: "test@no-project.iam.gserviceaccount.com",
+    });
+
+    await createSecret(projectScope, {
+      name: "Google SA",
+      type: "google_service_account",
+      hostPattern: "www.googleapis.com",
+      value: saWithoutProject,
+    });
+
+    const data = callData(dbMock.secret.create);
+    expect(data.metadata).toEqual({
+      clientEmail: "test@no-project.iam.gserviceaccount.com",
+      scope: GOOGLE_SA_DEFAULT_SCOPE,
+    });
+    expect(data.metadata).not.toHaveProperty("projectId");
+  });
+
+  it("rejects SA JSON missing private_key", async () => {
+    const noKey = JSON.stringify({
+      type: "service_account",
+      client_email: "test@my-project.iam.gserviceaccount.com",
+      project_id: "my-project",
+    });
+    await expect(
+      createSecret(projectScope, {
+        name: "Google SA",
+        type: "google_service_account",
+        hostPattern: "www.googleapis.com",
+        value: noKey,
+      }),
+    ).rejects.toThrow(/service account JSON/);
+  });
+
+  it("rejects SA JSON missing client_email", async () => {
+    const noEmail = JSON.stringify({
+      type: "service_account",
+      private_key:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+      project_id: "my-project",
+    });
+    await expect(
+      createSecret(projectScope, {
+        name: "Google SA",
+        type: "google_service_account",
+        hostPattern: "www.googleapis.com",
+        value: noEmail,
+      }),
+    ).rejects.toThrow(/service account JSON/);
+  });
+
+  it("error message does not leak private_key value", async () => {
+    const badSa = JSON.stringify({
+      type: "authorized_user",
+      private_key: "SUPER_SECRET_KEY_VALUE",
+      client_email: "test@example.com",
+    });
+    try {
+      await createSecret(projectScope, {
+        name: "Google SA",
+        type: "google_service_account",
+        hostPattern: "www.googleapis.com",
+        value: badSa,
+      });
+      expect.unreachable("should have thrown");
+    } catch (err: unknown) {
+      const msg = (err as Error).message;
+      expect(msg).not.toContain("SUPER_SECRET_KEY_VALUE");
+    }
+  });
+});
+
+describe("updateSecret — google_service_account", () => {
+  beforeEach(() => {
+    dbMock.secret.findFirst.mockReset();
+    dbMock.secret.update.mockReset();
+    dbMock.secret.findFirst.mockResolvedValue({
+      id: "sec-1",
+      type: "google_service_account",
+    });
+    dbMock.secret.update.mockResolvedValue({});
+  });
+
+  it("validates SA JSON on value update", async () => {
+    await expect(
+      updateSecret(projectScope, "sec-1", {
+        value: "not-valid-json",
+        valueSource: "inline",
+      }),
+    ).rejects.toThrow(/service account JSON/);
+  });
+
+  it("rebuilds metadata on value update", async () => {
+    await updateSecret(projectScope, "sec-1", {
+      value: validSaJson,
+      valueSource: "inline",
+    });
+
+    const data = callData(dbMock.secret.update);
+    expect(data.metadata).toEqual({
+      clientEmail: "test@my-project.iam.gserviceaccount.com",
+      projectId: "my-project",
+      scope: GOOGLE_SA_DEFAULT_SCOPE,
+    });
+  });
+
+  it("persists an explicit scope alongside a value update", async () => {
+    await updateSecret(projectScope, "sec-1", {
+      value: validSaJson,
+      valueSource: "inline",
+      scope: "https://www.googleapis.com/auth/spreadsheets",
+    });
+
+    const data = callData(mockUpdate);
+    expect(data.metadata.scope).toBe(
+      "https://www.googleapis.com/auth/spreadsheets",
+    );
+  });
+
+  it("preserves the existing scope on a value-only update", async () => {
+    mockFindFirst.mockResolvedValueOnce({
+      id: "sec-1",
+      type: "google_service_account",
+      metadata: { scope: "https://www.googleapis.com/auth/calendar" },
+    });
+
+    await updateSecret(projectScope, "sec-1", {
+      value: validSaJson,
+      valueSource: "inline",
+    });
+
+    const data = callData(mockUpdate);
+    expect(data.metadata.scope).toBe(
+      "https://www.googleapis.com/auth/calendar",
+    );
+  });
+
+  it("updates scope alone, preserving clientEmail/projectId", async () => {
+    mockFindFirst.mockResolvedValueOnce({
+      id: "sec-1",
+      type: "google_service_account",
+      metadata: {
+        clientEmail: "test@my-project.iam.gserviceaccount.com",
+        projectId: "my-project",
+        scope: GOOGLE_SA_DEFAULT_SCOPE,
+      },
+    });
+
+    await updateSecret(projectScope, "sec-1", {
+      scope: "https://www.googleapis.com/auth/spreadsheets",
+    });
+
+    const data = callData(mockUpdate);
+    expect(data.metadata).toEqual({
+      clientEmail: "test@my-project.iam.gserviceaccount.com",
+      projectId: "my-project",
+      scope: "https://www.googleapis.com/auth/spreadsheets",
+    });
+    expect(data.encryptedValue).toBeUndefined();
+  });
+
+  it("does not override hostPattern on value-only update", async () => {
+    await updateSecret(projectScope, "sec-1", {
+      value: validSaJson,
+      valueSource: "inline",
+    });
+
+    const data = callData(dbMock.secret.update);
+    expect(data.hostPattern).toBeUndefined();
+  });
+
+  it("uses explicit hostPattern when provided alongside value", async () => {
+    await updateSecret(projectScope, "sec-1", {
+      value: validSaJson,
+      valueSource: "inline",
+      hostPattern: "storage.googleapis.com",
+    });
+
+    const data = callData(dbMock.secret.update);
+    expect(data.hostPattern).toBe("storage.googleapis.com");
+  });
+
+  it("preserves existing hostPattern when switching to 1Password", async () => {
+    await updateSecret(projectScope, "sec-1", {
+      valueSource: "onepassword",
+      opRef: "op://vault/item/field",
+    });
+
+    const data = callData(dbMock.secret.update);
+    expect(data.hostPattern).toBeUndefined();
+    expect(data.valueSource).toBe("onepassword");
+    expect(data.encryptedValue).toBeNull();
+  });
+
+  it("metadata from value update excludes private_key", async () => {
+    await updateSecret(projectScope, "sec-1", {
+      value: validSaJson,
+      valueSource: "inline",
+    });
+
+    const data = callData(dbMock.secret.update);
+    expect(data.metadata).not.toHaveProperty("private_key");
+    expect(data.metadata).not.toHaveProperty("privateKey");
+    expect(data.metadata).toHaveProperty("clientEmail");
   });
 });

--- a/packages/api/src/services/secret-service.ts
+++ b/packages/api/src/services/secret-service.ts
@@ -13,8 +13,10 @@ import {
   isPathRegexInjection,
   isPathSafeValue,
   isPathTemplateInjection,
+  parseGoogleServiceAccountJson,
   parseOpenaiAuthJson,
   parseOpenaiOAuthJson,
+  GOOGLE_SA_DEFAULT_SCOPE,
   type CreateSecretInput,
   type UpdateSecretInput,
 } from "../validations/secret";
@@ -32,10 +34,20 @@ const normalizeOpenaiValue = (
   return { value, hostPattern };
 };
 
+const validateGoogleServiceAccountValue = (raw: string): void => {
+  if (!parseGoogleServiceAccountJson(raw)) {
+    throw new ServiceError(
+      "BAD_REQUEST",
+      'Invalid service account JSON: must contain type "service_account", private_key, and client_email',
+    );
+  }
+};
+
 const SECRET_TYPE_LABELS: Record<string, string> = {
   anthropic: "Anthropic API Key",
   openai: "OpenAI",
   generic: "Generic Secret",
+  google_service_account: "Google Service Account",
 };
 
 const buildPreview = (plaintext: string): string => {
@@ -98,6 +110,7 @@ const assertPathValueSafe = (
 const buildMetadata = (
   type: string,
   value: string,
+  scope?: string,
 ): Prisma.InputJsonValue | typeof Prisma.JsonNull => {
   if (type === "anthropic") {
     return {
@@ -112,16 +125,33 @@ const buildMetadata = (
       ...(parsed ? { accountId: parsed.tokens.account_id ?? null } : {}),
     } as Prisma.InputJsonValue;
   }
+  if (type === "google_service_account") {
+    const sa = parseGoogleServiceAccountJson(value);
+    if (sa) {
+      return {
+        clientEmail: sa.client_email,
+        ...(sa.project_id ? { projectId: sa.project_id } : {}),
+        // Persist the OAuth scope so the gateway includes it in the JWT `scope`
+        // claim; default to the Drive scope when the caller omits it.
+        scope: scope?.trim() || GOOGLE_SA_DEFAULT_SCOPE,
+      } as Prisma.InputJsonValue;
+    }
+  }
   return Prisma.JsonNull;
 };
 
 const buildOnePasswordMetadata = (
   type: string,
   opDisplay: CreateSecretInput["opDisplay"],
+  scope?: string,
 ): Prisma.InputJsonValue | typeof Prisma.JsonNull => {
   const meta: Record<string, unknown> = {};
   // LLM keys resolved from 1Password are always API-key mode (no value to inspect, no OAuth).
   if (type === "anthropic" || type === "openai") meta.authMode = "api-key";
+  // The SA JSON is resolved from 1Password at request time, but the OAuth scope
+  // is still configured per-secret, so persist it in metadata.scope.
+  if (type === "google_service_account")
+    meta.scope = scope?.trim() || GOOGLE_SA_DEFAULT_SCOPE;
   if (opDisplay) meta.opDisplay = opDisplay;
   return Object.keys(meta).length > 0
     ? (meta as Prisma.InputJsonValue)
@@ -330,6 +360,7 @@ export const createSecret = async (
       throw new ServiceError("BAD_REQUEST", "Select a 1Password field");
     }
     // LLM keys from 1Password are treated as plain API keys on their fixed host.
+    // Google SA secrets use the schema-defaulted hostPattern (which callers may override).
     if (input.type === "anthropic") hostPattern = "api.anthropic.com";
     if (input.type === "openai") hostPattern = "api.openai.com";
 
@@ -343,7 +374,11 @@ export const createSecret = async (
         hostPattern,
         pathPattern,
         injectionConfig,
-        metadata: buildOnePasswordMetadata(input.type, input.opDisplay),
+        metadata: buildOnePasswordMetadata(
+          input.type,
+          input.opDisplay,
+          input.scope,
+        ),
         ...scopeCreate(scope),
       },
       select: {
@@ -374,6 +409,10 @@ export const createSecret = async (
     hostPattern = normalized.hostPattern;
   }
 
+  if (input.type === "google_service_account") {
+    validateGoogleServiceAccountValue(value);
+  }
+
   const secret = await db.secret.create({
     data: {
       name,
@@ -383,7 +422,7 @@ export const createSecret = async (
       hostPattern,
       pathPattern,
       injectionConfig,
-      metadata: buildMetadata(input.type, value),
+      metadata: buildMetadata(input.type, value, input.scope),
       ...scopeCreate(scope),
     },
     select: {
@@ -423,12 +462,26 @@ export const updateSecret = async (
 ) => {
   const secret = await db.secret.findFirst({
     where: scopeOwnership(scope, secretId),
-    select: { id: true, type: true },
+    select: { id: true, type: true, metadata: true },
   });
 
   if (!secret) throw new ServiceError("NOT_FOUND", "Secret not found");
 
   const data: Record<string, unknown> = {};
+
+  // Existing SA scope, used to preserve the configured scope across value/1Password
+  // updates that don't restate it. Read directly from metadata (not via
+  // parseGoogleServiceAccountMetadata, which requires clientEmail — absent on
+  // 1Password-sourced SA secrets).
+  const existingMetadata =
+    secret.metadata && typeof secret.metadata === "object"
+      ? (secret.metadata as Record<string, unknown>)
+      : undefined;
+  const existingScope =
+    secret.type === "google_service_account" &&
+    typeof existingMetadata?.scope === "string"
+      ? existingMetadata.scope
+      : undefined;
 
   if (input.name !== undefined) {
     const name = input.name.trim();
@@ -453,7 +506,13 @@ export const updateSecret = async (
     data.opRef = input.opRef;
     if (secret.type === "anthropic") data.hostPattern = "api.anthropic.com";
     if (secret.type === "openai") data.hostPattern = "api.openai.com";
-    data.metadata = buildOnePasswordMetadata(secret.type, input.opDisplay);
+    // SA: preserve existing hostPattern — users may have set a custom host
+    // (e.g. storage.googleapis.com). anthropic/openai have fixed hosts.
+    data.metadata = buildOnePasswordMetadata(
+      secret.type,
+      input.opDisplay,
+      input.scope ?? existingScope,
+    );
   } else if (input.value !== undefined) {
     let value = input.value.trim();
     if (!value)
@@ -465,12 +524,24 @@ export const updateSecret = async (
       data.hostPattern = normalized.hostPattern;
     }
 
+    if (secret.type === "google_service_account") {
+      validateGoogleServiceAccountValue(value);
+    }
+
     data.valueSource = "inline";
     data.encryptedValue = await getCrypto().encrypt(value);
     data.opRef = null;
 
-    if (secret.type === "anthropic" || secret.type === "openai") {
-      data.metadata = buildMetadata(secret.type, value);
+    if (
+      secret.type === "anthropic" ||
+      secret.type === "openai" ||
+      secret.type === "google_service_account"
+    ) {
+      data.metadata = buildMetadata(
+        secret.type,
+        value,
+        input.scope ?? existingScope,
+      );
     }
   }
 
@@ -488,6 +559,20 @@ export const updateSecret = async (
   if (input.injectionConfig !== undefined && secret.type === "generic") {
     data.injectionConfig = buildInjectionConfig(input.injectionConfig);
     assertPathValueSafe(input.injectionConfig, input.valueSource, input.value);
+  }
+
+  // Scope-only update (no new value / 1Password change re-derived the metadata
+  // above): merge the new scope into the existing SA metadata, preserving
+  // clientEmail/projectId.
+  if (
+    input.scope !== undefined &&
+    secret.type === "google_service_account" &&
+    data.metadata === undefined
+  ) {
+    data.metadata = {
+      ...(existingMetadata ?? {}),
+      scope: input.scope.trim() || GOOGLE_SA_DEFAULT_SCOPE,
+    } as Prisma.InputJsonValue;
   }
 
   if (Object.keys(data).length === 0) {

--- a/packages/api/src/validations/secret.test.ts
+++ b/packages/api/src/validations/secret.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import {
   createSecretSchema,
+  GOOGLE_SA_DEFAULT_HOST,
   hostPatternSchema,
   injectionConfigSchema,
   isPathInjection,
   isPathRegexInjection,
   isPathSafeValue,
   isPathTemplateInjection,
+  parseGoogleServiceAccountJson,
+  parseGoogleServiceAccountMetadata,
   wildcardCoversPublicSuffix,
 } from "./secret";
 
@@ -159,5 +162,241 @@ describe("isPathSafeValue", () => {
     expect(isPathSafeValue("a" + String.fromCharCode(0x09) + "b")).toBe(false);
     expect(isPathSafeValue("a" + String.fromCharCode(0x07) + "b")).toBe(false);
     expect(isPathSafeValue("a" + String.fromCharCode(0x7f) + "b")).toBe(false);
+  });
+});
+
+// ── Google Service Account ──
+
+const validSaJson = JSON.stringify({
+  type: "service_account",
+  project_id: "my-project",
+  private_key:
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+  client_email: "test@my-project.iam.gserviceaccount.com",
+  client_id: "123456789",
+});
+
+const saSecretInput = (overrides: Record<string, unknown> = {}) => ({
+  name: "Google SA",
+  type: "google_service_account" as const,
+  hostPattern: "www.googleapis.com",
+  value: validSaJson,
+  ...overrides,
+});
+
+describe("google_service_account schema validation", () => {
+  it("accepts a valid SA JSON key", () => {
+    expect(createSecretSchema.safeParse(saSecretInput()).success).toBe(true);
+  });
+
+  it("rejects non-JSON value", () => {
+    expect(
+      createSecretSchema.safeParse(saSecretInput({ value: "not-json" }))
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects SA JSON with wrong type field", () => {
+    const wrongType = JSON.stringify({
+      ...JSON.parse(validSaJson),
+      type: "authorized_user",
+    });
+    expect(
+      createSecretSchema.safeParse(saSecretInput({ value: wrongType })).success,
+    ).toBe(false);
+  });
+
+  it("rejects SA JSON missing private_key", () => {
+    const parsed = JSON.parse(validSaJson) as Record<string, unknown>;
+    delete parsed.private_key;
+    expect(
+      createSecretSchema.safeParse(
+        saSecretInput({ value: JSON.stringify(parsed) }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("rejects SA JSON missing client_email", () => {
+    const parsed = JSON.parse(validSaJson) as Record<string, unknown>;
+    delete parsed.client_email;
+    expect(
+      createSecretSchema.safeParse(
+        saSecretInput({ value: JSON.stringify(parsed) }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("rejects SA JSON with empty private_key", () => {
+    const empty = JSON.stringify({
+      ...JSON.parse(validSaJson),
+      private_key: "",
+    });
+    expect(
+      createSecretSchema.safeParse(saSecretInput({ value: empty })).success,
+    ).toBe(false);
+  });
+
+  it("rejects SA JSON with empty client_email", () => {
+    const empty = JSON.stringify({
+      ...JSON.parse(validSaJson),
+      client_email: "",
+    });
+    expect(
+      createSecretSchema.safeParse(saSecretInput({ value: empty })).success,
+    ).toBe(false);
+  });
+
+  it("rejects SA JSON with whitespace-only private_key", () => {
+    const ws = JSON.stringify({
+      ...JSON.parse(validSaJson),
+      private_key: "   ",
+    });
+    expect(
+      createSecretSchema.safeParse(saSecretInput({ value: ws })).success,
+    ).toBe(false);
+  });
+
+  it("rejects SA JSON with whitespace-only client_email", () => {
+    const ws = JSON.stringify({
+      ...JSON.parse(validSaJson),
+      client_email: "   ",
+    });
+    expect(
+      createSecretSchema.safeParse(saSecretInput({ value: ws })).success,
+    ).toBe(false);
+  });
+
+  it("skips SA JSON validation for 1Password source", () => {
+    expect(
+      createSecretSchema.safeParse(
+        saSecretInput({
+          valueSource: "onepassword",
+          opRef: "op://vault/item/field",
+        }),
+      ).success,
+    ).toBe(true);
+  });
+
+  it("defaults hostPattern to GOOGLE_SA_DEFAULT_HOST when omitted", () => {
+    const input = saSecretInput();
+    delete (input as Record<string, unknown>).hostPattern;
+    const result = createSecretSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.hostPattern).toBe("www.googleapis.com");
+    }
+  });
+
+  it("preserves explicit hostPattern override", () => {
+    const result = createSecretSchema.safeParse(
+      saSecretInput({ hostPattern: "storage.googleapis.com" }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.hostPattern).toBe("storage.googleapis.com");
+    }
+  });
+
+  it("rejects omitted hostPattern for non-SA types", () => {
+    expect(
+      createSecretSchema.safeParse({
+        name: "Generic Secret",
+        type: "generic",
+        value: "my-token",
+        injectionConfig: {
+          headerName: "Authorization",
+          valueFormat: "Bearer {value}",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts an explicit scope", () => {
+    const result = createSecretSchema.safeParse(
+      saSecretInput({
+        scope:
+          "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.readonly",
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("omits scope when not provided (service defaults it)", () => {
+    const result = createSecretSchema.safeParse(saSecretInput());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scope).toBeUndefined();
+    }
+  });
+
+  it("rejects an empty scope", () => {
+    expect(
+      createSecretSchema.safeParse(saSecretInput({ scope: "   " })).success,
+    ).toBe(false);
+  });
+});
+
+describe("GOOGLE_SA_DEFAULT_HOST", () => {
+  it("is www.googleapis.com", () => {
+    expect(GOOGLE_SA_DEFAULT_HOST).toBe("www.googleapis.com");
+  });
+});
+
+describe("parseGoogleServiceAccountJson", () => {
+  it("parses valid SA JSON", () => {
+    const result = parseGoogleServiceAccountJson(validSaJson);
+    expect(result).not.toBeNull();
+    expect(result!.client_email).toBe(
+      "test@my-project.iam.gserviceaccount.com",
+    );
+    expect(result!.project_id).toBe("my-project");
+  });
+
+  it("returns null for non-JSON", () => {
+    expect(parseGoogleServiceAccountJson("not-json")).toBeNull();
+  });
+
+  it("returns null when type is not service_account", () => {
+    expect(
+      parseGoogleServiceAccountJson(
+        JSON.stringify({ ...JSON.parse(validSaJson), type: "authorized_user" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when private_key is missing", () => {
+    const parsed = JSON.parse(validSaJson) as Record<string, unknown>;
+    delete parsed.private_key;
+    expect(parseGoogleServiceAccountJson(JSON.stringify(parsed))).toBeNull();
+  });
+});
+
+describe("parseGoogleServiceAccountMetadata", () => {
+  it("parses valid metadata", () => {
+    const result = parseGoogleServiceAccountMetadata({
+      clientEmail: "test@example.iam.gserviceaccount.com",
+      projectId: "my-project",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.clientEmail).toBe("test@example.iam.gserviceaccount.com");
+    expect(result!.projectId).toBe("my-project");
+  });
+
+  it("returns null for missing clientEmail", () => {
+    expect(
+      parseGoogleServiceAccountMetadata({ projectId: "my-project" }),
+    ).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(parseGoogleServiceAccountMetadata(null)).toBeNull();
+  });
+
+  it("parses an optional scope", () => {
+    const result = parseGoogleServiceAccountMetadata({
+      clientEmail: "test@example.iam.gserviceaccount.com",
+      scope: "https://www.googleapis.com/auth/spreadsheets",
+    });
+    expect(result?.scope).toBe("https://www.googleapis.com/auth/spreadsheets");
   });
 });

--- a/packages/api/src/validations/secret.ts
+++ b/packages/api/src/validations/secret.ts
@@ -201,16 +201,30 @@ const opDisplaySchema = z
 export const createSecretSchema = z
   .object({
     name: z.string().trim().min(1).max(255),
-    type: z.enum(["anthropic", "openai", "generic"]),
+    type: z.enum(["anthropic", "openai", "generic", "google_service_account"]),
     valueSource: z.enum(valueSources).optional(),
     value: z.string().max(10000).optional(),
     opRef: opRefSchema.optional(),
     opDisplay: opDisplaySchema,
-    hostPattern: hostPatternSchema,
+    hostPattern: hostPatternSchema.optional(),
     pathPattern: z.string().max(1000).optional(),
     injectionConfig: injectionConfigSchema,
+    // OAuth scope(s) for google_service_account secrets, stored in
+    // metadata.scope. A space-separated list is allowed (Google's JWT `scope`
+    // claim supports multiple scopes). Defaults to GOOGLE_SA_DEFAULT_SCOPE.
+    scope: z.string().max(2000).optional(),
   })
   .superRefine((data, ctx) => {
+    // hostPattern is required for all types except google_service_account,
+    // which defaults to GOOGLE_SA_DEFAULT_HOST when omitted.
+    if (!data.hostPattern && data.type !== "google_service_account") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["hostPattern"],
+        message: "Host pattern is required",
+      });
+    }
+
     if (data.valueSource === "onepassword") {
       if (!data.opRef) {
         ctx.addIssue({
@@ -226,7 +240,40 @@ export const createSecretSchema = z
         message: "Secret value is required",
       });
     }
-  });
+
+    if (
+      data.type === "google_service_account" &&
+      data.valueSource !== "onepassword" &&
+      data.value
+    ) {
+      if (!parseGoogleServiceAccountJson(data.value)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["value"],
+          message:
+            'Value must be a valid Google Service Account JSON key with type "service_account", private_key, and client_email',
+        });
+      }
+    }
+
+    // A provided scope must be non-empty (Google rejects an empty `scope`
+    // claim). Omitting scope is fine — the service defaults it.
+    if (
+      data.type === "google_service_account" &&
+      data.scope !== undefined &&
+      data.scope.trim().length === 0
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["scope"],
+        message: "Scope must not be empty",
+      });
+    }
+  })
+  .transform((data) => ({
+    ...data,
+    hostPattern: data.hostPattern ?? GOOGLE_SA_DEFAULT_HOST,
+  }));
 
 export type CreateSecretInput = z.infer<typeof createSecretSchema>;
 
@@ -240,6 +287,8 @@ export const updateSecretSchema = z
     hostPattern: hostPatternSchema.optional(),
     pathPattern: z.string().max(1000).nullable().optional(),
     injectionConfig: injectionConfigSchema,
+    // OAuth scope(s) for google_service_account secrets (see createSecretSchema).
+    scope: z.string().max(2000).optional(),
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: "At least one field must be provided",
@@ -250,6 +299,13 @@ export const updateSecretSchema = z
         code: "custom",
         path: ["opRef"],
         message: "Select a 1Password field",
+      });
+    }
+    if (data.scope !== undefined && data.scope.trim().length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["scope"],
+        message: "Scope must not be empty",
       });
     }
     if (
@@ -397,3 +453,59 @@ export const parseOpenaiMetadata = (
 
 export const detectOpenaiAuthMode = (value: string): OpenaiAuthMode =>
   parseOpenaiOAuthJson(value) !== null ? "oauth" : "api-key";
+
+// ── Google Service Account ──
+
+export const GOOGLE_SA_DEFAULT_HOST = "www.googleapis.com";
+
+// Default OAuth scope for Google Service Account secrets, used when a secret
+// has no explicit metadata.scope. Kept in sync with the gateway's
+// GOOGLE_SA_DEFAULT_SCOPE (apps/gateway/src/apps.rs).
+export const GOOGLE_SA_DEFAULT_SCOPE = "https://www.googleapis.com/auth/drive";
+
+export interface GoogleServiceAccountJson {
+  type: string;
+  private_key: string;
+  client_email: string;
+  project_id?: string;
+}
+
+export const parseGoogleServiceAccountJson = (
+  value: string,
+): GoogleServiceAccountJson | null => {
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    if (
+      parsed.type === "service_account" &&
+      typeof parsed.private_key === "string" &&
+      parsed.private_key.trim().length > 0 &&
+      typeof parsed.client_email === "string" &&
+      parsed.client_email.trim().length > 0
+    ) {
+      return parsed as unknown as GoogleServiceAccountJson;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+export interface GoogleServiceAccountMetadata {
+  projectId?: string;
+  clientEmail: string;
+  scope?: string;
+}
+
+export const parseGoogleServiceAccountMetadata = (
+  metadata: unknown,
+): GoogleServiceAccountMetadata | null => {
+  if (
+    metadata &&
+    typeof metadata === "object" &&
+    "clientEmail" in metadata &&
+    typeof (metadata as Record<string, unknown>).clientEmail === "string"
+  ) {
+    return metadata as GoogleServiceAccountMetadata;
+  }
+  return null;
+};


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Feature — adds a new `google_service_account` secret type.

## What is the current behavior?

Closes #414

There is currently no way to authenticate agent requests to general Google APIs (Drive, Sheets, Storage, ...) as a GCP service account. The existing options
don't cover this:

- OAuth app connectors handle human-account (3-legged) flows. - The Vertex AI provider performs an SA JWT exchange, but is tied to `cloud-platform` scope and `*-aiplatform.googleapis.com` hosts.

Storing an SA key as a `generic` secret doesn't work either, since the JSON key is not itself a Bearer credential — it must be exchanged (signed JWT → access token) before injection.

## What is the new behavior?

Users can register a Google Service Account JSON key as a secret. The gateway signs a short-lived RS256 JWT, exchanges it at `oauth2.googleapis.com/token`, caches the resulting access token, and injects it as a Bearer header into matching requests. The private key is never handed to the agent — agents only ever see request results.

**api**
- New secret type with Zod validation of the SA JSON (`type: "service_account"`, `private_key`, `client_email`).
- Metadata extraction limited to `client_email` / `project_id`, plus an optional `scope`.
- Default `hostPattern`: `www.googleapis.com`.

**gateway**
- Token resolution happens in the connect phase (mirroring the OpenAI OAuth refresh), keeping `build_injections()` synchronous.
- JWT claims omit `sub`. `sub` only means domain-wide delegation; without DWD configured, including it causes `invalid_grant`. The Vertex AI path tolerates it because it uses `cloud-platform` scope on GCP projects.
- **Scope is configured per secret** via `metadata.scope` (space-separated list supported). Secrets without one fall back to `GOOGLE_SA_DEFAULT_SCOPE` = `https://www.googleapis.com/auth/drive`. The gateway constant is kept in sync with the API's.
- Token cache uses the shared `CacheStore`, keyed by `secret_id` + a hash of the secret value, so key rotation invalidates immediately. `create_store()` now runs before the `PolicyEngine` is built and the `Arc` is held on the engine; `InMemoryCacheStore` became `pub(crate)` for that.
- Injection is explicitly skipped when the target host is `oauth2.googleapis.com`, to prevent circular injection if a user broadens the  host pattern.
- If token resolution fails, the secret is skipped and the request proceeds without injection — same behaviour as an existing decrypt failure. This is  fail-open; upstream returns 401.

**web**
- Secret dialog gains a Google Service Account option with JSON paste / file upload, inline validation, a read-only preview of the detected `client_email` / `project_id`, and a scope field defaulting to the Drive scope.
- Secret cards show the client email.

**tests**
- Validation and service-layer tests, including that the private key never appears in metadata or error messages.
- Token-resolution tests covering cache hit / miss / expiry / rotation / exchange failure via an injected fetcher.

## Notes for review

1. **The default scope is read/write Drive, not read-only.**
   `https://www.googleapis.com/auth/drive` grants full access to everything the  service account can see. Happy to make `drive.readonly` the default and have  callers opt into write — let me know which you'd prefer before merge.
2. **The default `hostPattern` only covers Drive.** Sheets  (`sheets.googleapis.com`) and Storage (`storage.googleapis.com`) are  different hosts, so users have to widen the pattern themselves. Should the  dialog call this out, or should the default cover more hosts?
3. **The circular-injection guard is an exact string match** on the hostname  after stripping the port, so a differing case or a trailing dot would slip  past. I can tighten it to a case-insensitive compare with trailing-dot  stripping in this PR if you'd rather not leave it to a follow-up.
4. **Cloud edition: access tokens would transit Redis.** The token cache uses  the shared cache store, which is ElastiCache on Cloud. The tokens are  short-lived but stored as-is — flagging in case they should go through  `CryptoService` first.
5. The JWT-exchange logic intentionally does not modify the Vertex AI path. If  preferred, I'm happy to factor a shared exchange helper out of  `refresh_via_service_account()` with `scope` / `sub` parameterized — kept out  of this PR to minimize blast radius.

Follow-ups (out of scope): credential-stub interception for Google SDKs, as the Vertex AI path does.

## Additional context

Verified end-to-end locally: two agents with selective secret grants, each assigned a different SA, can list only their own shared drive through the gateway (`mode="mitm"`, token exchange logged once, then cache hits).