### PR TITLE
fix(gateway): merge secret and OAuth app injection on shared hosts

### DIFF
--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -636,17 +636,35 @@ impl PolicyEngine {
         let candidates = narrow_connections_by_path(app_connections, hostname, request_path);
         let app_connections: &[db::AppConnectionRow] = &candidates;
 
-        // Single connection — use it directly
+        // Single connection — use it directly. Its rules always merge (they
+        // self-select by path at apply time), but the winner metadata is
+        // dropped when the provider does not serve this request's path — a
+        // lone Calendar connection on a `/youtube/` request must not donate
+        // its granular policy, finalizer, or host rewrite.
         if app_connections.len() == 1 {
-            return self
-                .resolve_connection_injections(
-                    &app_connections[0],
-                    hostname,
-                    organization_id,
-                    project_id,
-                    cache,
-                )
-                .await;
+            let conn = &app_connections[0];
+            let mut result = self
+                .resolve_connection_injections(conn, hostname, organization_id, project_id, cache)
+                .await?;
+            if let AppConnectionResult::Rules {
+                provider,
+                rewrite_host,
+                connection_label,
+                finalizer,
+                body_transform,
+                session_policy,
+                ..
+            } = &mut result
+            {
+                if !provider_serves_request(provider, hostname, request_path) {
+                    *rewrite_host = None;
+                    *connection_label = None;
+                    *finalizer = None;
+                    *body_transform = None;
+                    *session_policy = None;
+                }
+            }
+            return Ok(result);
         }
 
         // Multiple connections — check for ambiguity per provider
@@ -711,27 +729,25 @@ impl PolicyEngine {
                     .await?
                 {
                     rules.extend(r);
-                    if rewrite_host.is_some() {
-                        resolved_rewrite_host = rewrite_host;
-                    }
-                    if resolved_label.is_none() {
-                        resolved_label = connection_label;
-                    }
-                    if finalizer.is_some() {
-                        resolved_finalizer = finalizer;
-                    }
-                    if body_transform.is_some() {
-                        resolved_body_transform = body_transform;
-                    }
-                    // Tie the granular policy to the connection that actually
-                    // serves THIS host — not merely the first to yield rules. A
-                    // non-serving connection (e.g. a GitHub connection on a
-                    // Dropbox request) still returns `Rules` carrying its own
-                    // policy, so adopting the first would mis-apply it.
-                    let serves_host = request_path
-                        .map(|p| apps::provider_matches_host_and_path(&provider, hostname, p))
-                        .unwrap_or(false);
-                    if serves_host {
+                    // Tie ALL winner metadata to the connection that actually
+                    // serves THIS request — not merely the first to yield
+                    // rules. A non-serving connection (e.g. a GitHub
+                    // connection on a Dropbox request) still returns `Rules`
+                    // carrying its own policy/finalizer/rewrite, and adopting
+                    // those would mis-apply them to a request it doesn't own.
+                    if provider_serves_request(&provider, hostname, request_path) {
+                        if rewrite_host.is_some() {
+                            resolved_rewrite_host = rewrite_host;
+                        }
+                        if resolved_label.is_none() {
+                            resolved_label = connection_label;
+                        }
+                        if finalizer.is_some() {
+                            resolved_finalizer = finalizer;
+                        }
+                        if body_transform.is_some() {
+                            resolved_body_transform = body_transform;
+                        }
                         resolved_session_policy = session_policy;
                     }
                     if resolved_provider.is_none() {
@@ -1411,6 +1427,73 @@ fn narrow_connections_by_path<'a>(
     }
 }
 
+/// True when `provider` serves this request's host+path. Winner metadata
+/// (granular policy, finalizer, body transform, host rewrite, label) is
+/// adopted only from a serving connection; injection rules need no such
+/// gate — they self-select via `path_pattern` at apply time. A missing
+/// request path is conservatively non-serving.
+fn provider_serves_request(provider: &str, hostname: &str, request_path: Option<&str>) -> bool {
+    request_path
+        .map(|p| apps::provider_matches_host_and_path(provider, hostname, p))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+impl PolicyEngine {
+    /// Test-only engine whose pool is lazy and never dereferenced —
+    /// resolution tests that stay on cache-hit paths need no Postgres.
+    pub(crate) fn test_stub() -> Self {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://unused:unused@127.0.0.1:9/unused")
+            .expect("lazy pool");
+        let crypto = Arc::new(
+            CryptoService::from_base64_key("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+                .expect("test key"),
+        );
+        let onepassword = Arc::new(OnePasswordVaultProvider::new(
+            pool.clone(),
+            Arc::clone(&crypto),
+        ));
+        PolicyEngine {
+            pool,
+            crypto,
+            onepassword,
+        }
+    }
+}
+
+/// Test-only: seed the `app_injection:` cache entry exactly the way
+/// `resolve_connection_injections` writes it (struct-typed, so shape drift
+/// breaks tests loudly instead of deserializing via defaults).
+#[cfg(test)]
+#[expect(clippy::too_many_arguments)]
+pub(crate) async fn seed_app_injection_cache(
+    cache: &Arc<dyn CacheStore>,
+    organization_id: &str,
+    project_id: &str,
+    conn: &db::AppConnectionRow,
+    hostname: &str,
+    rules: Vec<InjectionRule>,
+    rewrite_host: Option<&str>,
+    connection_label: Option<&str>,
+) {
+    let policy_suffix = conn
+        .session_policy
+        .as_ref()
+        .map(|sp| format!(":{sp}"))
+        .unwrap_or_default();
+    let key = format!(
+        "app_injection:{organization_id}:{project_id}:{}:{hostname}{policy_suffix}",
+        conn.id
+    );
+    let entry = CachedAppInjection {
+        rules,
+        rewrite_host: rewrite_host.map(str::to_string),
+        connection_label: connection_label.map(str::to_string),
+    };
+    cache.set(&key, &entry, 60).await;
+}
+
 // ── Host matching ───────────────────────────────────────────────────────
 
 /// Returns `true` when the credential's stored host does not match the
@@ -1857,6 +1940,215 @@ mod tests {
 
     fn ids(conns: &[db::AppConnectionRow]) -> Vec<&str> {
         conns.iter().map(|c| c.id.as_str()).collect()
+    }
+
+    // ── serves-path metadata gating (#428) ──────────────────────────────
+
+    fn bearer_rule(pattern: &str, token: &str) -> InjectionRule {
+        InjectionRule {
+            path_pattern: pattern.to_string(),
+            injections: vec![Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: format!("Bearer {token}"),
+            }],
+        }
+    }
+
+    async fn seed_app_injection(
+        cache: &Arc<dyn CacheStore>,
+        conn: &db::AppConnectionRow,
+        hostname: &str,
+        rules: Vec<InjectionRule>,
+        rewrite_host: Option<&str>,
+        connection_label: Option<&str>,
+    ) {
+        seed_app_injection_cache(
+            cache,
+            "o1",
+            "p1",
+            conn,
+            hostname,
+            rules,
+            rewrite_host,
+            connection_label,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn single_connection_metadata_gated_to_serving_path() {
+        let engine = PolicyEngine::test_stub();
+        let store = new_store().await;
+        let mut c = conn("c1", "google-calendar");
+        c.session_policy = Some(serde_json::json!({"folders": ["x"]}));
+        seed_app_injection(
+            &store,
+            &c,
+            "www.googleapis.com",
+            vec![bearer_rule("/calendar/*", "cal")],
+            Some("rw.example.com"),
+            Some("Cal"),
+        )
+        .await;
+
+        // Non-serving path (/youtube): rules still returned, metadata dropped.
+        let res = engine
+            .resolve_app_injection_for_request(
+                std::slice::from_ref(&c),
+                "www.googleapis.com",
+                Some("/youtube/v3/search"),
+                None,
+                "o1",
+                "p1",
+                &*store,
+            )
+            .await
+            .unwrap();
+        match res {
+            AppConnectionResult::Rules {
+                rules,
+                rewrite_host,
+                connection_label,
+                finalizer,
+                body_transform,
+                session_policy,
+                ..
+            } => {
+                assert_eq!(rules.len(), 1);
+                assert!(rewrite_host.is_none());
+                assert!(connection_label.is_none());
+                assert!(finalizer.is_none());
+                assert!(body_transform.is_none());
+                assert!(session_policy.is_none());
+            }
+            _ => panic!("expected Rules"),
+        }
+
+        // Serving path (/calendar): metadata kept.
+        let res = engine
+            .resolve_app_injection_for_request(
+                std::slice::from_ref(&c),
+                "www.googleapis.com",
+                Some("/calendar/v3/events"),
+                None,
+                "o1",
+                "p1",
+                &*store,
+            )
+            .await
+            .unwrap();
+        match res {
+            AppConnectionResult::Rules {
+                rewrite_host,
+                connection_label,
+                session_policy,
+                ..
+            } => {
+                assert_eq!(rewrite_host.as_deref(), Some("rw.example.com"));
+                assert_eq!(connection_label.as_deref(), Some("Cal"));
+                assert!(session_policy.is_some());
+            }
+            _ => panic!("expected Rules"),
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_connection_id_keeps_metadata_off_path() {
+        let engine = PolicyEngine::test_stub();
+        let store = new_store().await;
+        let c = conn("c1", "google-calendar");
+        seed_app_injection(
+            &store,
+            &c,
+            "www.googleapis.com",
+            vec![bearer_rule("/calendar/*", "cal")],
+            Some("rw.example.com"),
+            Some("Cal"),
+        )
+        .await;
+
+        // An explicit x-onecli-connection-id is a deliberate override: the
+        // serves-path gate does not apply.
+        let res = engine
+            .resolve_app_injection_for_request(
+                std::slice::from_ref(&c),
+                "www.googleapis.com",
+                Some("/youtube/v3/search"),
+                Some("c1"),
+                "o1",
+                "p1",
+                &*store,
+            )
+            .await
+            .unwrap();
+        match res {
+            AppConnectionResult::Rules {
+                rewrite_host,
+                connection_label,
+                ..
+            } => {
+                assert_eq!(rewrite_host.as_deref(), Some("rw.example.com"));
+                assert_eq!(connection_label.as_deref(), Some("Cal"));
+            }
+            _ => panic!("expected Rules"),
+        }
+    }
+
+    #[tokio::test]
+    async fn merge_loop_drops_metadata_when_no_provider_serves() {
+        // Two providers, neither serving the request path (/youtube): the
+        // empty-narrow fallback keeps both, their rules merge (they
+        // self-select at apply time), and no one's metadata is adopted.
+        let engine = PolicyEngine::test_stub();
+        let store = new_store().await;
+        let cal = conn("c1", "google-calendar");
+        let gm = conn("c2", "gmail");
+        seed_app_injection(
+            &store,
+            &cal,
+            "www.googleapis.com",
+            vec![bearer_rule("/calendar/*", "cal")],
+            Some("cal.example.com"),
+            Some("Cal"),
+        )
+        .await;
+        seed_app_injection(
+            &store,
+            &gm,
+            "www.googleapis.com",
+            vec![bearer_rule("/gmail/*", "gm")],
+            Some("gm.example.com"),
+            Some("Gm"),
+        )
+        .await;
+
+        let res = engine
+            .resolve_app_injection_for_request(
+                &[cal, gm],
+                "www.googleapis.com",
+                Some("/youtube/v3/search"),
+                None,
+                "o1",
+                "p1",
+                &*store,
+            )
+            .await
+            .unwrap();
+        match res {
+            AppConnectionResult::Rules {
+                rules,
+                rewrite_host,
+                connection_label,
+                session_policy,
+                ..
+            } => {
+                assert_eq!(rules.len(), 2);
+                assert!(rewrite_host.is_none());
+                assert!(connection_label.is_none());
+                assert!(session_policy.is_none());
+            }
+            _ => panic!("expected Rules"),
+        }
     }
 
     #[test]

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -50,7 +50,7 @@ use hyper_util::rt::TokioIo;
 use tokio::net::{TcpListener, TcpStream};
 use tower::ServiceExt;
 use tower_http::cors::CorsLayer;
-use tracing::{info, info_span, warn, Instrument};
+use tracing::{debug, info, info_span, warn, Instrument};
 
 use crate::approval::{ApprovalDecision, ApprovalStore, APPROVAL_TIMEOUT_SECS};
 use crate::auth::AuthUser;
@@ -782,7 +782,11 @@ async fn handle_http_proxy(
         connect::ConnectResponse::default()
     };
 
-    // Per-request app connection disambiguation
+    // Per-request app connection disambiguation — app rules MERGE with the
+    // secret rules (see inject::merge_injection_rules; #428). When the secret
+    // rules already serve this request's path, app-side escalations are
+    // best-effort no-ops rather than failures of a request the secret alone
+    // satisfies.
     let mut resolved_finalizer: Option<crate::apps::RequestFinalizer> = None;
     let mut resolved_body_transform: Option<crate::apps::BodyTransform> = None;
     // Granular-access policy of the connection that wins injection (if any).
@@ -791,6 +795,9 @@ async fn handle_http_proxy(
         let oid = resolved.organization_id.as_deref().unwrap_or("");
         let pid = resolved.project_id.as_deref().unwrap_or("");
         let request_path = req.uri().path_and_query().map(|pq| pq.as_str());
+        let secret_rules = std::mem::take(&mut resolved.injection_rules);
+        let secrets_serve = inject::rules_serve_path(&secret_rules, request_path);
+        let mut app_rules: Vec<inject::InjectionRule> = Vec::new();
         match state
             .policy_engine
             .resolve_app_injection_for_request(
@@ -811,27 +818,40 @@ async fn handle_http_proxy(
                 session_policy,
                 ..
             }) => {
-                resolved.injection_rules.extend(rules);
+                app_rules = rules;
                 resolved_finalizer = finalizer;
                 resolved_body_transform = body_transform;
                 resolved_session_policy = session_policy;
             }
             Ok(AppConnectionResult::Ambiguous { connections }) => {
-                return Ok(response::multiple_connections_axum(&connections));
+                if !secrets_serve {
+                    return Ok(response::multiple_connections_axum(&connections));
+                }
+                debug!(host = %authority, "app connections ambiguous; secret rules serve this path");
             }
             Ok(AppConnectionResult::MultipleProviders { connections }) => {
-                return Ok(response::multiple_providers_axum(&connections));
+                if !secrets_serve {
+                    return Ok(response::multiple_providers_axum(&connections));
+                }
+                debug!(host = %authority, "multiple providers match; secret rules serve this path");
             }
             Ok(AppConnectionResult::NotFound { connections }) => {
-                let cid = connection_id.as_deref().unwrap_or("");
-                return Ok(response::connection_not_found_axum(cid, &connections));
+                if !secrets_serve {
+                    let cid = connection_id.as_deref().unwrap_or("");
+                    return Ok(response::connection_not_found_axum(cid, &connections));
+                }
+                debug!(host = %authority, "requested connection not found; secret rules serve this path");
             }
             Ok(AppConnectionResult::NoConnections) => {}
             Err(e) => {
-                warn!(peer = %peer_addr, host = %authority, error = ?e, "HTTP proxy: app connection resolution failed");
-                return Ok(response::bad_gateway());
+                if !secrets_serve {
+                    warn!(peer = %peer_addr, host = %authority, error = ?e, "HTTP proxy: app connection resolution failed");
+                    return Ok(response::bad_gateway());
+                }
+                warn!(peer = %peer_addr, host = %authority, error = ?e, "HTTP proxy: app resolution failed; proceeding with secret rules");
             }
         }
+        resolved.injection_rules = inject::merge_injection_rules(app_rules, secret_rules);
     }
 
     // Vault fallback

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -787,7 +787,7 @@ async fn handle_http_proxy(
     let mut resolved_body_transform: Option<crate::apps::BodyTransform> = None;
     // Granular-access policy of the connection that wins injection (if any).
     let mut resolved_session_policy: Option<serde_json::Value> = None;
-    if resolved.injection_rules.is_empty() && !resolved.app_connections.is_empty() {
+    if !resolved.app_connections.is_empty() {
         let oid = resolved.organization_id.as_deref().unwrap_or("");
         let pid = resolved.project_id.as_deref().unwrap_or("");
         let request_path = req.uri().path_and_query().map(|pq| pq.as_str());
@@ -811,7 +811,7 @@ async fn handle_http_proxy(
                 session_policy,
                 ..
             }) => {
-                resolved.injection_rules = rules;
+                resolved.injection_rules.extend(rules);
                 resolved_finalizer = finalizer;
                 resolved_body_transform = body_transform;
                 resolved_session_policy = session_policy;

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -256,8 +256,9 @@ enum ResolveResult {
 }
 
 /// Resolve injection + policy rules from cache, with per-request app connection
-/// disambiguation. Falls back to vault rules if no DB secrets or app connections
-/// are configured for this host.
+/// disambiguation. Secret and app-connection rules are both path-scoped and are
+/// merged per request (`inject::merge_injection_rules`); vault rules fill in
+/// only when neither source yields any.
 async fn resolve_rules(
     ctx: &ProxyContext,
     hostname: &str,
@@ -287,7 +288,8 @@ async fn resolve_rules(
     )
     .await?;
 
-    let mut injection_rules = resp.injection_rules; // from secrets
+    let secret_rules = resp.injection_rules; // from secrets (path-scoped)
+    let mut app_rules: Vec<InjectionRule> = Vec::new();
     let mut token_expires_at: Option<i64> = None;
     let mut rewrite_host: Option<String> = None;
     let mut connection_label: Option<String> = None;
@@ -296,11 +298,16 @@ async fn resolve_rules(
     // Granular-access policy of the connection that wins injection (if any).
     let mut session_policy: Option<serde_json::Value> = None;
 
-    // Resolve app connections and MERGE with any secret rules. A shared host
-    // (e.g. www.googleapis.com) can carry both an API-key secret (/youtube/*)
-    // and OAuth app connections (/calendar/*, /drive/*); both are path-scoped
-    // and must coexist rather than the secret preempting the OAuth apps.
+    // Resolve app connections whenever any exist and MERGE their rules with
+    // the secret rules. A shared host (e.g. www.googleapis.com) can carry
+    // both an API-key secret (/youtube/*) and OAuth app connections
+    // (/calendar/*, /drive/*); both rule sets are path-scoped and coexist —
+    // a secret must not preempt the apps (#428). When the secret rules
+    // already serve this request's path, app-side escalations (ambiguity,
+    // stale connection id, resolution errors) are best-effort no-ops rather
+    // than failures of a request the secret alone satisfies.
     if !resp.app_connections.is_empty() {
+        let secrets_serve = crate::inject::rules_serve_path(&secret_rules, request_path);
         match engine
             .resolve_app_injection_for_request(
                 &resp.app_connections,
@@ -311,9 +318,9 @@ async fn resolve_rules(
                 project_id,
                 cache,
             )
-            .await?
+            .await
         {
-            AppConnectionResult::Rules {
+            Ok(AppConnectionResult::Rules {
                 rules,
                 token_expires_at: exp,
                 rewrite_host: rh,
@@ -322,8 +329,8 @@ async fn resolve_rules(
                 body_transform: bt,
                 session_policy: sp,
                 ..
-            } => {
-                injection_rules.extend(rules);
+            }) => {
+                app_rules = rules;
                 token_expires_at = exp;
                 rewrite_host = rh;
                 connection_label = cl;
@@ -331,30 +338,44 @@ async fn resolve_rules(
                 body_transform = bt;
                 session_policy = sp;
             }
-            AppConnectionResult::Ambiguous { connections } => {
-                return Ok(ResolveResult::Ambiguous(connections));
+            Ok(AppConnectionResult::Ambiguous { connections }) => {
+                if !secrets_serve {
+                    return Ok(ResolveResult::Ambiguous(connections));
+                }
+                debug!(host = %hostname, "app connections ambiguous; secret rules serve this path");
             }
-            AppConnectionResult::MultipleProviders { connections } => {
-                return Ok(ResolveResult::MultipleProviders(connections));
+            Ok(AppConnectionResult::MultipleProviders { connections }) => {
+                if !secrets_serve {
+                    return Ok(ResolveResult::MultipleProviders(connections));
+                }
+                debug!(host = %hostname, "multiple providers match; secret rules serve this path");
             }
-            AppConnectionResult::NotFound { connections } => {
-                return Ok(ResolveResult::NotFound {
-                    connection_id: connection_id.unwrap_or("").to_string(),
-                    connections,
-                });
+            Ok(AppConnectionResult::NotFound { connections }) => {
+                if !secrets_serve {
+                    return Ok(ResolveResult::NotFound {
+                        connection_id: connection_id.unwrap_or("").to_string(),
+                        connections,
+                    });
+                }
+                debug!(host = %hostname, "requested connection not found; secret rules serve this path");
             }
-            AppConnectionResult::NoConnections => {}
+            Ok(AppConnectionResult::NoConnections) => {}
+            Err(e) => {
+                if !secrets_serve {
+                    return Err(e);
+                }
+                warn!(host = %hostname, error = ?e, "app resolution failed; proceeding with secret rules");
+            }
         }
     }
 
-    // Vault fallback
-    if injection_rules.is_empty() && !vault_rules.is_empty() {
-        injection_rules = vault_rules.to_vec();
-    }
-
-    // Build intercept token only for providers that have intercept rules
+    // Build the intercept token only for providers that have intercept rules.
+    // Scan the APP rules only: the intercept exists to answer token-refresh
+    // POSTs for app connections (vertex-ai on oauth2.googleapis.com), so a
+    // Bearer-shaped secret or vault credential on the same host must not
+    // donate the token.
     let intercept_token = if crate::apps::host_has_intercept_rules(hostname) {
-        injection_rules
+        app_rules
             .iter()
             .find_map(|rule| {
                 rule.injections.iter().find_map(|inj| match inj {
@@ -385,6 +406,13 @@ async fn resolve_rules(
         None
     };
 
+    let mut injection_rules = crate::inject::merge_injection_rules(app_rules, secret_rules);
+
+    // Vault fallback — only when neither secrets nor apps yielded any rules.
+    if injection_rules.is_empty() && !vault_rules.is_empty() {
+        injection_rules = vault_rules.to_vec();
+    }
+
     Ok(ResolveResult::Resolved {
         rules: Box::new(ResolvedRules {
             injection_rules,
@@ -403,4 +431,393 @@ async fn resolve_rules(
         }),
         app_connections: resp.app_connections,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::connect::{seed_app_injection_cache, ConnectResponse};
+    use crate::inject::{apply_injections, Injection};
+
+    const HOST: &str = "www.googleapis.com";
+
+    fn ctx() -> ProxyContext {
+        ProxyContext {
+            project_id: Some("p1".to_string()),
+            organization_id: Some("o1".to_string()),
+            agent_id: None,
+            agent_name: None,
+            agent_identifier: None,
+            agent_token: Some("tok".to_string()),
+        }
+    }
+
+    fn app_conn(id: &str, provider: &str) -> db::AppConnectionRow {
+        db::AppConnectionRow {
+            id: id.to_string(),
+            provider: provider.to_string(),
+            scope: "project".to_string(),
+            credentials: None,
+            label: None,
+            metadata: None,
+            session_policy: None,
+        }
+    }
+
+    fn header_rule(pattern: &str, value: &str) -> InjectionRule {
+        InjectionRule {
+            path_pattern: pattern.to_string(),
+            injections: vec![Injection::SetHeader {
+                name: "authorization".to_string(),
+                value: value.to_string(),
+            }],
+        }
+    }
+
+    fn param_rule(pattern: &str, name: &str, value: &str) -> InjectionRule {
+        InjectionRule {
+            path_pattern: pattern.to_string(),
+            injections: vec![Injection::SetParam {
+                name: name.to_string(),
+                value: value.to_string(),
+            }],
+        }
+    }
+
+    async fn seed_connect(
+        store: &Arc<dyn CacheStore>,
+        hostname: &str,
+        secrets: Vec<InjectionRule>,
+        connections: Vec<db::AppConnectionRow>,
+    ) {
+        let resp = ConnectResponse {
+            injection_rules: secrets,
+            app_connections: connections,
+            project_id: Some("p1".to_string()),
+            organization_id: Some("o1".to_string()),
+            ..Default::default()
+        };
+        let key = format!("connect:o1:p1:tok:{hostname}");
+        store.set(&key, &resp, 60).await;
+    }
+
+    /// Seed the app-injection cache for a fixture connection (no
+    /// session_policy → no cache-key suffix), labeled "Conn".
+    async fn seed_app_injection(
+        store: &Arc<dyn CacheStore>,
+        conn_id: &str,
+        provider: &str,
+        hostname: &str,
+        rules: Vec<InjectionRule>,
+    ) {
+        seed_app_injection_cache(
+            store,
+            "o1",
+            "p1",
+            &app_conn(conn_id, provider),
+            hostname,
+            rules,
+            None,
+            Some("Conn"),
+        )
+        .await;
+    }
+
+    fn applied_auth(path: &str, rules: &[InjectionRule]) -> (Option<String>, String) {
+        let mut headers = hyper::HeaderMap::new();
+        let mut request_path = path.to_string();
+        apply_injections(&mut headers, &mut request_path, rules);
+        let auth = headers
+            .get("authorization")
+            .map(|v| v.to_str().unwrap().to_string());
+        (auth, request_path)
+    }
+
+    #[tokio::test]
+    async fn coexisting_secret_and_app_rules_merge() {
+        let engine = PolicyEngine::test_stub();
+        let store = crate::cache::create_store().await.unwrap();
+        seed_connect(
+            &store,
+            HOST,
+            vec![param_rule("/youtube/*", "key", "yt-key")],
+            vec![app_conn("c1", "google-calendar")],
+        )
+        .await;
+        seed_app_injection(
+            &store,
+            "c1",
+            "google-calendar",
+            HOST,
+            vec![header_rule("/calendar/*", "Bearer cal")],
+        )
+        .await;
+
+        // A calendar request gets the OAuth Bearer (the #428 fix)…
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &[],
+            None,
+            Some("/calendar/v3/users/me/calendarList"),
+        )
+        .await
+        .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let (auth, path) =
+            applied_auth("/calendar/v3/users/me/calendarList", &rules.injection_rules);
+        assert_eq!(auth.as_deref(), Some("Bearer cal"));
+        assert!(!path.contains("key=yt-key"));
+        // …and the serving connection's label is attributed.
+        assert_eq!(rules.connection_label.as_deref(), Some("Conn"));
+
+        // A youtube request still gets the API key and no app metadata.
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &[],
+            None,
+            Some("/youtube/v3/search"),
+        )
+        .await
+        .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let (auth, path) = applied_auth("/youtube/v3/search", &rules.injection_rules);
+        assert_eq!(auth, None);
+        assert!(path.contains("key=yt-key"));
+        assert!(rules.connection_label.is_none());
+        assert!(rules.session_policy.is_none());
+    }
+
+    #[tokio::test]
+    async fn ambiguity_swallowed_when_secrets_serve_the_path() {
+        let engine = PolicyEngine::test_stub();
+        let store = crate::cache::create_store().await.unwrap();
+        // Two same-provider connections make /gmail requests ambiguous.
+        seed_connect(
+            &store,
+            HOST,
+            vec![header_rule("/gmail/*", "ApiKey gmail-secret")],
+            vec![app_conn("c1", "gmail"), app_conn("c2", "gmail")],
+        )
+        .await;
+
+        // The secret serves /gmail — the ambiguity is a best-effort no-op.
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &[],
+            None,
+            Some("/gmail/v1/users/me"),
+        )
+        .await
+        .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let (auth, _) = applied_auth("/gmail/v1/users/me", &rules.injection_rules);
+        assert_eq!(auth.as_deref(), Some("ApiKey gmail-secret"));
+
+        // With a secret that does NOT serve the path, ambiguity still escalates.
+        seed_connect(
+            &store,
+            HOST,
+            vec![param_rule("/youtube/*", "key", "yt-key")],
+            vec![app_conn("c1", "gmail"), app_conn("c2", "gmail")],
+        )
+        .await;
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &[],
+            None,
+            Some("/gmail/v1/users/me"),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(res, ResolveResult::Ambiguous(_)));
+    }
+
+    #[tokio::test]
+    async fn stale_connection_id_swallowed_when_secrets_serve_the_path() {
+        let engine = PolicyEngine::test_stub();
+        let store = crate::cache::create_store().await.unwrap();
+        seed_connect(
+            &store,
+            HOST,
+            vec![param_rule("/youtube/*", "key", "yt-key")],
+            vec![app_conn("c1", "google-calendar")],
+        )
+        .await;
+
+        // Stale explicit id on a secret-served path → proceed with the secret.
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &[],
+            Some("gone"),
+            Some("/youtube/v3/search"),
+        )
+        .await
+        .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let (_, path) = applied_auth("/youtube/v3/search", &rules.injection_rules);
+        assert!(path.contains("key=yt-key"));
+
+        // On a path the secret does not serve, NotFound still escalates.
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &[],
+            Some("gone"),
+            Some("/calendar/v3/events"),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(res, ResolveResult::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn intercept_token_comes_from_app_rules_only() {
+        let engine = PolicyEngine::test_stub();
+        let store = crate::cache::create_store().await.unwrap();
+        let host = "oauth2.googleapis.com";
+        // A Bearer-shaped catch-all secret coexists with the vertex-ai app
+        // connection on the intercept host; the intercepted token must be the
+        // app's, not the secret's.
+        seed_connect(
+            &store,
+            host,
+            vec![header_rule("*", "Bearer secret-tok")],
+            vec![app_conn("c1", "vertex-ai")],
+        )
+        .await;
+        seed_app_injection(
+            &store,
+            "c1",
+            "vertex-ai",
+            host,
+            vec![header_rule("/token*", "Bearer app-tok")],
+        )
+        .await;
+
+        let res = resolve_rules(&ctx(), host, &engine, &*store, &[], None, Some("/token"))
+            .await
+            .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let token = rules.intercept_token.expect("intercept token");
+        assert_eq!(token.access_token, "app-tok");
+    }
+
+    #[tokio::test]
+    async fn app_only_host_behavior_unchanged() {
+        let engine = PolicyEngine::test_stub();
+        let store = crate::cache::create_store().await.unwrap();
+        seed_connect(
+            &store,
+            HOST,
+            vec![],
+            vec![app_conn("c1", "google-calendar")],
+        )
+        .await;
+        seed_app_injection(
+            &store,
+            "c1",
+            "google-calendar",
+            HOST,
+            vec![header_rule("/calendar/*", "Bearer cal")],
+        )
+        .await;
+
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &[],
+            None,
+            Some("/calendar/v3/events"),
+        )
+        .await
+        .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let (auth, _) = applied_auth("/calendar/v3/events", &rules.injection_rules);
+        assert_eq!(auth.as_deref(), Some("Bearer cal"));
+        assert_eq!(rules.connection_label.as_deref(), Some("Conn"));
+    }
+
+    #[tokio::test]
+    async fn secret_only_resolution_keeps_rule_order() {
+        // No app connections: resolution must not reorder the secrets — the
+        // last-listed catch-all keeps winning overlaps exactly as before.
+        let engine = PolicyEngine::test_stub();
+        let store = crate::cache::create_store().await.unwrap();
+        seed_connect(
+            &store,
+            HOST,
+            vec![
+                header_rule("/v1/*", "specific"),
+                header_rule("*", "catch-all"),
+            ],
+            vec![],
+        )
+        .await;
+
+        let res = resolve_rules(&ctx(), HOST, &engine, &*store, &[], None, Some("/v1/x"))
+            .await
+            .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let (auth, _) = applied_auth("/v1/x", &rules.injection_rules);
+        assert_eq!(auth.as_deref(), Some("catch-all"));
+    }
+
+    #[tokio::test]
+    async fn vault_fallback_when_no_secret_or_app_rules() {
+        let engine = PolicyEngine::test_stub();
+        let store = crate::cache::create_store().await.unwrap();
+        seed_connect(&store, HOST, vec![], vec![]).await;
+        let vault_rules = vec![header_rule("*", "Basic vault-cred")];
+
+        let res = resolve_rules(
+            &ctx(),
+            HOST,
+            &engine,
+            &*store,
+            &vault_rules,
+            None,
+            Some("/anything"),
+        )
+        .await
+        .unwrap();
+        let ResolveResult::Resolved { rules, .. } = res else {
+            panic!("expected Resolved");
+        };
+        let (auth, _) = applied_auth("/anything", &rules.injection_rules);
+        assert_eq!(auth.as_deref(), Some("Basic vault-cred"));
+    }
 }

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -296,8 +296,11 @@ async fn resolve_rules(
     // Granular-access policy of the connection that wins injection (if any).
     let mut session_policy: Option<serde_json::Value> = None;
 
-    // If no secret rules, try app connections (per-request disambiguation)
-    if injection_rules.is_empty() && !resp.app_connections.is_empty() {
+    // Resolve app connections and MERGE with any secret rules. A shared host
+    // (e.g. www.googleapis.com) can carry both an API-key secret (/youtube/*)
+    // and OAuth app connections (/calendar/*, /drive/*); both are path-scoped
+    // and must coexist rather than the secret preempting the OAuth apps.
+    if !resp.app_connections.is_empty() {
         match engine
             .resolve_app_injection_for_request(
                 &resp.app_connections,
@@ -320,7 +323,7 @@ async fn resolve_rules(
                 session_policy: sp,
                 ..
             } => {
-                injection_rules = rules;
+                injection_rules.extend(rules);
                 token_expires_at = exp;
                 rewrite_host = rh;
                 connection_label = cl;

--- a/apps/gateway/src/inject.rs
+++ b/apps/gateway/src/inject.rs
@@ -172,6 +172,64 @@ pub(crate) fn apply_injections(
     count
 }
 
+/// True for the two host-wide catch-all shapes (`*` and `/*`) that
+/// [`path_matches`] accepts for every request path.
+pub(crate) fn is_catch_all_pattern(pattern: &str) -> bool {
+    matches!(pattern, "*" | "/*")
+}
+
+/// True when any rule's `path_pattern` matches the request path. A missing
+/// request path is conservatively non-matching.
+pub(crate) fn rules_serve_path(rules: &[InjectionRule], request_path: Option<&str>) -> bool {
+    request_path.is_some_and(|path| {
+        rules
+            .iter()
+            .any(|rule| path_matches(path, &rule.path_pattern))
+    })
+}
+
+/// Merge app-connection and secret injection rules for one request.
+///
+/// Both sets are path-scoped, so they coexist on shared hosts — e.g.
+/// `www.googleapis.com`, where a `/youtube/*` API-key secret and a
+/// `/calendar/*` OAuth Bearer serve different APIs (#428).
+/// [`apply_injections`] applies every matching rule in order with
+/// last-insert-wins per header, so ordering encodes precedence:
+///
+/// - specific patterns out-rank catch-alls (`*` / `/*`) regardless of
+///   source, so a host-wide secret doesn't starve path-scoped apps;
+/// - on equal specificity, secrets keep their historical precedence over
+///   apps, so pre-existing overlapping configs keep injecting the secret;
+/// - disjoint patterns simply coexist. A path matched by rules of both
+///   sources with different injection kinds (e.g. a query-param key and a
+///   Bearer header) carries both — pre-existing apply semantics.
+pub(crate) fn merge_injection_rules(
+    app_rules: Vec<InjectionRule>,
+    secret_rules: Vec<InjectionRule>,
+) -> Vec<InjectionRule> {
+    // Single-source resolutions pass through untouched: the specificity law
+    // arbitrates real coexistence, never a lone source, whose list order is
+    // load-bearing pre-existing behavior.
+    if app_rules.is_empty() {
+        return secret_rules;
+    }
+    if secret_rules.is_empty() {
+        return app_rules;
+    }
+    let (app_catch_all, app_specific): (Vec<_>, Vec<_>) = app_rules
+        .into_iter()
+        .partition(|rule| is_catch_all_pattern(&rule.path_pattern));
+    let (secret_catch_all, secret_specific): (Vec<_>, Vec<_>) = secret_rules
+        .into_iter()
+        .partition(|rule| is_catch_all_pattern(&rule.path_pattern));
+
+    let mut merged = app_catch_all;
+    merged.extend(secret_catch_all);
+    merged.extend(app_specific);
+    merged.extend(secret_specific);
+    merged
+}
+
 /// Add or replace a URL query parameter in a path+query string.
 ///
 /// Only the injected parameter is encoded via `form_urlencoded`; existing
@@ -896,6 +954,114 @@ mod tests {
             name: name.to_string(),
             value: value.to_string(),
         }
+    }
+
+    // ── merge_injection_rules / secret+app coexistence (#428) ───────────
+
+    fn apply_to(path: &str, rules: &[InjectionRule]) -> (hyper::HeaderMap, String) {
+        let mut headers = hyper::HeaderMap::new();
+        let mut request_path = path.to_string();
+        apply_injections(&mut headers, &mut request_path, rules);
+        (headers, request_path)
+    }
+
+    #[test]
+    fn catch_all_pattern_is_star_or_slash_star() {
+        assert!(is_catch_all_pattern("*"));
+        assert!(is_catch_all_pattern("/*"));
+        assert!(!is_catch_all_pattern("/youtube/*"));
+        assert!(!is_catch_all_pattern("/v1*"));
+        assert!(!is_catch_all_pattern(""));
+    }
+
+    #[test]
+    fn rules_serve_path_matches_any_rule() {
+        let rules = vec![make_rule("/youtube/*", vec![])];
+        assert!(rules_serve_path(&rules, Some("/youtube/v3/search")));
+        assert!(!rules_serve_path(&rules, Some("/calendar/v3/events")));
+        assert!(!rules_serve_path(&rules, None));
+        assert!(!rules_serve_path(&[], Some("/youtube/v3/search")));
+    }
+
+    #[test]
+    fn merged_disjoint_secret_and_app_rules_coexist() {
+        // #428: a /youtube/* API-key secret and a /calendar/* OAuth app share
+        // www.googleapis.com; each request applies only its own rule.
+        let secrets = vec![make_rule(
+            "/youtube/*",
+            vec![Injection::SetParam {
+                name: "key".to_string(),
+                value: "yt-key".to_string(),
+            }],
+        )];
+        let apps = vec![make_rule(
+            "/calendar/*",
+            vec![set_header("authorization", "Bearer app-token")],
+        )];
+        let merged = merge_injection_rules(apps, secrets);
+
+        let (headers, path) = apply_to("/calendar/v3/users/me/calendarList", &merged);
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer app-token");
+        assert!(!path.contains("key=yt-key"));
+
+        let (headers, path) = apply_to("/youtube/v3/search", &merged);
+        assert!(headers.get("authorization").is_none());
+        assert!(path.contains("key=yt-key"));
+    }
+
+    #[test]
+    fn specific_app_rule_beats_catch_all_secret_on_its_path() {
+        let secrets = vec![make_rule(
+            "*",
+            vec![set_header("authorization", "ApiKey secret-key")],
+        )];
+        let apps = vec![make_rule(
+            "/calendar/*",
+            vec![set_header("authorization", "Bearer app-token")],
+        )];
+        let merged = merge_injection_rules(apps, secrets);
+
+        let (headers, _) = apply_to("/calendar/v3/events", &merged);
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer app-token");
+
+        // Off the app's paths the host-wide secret still applies.
+        let (headers, _) = apply_to("/other/v1/x", &merged);
+        assert_eq!(headers.get("authorization").unwrap(), "ApiKey secret-key");
+    }
+
+    #[test]
+    fn single_source_lists_pass_through_unchanged() {
+        // An app-less (or secret-less) resolution must keep its original
+        // order — the specificity law applies only to real coexistence.
+        let secrets = vec![
+            make_rule("/v1/*", vec![set_header("authorization", "specific")]),
+            make_rule("*", vec![set_header("authorization", "catch-all")]),
+        ];
+        assert_eq!(merge_injection_rules(vec![], secrets.clone()), secrets);
+
+        let apps = vec![
+            make_rule("/v1/*", vec![set_header("authorization", "specific")]),
+            make_rule("*", vec![set_header("authorization", "catch-all")]),
+        ];
+        assert_eq!(merge_injection_rules(apps.clone(), vec![]), apps);
+    }
+
+    #[test]
+    fn equal_specificity_keeps_secret_precedence() {
+        // A pre-existing catch-all secret keeps winning over a catch-all app
+        // rule — no silent credential flip for overlapping configs.
+        let secrets = vec![make_rule(
+            "*",
+            vec![set_header("authorization", "token secret-pat")],
+        )];
+        let apps = vec![make_rule(
+            "*",
+            vec![set_header("authorization", "Bearer app-token")],
+        )];
+        let merged = merge_injection_rules(apps, secrets);
+
+        let (headers, _) = apply_to("/repos/acme/x", &merged);
+        assert_eq!(headers.get("authorization").unwrap(), "token secret-pat");
     }
 
     fn remove_header(name: &str) -> Injection {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (gateway). Fixes #428.

## What is the current behavior?

When a host carries **both** a vaulted API-key secret and one or more OAuth **app** connections, the gateway injects only the secret and skips OAuth app resolution entirely for that host. OAuth requests then reach the provider with no `Authorization` header and 401, surfaced as `app_not_connected`.

Concretely: with a YouTube Data API key vaulted as a secret on `www.googleapis.com` (`/youtube/`), every Google Workspace OAuth app that shares that host — Calendar (`/calendar/`), Drive (`/drive/`), and the Gmail legacy path (`/gmail/`) — stops authenticating. The same OAuth connection works on its dedicated host (`gmail.googleapis.com`), which is the tell.

Root cause: app-connection resolution is gated on there being no secret rules — `if injection_rules.is_empty() && !resp.app_connections.is_empty()` — in both `apps/gateway/src/gateway/mitm.rs` and `apps/gateway/src/gateway.rs`. The YouTube key makes `injection_rules` non-empty, so `resolve_app_injection_for_request` is never called. This is distinct from #236/#237 (which added missing `/batch/` path rules); here the path rules are correct but app resolution is skipped.

## What is the new behavior?

Run app resolution whenever app connections exist, and **merge** the resulting rules with any secret rules (`injection_rules.extend(rules)`) instead of gating on `injection_rules.is_empty()` and replacing. Secret and app rules are both path-scoped (`/youtube/*` vs `/calendar/*`), so they coexist: a `/calendar/` request now applies the OAuth Bearer, and a `/youtube/` request still applies the API key and ignores the non-matching OAuth rules. Applied to both the MITM and HTTP-proxy paths.

## Additional context

**Verification.** Reproduced and fixed against `main` (32b5852), and verified live end-to-end on a self-hosted gateway. Instrumenting the `apply_injections` call site, before the fix a calendar request carried only the youtube rule:

```
path=/calendar/v3/... n_rules=1 patterns=[("/youtube/*", 1)] injection_count=0 auth_len=0
```

After the fix it carries both, and the Bearer applies:

```
path=/calendar/v3/... n_rules=3 patterns=[("/youtube/*",1),("/calendar/*",1),("/batch/calendar/*",1)] injection_count=1 auth_len=260
```

All five services (Gmail dedicated + legacy, Calendar, Drive, Tasks, YouTube) return 200 after the fix; selective-mode agents still correctly get `access_restricted`.

**Local checks.** `cargo fmt --check`, `cargo build`, `cargo test`, and `cargo clippy -- -D warnings` all pass for `apps/gateway`.

**On test coverage.** I didn't add a dedicated unit test with this change: `resolve_rules` (MITM) and the HTTP-proxy resolve path have no existing unit harness, and `tests/integration.rs` requires a seeded Postgres (`#[ignore]`d). A focused unit test is doable by seeding the `connect:` and `app_injection:` caches (so token decrypt/refresh is skipped) and asserting `resolve_rules` merges the secret and OAuth rules — but it needs a couple of internal structs made `pub(crate)`, which I didn't want to do unprompted. Happy to add that unit test, or an `#[ignore]`d integration test, in whichever form matches your conventions — just let me know which you'd prefer.

**AI Disclosure.** Code drafted with Claude Code, reviewed and modified by me. Root cause was found by instrumenting the gateway and reading the resolution path; I verified the repro, the fix, and the before/after behavior against a local build myself before submitting.
