### PR TITLE
fix(gateway): send client_id on OpenAI OAuth token refresh

### DIFF
--- a/apps/gateway/src/secret_inject.rs
+++ b/apps/gateway/src/secret_inject.rs
@@ -236,6 +236,12 @@ pub(crate) async fn refresh_openai_oauth_if_expired(
     }
 }
 
+/// Public OAuth client id of the Codex CLI (the app that issued the vaulted
+/// ChatGPT session). auth.openai.com rejects refresh_token grants that omit
+/// `client_id` with 400 "Missing 'client_id'", so it must accompany every
+/// refresh. Not a secret — it is hardcoded in the open-source Codex CLI.
+const OPENAI_CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
 /// Refresh an OpenAI OAuth access_token using the refresh_token.
 async fn refresh_openai_oauth_token(
     refresh_token: &str,
@@ -244,6 +250,7 @@ async fn refresh_openai_oauth_token(
         .post("https://auth.openai.com/oauth/token")
         .timeout(std::time::Duration::from_secs(10))
         .form(&[
+            ("client_id", OPENAI_CODEX_CLIENT_ID),
             ("grant_type", "refresh_token"),
             ("refresh_token", refresh_token),
         ])

--- a/apps/gateway/src/secret_inject.rs
+++ b/apps/gateway/src/secret_inject.rs
@@ -236,24 +236,40 @@ pub(crate) async fn refresh_openai_oauth_if_expired(
     }
 }
 
-/// Public OAuth client id of the Codex CLI (the app that issued the vaulted
-/// ChatGPT session). auth.openai.com rejects refresh_token grants that omit
-/// `client_id` with 400 "Missing 'client_id'", so it must accompany every
-/// refresh. Not a secret — it is hardcoded in the open-source Codex CLI.
+const OPENAI_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+
+/// Public OAuth client id of the Codex CLI — the app that issued the vaulted
+/// ChatGPT session we are refreshing.
+///
+/// `auth.openai.com` rejects a `refresh_token` grant that omits it with
+/// 400 `Missing 'client_id'`, so without this the refresh can never succeed and
+/// the session hard-expires with the access token (~10 days).
+///
+/// A constant rather than configuration: it identifies OpenAI's own first-party
+/// CLI, is hardcoded in the open-source Codex client, and the vaulted
+/// `auth.json` has no `client_id` field to read it from. That is unlike the
+/// OAuth providers in `apps.rs`, which take a `client_id_env` because an
+/// operator supplies their own app there.
 const OPENAI_CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+/// Form body for the refresh_token grant. Split out from the request so the
+/// field set can be asserted — sending it needs the network.
+fn refresh_token_form(refresh_token: &str) -> [(&'static str, &str); 3] {
+    [
+        ("client_id", OPENAI_CODEX_CLIENT_ID),
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+    ]
+}
 
 /// Refresh an OpenAI OAuth access_token using the refresh_token.
 async fn refresh_openai_oauth_token(
     refresh_token: &str,
 ) -> anyhow::Result<(String, Option<String>)> {
     let resp = reqwest::Client::new()
-        .post("https://auth.openai.com/oauth/token")
+        .post(OPENAI_TOKEN_URL)
         .timeout(std::time::Duration::from_secs(10))
-        .form(&[
-            ("client_id", OPENAI_CODEX_CLIENT_ID),
-            ("grant_type", "refresh_token"),
-            ("refresh_token", refresh_token),
-        ])
+        .form(&refresh_token_form(refresh_token))
         .send()
         .await
         .map_err(|e| anyhow::anyhow!("openai oauth token refresh request failed: {e}"))?;
@@ -288,6 +304,41 @@ async fn refresh_openai_oauth_token(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── openai oauth refresh ───────────────────────────────────────────
+
+    // The regression guard for a refresh that never once succeeded: without
+    // `client_id`, auth.openai.com answers 400 "Missing 'client_id'", the
+    // gateway falls through to the expired token, and every chatgpt.com request
+    // 401s until the user re-authenticates by hand.
+    #[test]
+    fn refresh_token_form_sends_client_id_and_the_grant() {
+        let form = refresh_token_form("rt-abc123");
+
+        assert_eq!(
+            form,
+            [
+                ("client_id", OPENAI_CODEX_CLIENT_ID),
+                ("grant_type", "refresh_token"),
+                ("refresh_token", "rt-abc123"),
+            ]
+        );
+    }
+
+    // Pinned as a literal: a typo here is not a compile error and not a test
+    // failure elsewhere — it surfaces as `invalid_client` from OpenAI, inside a
+    // warning, roughly ten days after anyone touched this.
+    #[test]
+    fn client_id_is_the_codex_cli_app() {
+        assert_eq!(OPENAI_CODEX_CLIENT_ID, "app_EMoamEEZ73f0CkXaXp7hrann");
+    }
+
+    // Same reasoning: the endpoint is only exercised against the network, so a
+    // wrong URL fails at runtime rather than here.
+    #[test]
+    fn token_url_is_the_openai_oauth_endpoint() {
+        assert_eq!(OPENAI_TOKEN_URL, "https://auth.openai.com/oauth/token");
+    }
 
     // ── build_injections: anthropic ────────────────────────────────────
 


### PR DESCRIPTION
Fixes #433.

`auth.openai.com/oauth/token` rejects a `refresh_token` grant that omits `client_id` with `400 Missing 'client_id'`, so `refresh_openai_oauth_token` has never once succeeded. The failure is quiet by design — the caller logs a warning and falls through to the *expired* token — so a vaulted ChatGPT session works until its access token expires (~10 days), then every `chatgpt.com` request 401s until someone deletes the secret and re-authenticates by hand.

---

> **Maintainer note.** @morganfamilyagents diagnosed this precisely — the endpoint, the missing field, the client id, and the log evidence in #433 were all correct, and the fix is unchanged in substance. I pushed a follow-up commit adding the tests and the endpoint verification, since the PR description noted a local Rust build wasn't available. Thanks for the unusually complete report; the reproduction steps and the downstream `Read-only file system (os error 30)` symptom made this quick to confirm.

---

## Verified against the live endpoint

Probed with a bogus refresh token (public endpoint, no auth):

| Request | Response |
| --- | --- |
| form, no `client_id` — **before this PR** | `Missing 'client_id'` / `missing_required_parameter` |
| form + `client_id` | `token_expired` — parsed, moved past `client_id` |
| **JSON** + `client_id` | `token_expired` — identical |
| form + **wrong** `client_id` | `Invalid client specified.` / `invalid_client` |

Row 1 reproduces the reported error exactly. Row 4 shows the id is genuinely validated and that this one is right.

Row 3 is worth recording: the Codex CLI sends this grant as **JSON**, not form-encoded (`codex-rs/login/src/auth/manager.rs`), so the form body looked like it might be rejected regardless of the added field. The endpoint accepts both identically — so the existing encoding stays and the change remains one field.

## Why a constant

The vaulted `auth.json` carries no `client_id` — confirmed in Codex's own `TokenData` — so it cannot be read from the credential. The value identifies OpenAI's first-party public CLI and is hardcoded in the open-source client. That is unlike the OAuth providers in `apps.rs`, which take a `client_id_env` because an *operator* supplies their own app there.

## Tests

The form construction is split into a small pure function, because the request itself needs the network; the tests then assert the field set and pin the client id as a literal.

Both were mutation-checked: renaming the key to `clientId` fails one, mistyping a single character of the id fails the other. That matters here because either mistake otherwise surfaces only as an OpenAI error inside a warning, days later.

## Not changed

`id_token` and `last_refresh` are still not persisted from the refresh response — deliberately. `default_interceptions.rs` intercepts Codex's *local* self-refresh with a synthetic `200` so Codex stamps its own `last_refresh`, and notes that `id_token` is intentionally not returned. Injection reads only `access_token` and `account_id`. The upstream refresh was the broken half.

The fall-through-to-expired-token behavior also stays: once the refresh works, that path only fires for a genuinely dead refresh token, where re-authenticating *is* the right answer.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` (483 + 8) all green with **no features** — the standalone OSS build.
