### PR TITLE
fix(codex): advertise a paid plan in the stub id_token so OAuth codex routes to chatgpt.com

### DIFF
--- a/packages/api/src/lib/codex-stubs.ts
+++ b/packages/api/src/lib/codex-stubs.ts
@@ -1,6 +1,13 @@
+// The stub id_token advertises a *paid* ChatGPT plan on purpose. codex-cli
+// (>= 0.14x) selects its model backend from the `chatgpt_plan_type` claim:
+// a "free" plan routes model calls to wss://api.openai.com/v1/responses (API
+// mode), where the injected ChatGPT-OAuth subscription token is rejected with
+// 401; a paid plan routes to wss://chatgpt.com/backend-api/codex/responses,
+// where the injected subscription token is accepted. The real entitlement is
+// still enforced upstream by the injected token — this claim only steers routing.
 const CODEX_ID_TOKEN = [
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
-  "eyJzdWIiOiJvbmVjbGktbWFuYWdlZCIsImVtYWlsIjoib25lY2xpQG9uZWNsaS5zaCIsImV4cCI6NDEwMjQ0NDgwMCwiaWF0IjoxNzM1Njg5NjAwLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJmcmVlIiwiY2hhdGdwdF91c2VyX2lkIjoib25lY2xpLW1hbmFnZWQiLCJjaGF0Z3B0X2FjY291bnRfaWQiOiJvbmVjbGktbWFuYWdlZCJ9fQ",
+  "eyJzdWIiOiJvbmVjbGktbWFuYWdlZCIsImVtYWlsIjoib25lY2xpQG9uZWNsaS5zaCIsImV4cCI6NDEwMjQ0NDgwMCwiaWF0IjoxNzM1Njg5NjAwLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwbHVzIiwiY2hhdGdwdF91c2VyX2lkIjoib25lY2xpLW1hbmFnZWQiLCJjaGF0Z3B0X2FjY291bnRfaWQiOiJvbmVjbGktbWFuYWdlZCJ9fQ",
   "b25lY2xpLW1hbmFnZWQtc2lnbmF0dXJl",
 ].join(".");
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Fixes #425.

Codex model calls made with a **ChatGPT-OAuth** (subscription) credential fail with:

```
401 Unauthorized: WebSocket upgrade rejected by upstream (wss://api.openai.com/v1/responses)
```

The stub `id_token` in `packages/api/src/lib/codex-stubs.ts` advertises `chatgpt_plan_type: "free"`. codex-cli (>= 0.14x) selects its model backend from this claim: a **free** plan routes to `wss://api.openai.com/v1/responses` (API mode), where the injected ChatGPT-OAuth subscription token is not accepted → 401. The credential injection is correct; only the routing is wrong.

## What is the new behavior?

The stub `id_token` now advertises a **paid** plan (`plus`), so codex routes to `wss://chatgpt.com/backend-api/codex/responses`, where the injected subscription token **is** accepted. The real entitlement stays enforced upstream by the injected token — this claim only steers routing.

The functional change (the single `chatgpt_plan_type` claim in the stub JWT) is identical to what we have compiled and running in production: after it, the `api.openai.com` WS 401s stop and codex traffic flows over `chatgpt.com/backend-api/codex/responses` with injections applied, returning 200.

## Additional context

Single data-literal change (one claim in the stub JWT) plus an explanatory comment. Gateway logs from one Codex session **before** the fix:

```
forward    GET  chatgpt.com/backend-api/...             status=200  injections_applied=2
websocket       api.openai.com/v1/responses (upgrade)   status=401  upstream rejected upgrade
```

HTTP calls to `chatgpt.com` inject fine; only the `api.openai.com` WS upgrade 401s — consistent with wrong-endpoint routing rather than a missing injection.
