### PR TITLE
fix(policy): close credential-injection host-enforcement bypass

### DIFF
--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -1352,6 +1352,56 @@ pub(crate) fn provider_matches_host_and_path(provider: &str, hostname: &str, pat
         })
 }
 
+/// Like [`provider_matches_host_and_path`], but matches ONLY through a
+/// **path-scoped** host rule (`path_prefix` set and the request path under it) —
+/// never a bare host/suffix rule. Path-scoped rules mark a legacy/mirror
+/// endpoint of a specific API surface (e.g. Gmail's `www.googleapis.com/gmail/`
+/// mirror of `gmail.googleapis.com`), so they are safe to fold into a
+/// TOOL-scoped policy match; a broad credential-zone rule (e.g. AWS's bare
+/// `*.amazonaws.com`) is deliberately excluded so a tool-scoped rule can't bleed
+/// across sibling services on the same zone.
+#[must_use]
+pub(crate) fn provider_matches_path_scoped(provider: &str, hostname: &str, path: &str) -> bool {
+    all_providers()
+        .find(|p| p.provider == provider)
+        .is_some_and(|app| {
+            app.host_rules.iter().any(|r| {
+                host_rule_matches(r, hostname)
+                    && r.path_prefix.is_some_and(|pfx| path.starts_with(pfx))
+            })
+        })
+}
+
+/// Test helper: a representative `(provider, host, path)` for every host rule
+/// that attaches a credential to a FORWARDED request — a concrete host matching
+/// the rule's pattern and a path under its prefix. Excludes intercept rules
+/// (synthetic-token, never forwarded) and per-tenant suffix rules gated on a
+/// stored credential host — as SAMPLES only; the runtime matcher
+/// (`provider_matches_host_and_path`) intentionally still covers those hosts, so
+/// a whole-app rule governs them too (enforcement ⊇ injection, monotonic — a
+/// per-tenant/intercept host can't be sampled statically, not that it's
+/// unenforced). Backs the enforcement-⊇-injection invariant test.
+#[cfg(test)]
+pub(crate) fn injection_surface_samples() -> Vec<(&'static str, String, String)> {
+    let mut out = Vec::new();
+    for p in all_providers() {
+        for r in p.host_rules {
+            if r.intercept || r.credential_host_field.is_some() {
+                continue;
+            }
+            let host = match r.pattern {
+                HostPattern::Exact(h) => h.to_string(),
+                HostPattern::Suffix(s) => format!("probe{s}"),
+            };
+            let path = r
+                .path_prefix
+                .map_or_else(|| "/".to_string(), |pfx| format!("{pfx}probe"));
+            out.push((p.provider, host, path));
+        }
+    }
+    out
+}
+
 /// Look up the display name for a provider slug (e.g., "jira" -> "Jira").
 #[must_use]
 pub(crate) fn display_name_for_provider(provider: &str) -> Option<&'static str> {

--- a/apps/gateway/src/connect.rs
+++ b/apps/gateway/src/connect.rs
@@ -344,18 +344,13 @@ impl PolicyEngine {
         let matching: Vec<_> = secrets
             .into_iter()
             .filter(|s| {
-                if host_matches(hostname, &s.host_pattern) {
-                    return true;
-                }
-                // OpenAI secrets cover chatgpt.com, api.openai.com, and their subdomains.
-                if s.type_ == "openai" {
-                    let h = hostname.split(':').next().unwrap_or(hostname);
-                    return h == "api.openai.com"
-                        || h == "chatgpt.com"
-                        || h.ends_with(".chatgpt.com")
-                        || h.ends_with(".openai.com");
-                }
-                false
+                // Injection covers every host this secret's credential is valid on —
+                // the SAME set enforcement resolves (`db::find_secret_hosts`), so a
+                // policy rule on the secret can never fall short of injection (the
+                // OpenAI multi-host bypass class).
+                secret_inject::secret_host_patterns(&s.type_, &s.host_pattern)
+                    .iter()
+                    .any(|p| host_matches(hostname, p))
             })
             .collect();
 
@@ -930,10 +925,11 @@ impl PolicyEngine {
         // Check 1: project or org has manual secrets matching this host
         match db::find_secrets_by_project(&self.pool, &agent.project_id).await {
             Ok(secrets) => {
-                if secrets
-                    .iter()
-                    .any(|s| host_matches(hostname, &s.host_pattern))
-                {
+                if secrets.iter().any(|s| {
+                    secret_inject::secret_host_patterns(&s.type_, &s.host_pattern)
+                        .iter()
+                        .any(|p| host_matches(hostname, p))
+                }) {
                     return true;
                 }
             }
@@ -945,10 +941,11 @@ impl PolicyEngine {
         // Also check org-level secrets
         match db::find_secrets_by_org(&self.pool, &agent.organization_id).await {
             Ok(secrets) => {
-                if secrets
-                    .iter()
-                    .any(|s| host_matches(hostname, &s.host_pattern))
-                {
+                if secrets.iter().any(|s| {
+                    secret_inject::secret_host_patterns(&s.type_, &s.host_pattern)
+                        .iter()
+                        .any(|p| host_matches(hostname, p))
+                }) {
                     return true;
                 }
             }

--- a/apps/gateway/src/db.rs
+++ b/apps/gateway/src/db.rs
@@ -532,7 +532,8 @@ pub(crate) struct PolicyV2Rules {
     pub principals: PrincipalSet,
     /// The org+project custom secrets' host patterns (step 8), so a `secret` target
     /// can permit/deny its host DB-free per request. Empty unless a loaded rule has
-    /// a secret target (lazy). Only cloud ever populates it.
+    /// a secret target (lazy). Populated by both the OSS core and the EE engine
+    /// (`find_secret_hosts` is shared) whenever `POLICY_ENFORCE_V2` is on.
     #[serde(default)]
     pub secret_hosts: SecretHosts,
     /// The org+project app connections' providers, so a `connection` target can
@@ -547,15 +548,18 @@ pub(crate) struct PolicyV2Rules {
 /// connection resolution (cached with `PolicyV2Rules`) so the block/allow engine
 /// can let a `secret` target PERMIT/deny its host DB-free per request (step 8).
 /// `by_id` serves a specific `secret_id` target; `project_hosts`/`org_hosts` serve
-/// a `secret_scope` ("all secrets at a level") target. Empty in OSS and whenever no
-/// loaded rule has a secret target (the lazy skip). Only cloud ever populates it.
+/// a `secret_scope` ("all secrets at a level") target. Each secret contributes ALL
+/// the hosts its credential injects on (`secret_inject::secret_host_patterns`) — a
+/// list, because a typed secret (OpenAI) is valid on several hosts — so enforcement
+/// covers exactly the injection surface. Populated whenever a loaded rule has a
+/// secret target (the lazy skip leaves it empty otherwise).
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct SecretHosts {
-    /// A specific secret's id → its `host_pattern`.
-    pub by_id: std::collections::HashMap<String, String>,
-    /// Every PROJECT-scoped secret's `host_pattern` (for `secret_scope="project"`).
+    /// A specific secret's id → every host pattern its credential injects on.
+    pub by_id: std::collections::HashMap<String, Vec<String>>,
+    /// Every PROJECT-scoped secret's host patterns (for `secret_scope="project"`).
     pub project_hosts: Vec<String>,
-    /// Every ORG-scoped secret's `host_pattern` (for `secret_scope="organization"`).
+    /// Every ORG-scoped secret's host patterns (for `secret_scope="organization"`).
     pub org_hosts: Vec<String>,
 }
 
@@ -658,6 +662,8 @@ struct SecretHostRow {
     id: String,
     host_pattern: String,
     scope: String,
+    #[sqlx(rename = "type")]
+    type_: String,
 }
 
 /// Resolve the host patterns of the acting org+project custom secrets so the
@@ -676,7 +682,7 @@ pub(crate) async fn find_secret_hosts(
 ) -> Result<SecretHosts> {
     let rows: Vec<SecretHostRow> = sqlx::query_as::<_, SecretHostRow>(
         r#"
-        SELECT id, host_pattern, scope FROM secrets
+        SELECT id, host_pattern, scope, type FROM secrets
         WHERE project_id = $2
            OR (organization_id = $1 AND scope = 'organization')
         "#,
@@ -689,12 +695,15 @@ pub(crate) async fn find_secret_hosts(
 
     let mut hosts = SecretHosts::default();
     for row in rows {
+        // Expand each secret to EVERY host its credential injects on (a typed
+        // secret like OpenAI covers several), so enforcement == injection.
+        let patterns = crate::secret_inject::secret_host_patterns(&row.type_, &row.host_pattern);
         match row.scope.as_str() {
-            "project" => hosts.project_hosts.push(row.host_pattern.clone()),
-            "organization" => hosts.org_hosts.push(row.host_pattern.clone()),
+            "project" => hosts.project_hosts.extend(patterns.iter().cloned()),
+            "organization" => hosts.org_hosts.extend(patterns.iter().cloned()),
             _ => {}
         }
-        hosts.by_id.insert(row.id, row.host_pattern);
+        hosts.by_id.insert(row.id, patterns);
     }
     Ok(hosts)
 }

--- a/apps/gateway/src/policy_engine/assemble.rs
+++ b/apps/gateway/src/policy_engine/assemble.rs
@@ -26,7 +26,7 @@ fn decode_identities(rows: &[PolicyIdentityRow]) -> Vec<Identity> {
 /// load, so a forged/foreign id resolves to nothing.
 fn secret_target_hosts(r: &PolicyTargetRow, secret_hosts: &SecretHosts) -> Vec<String> {
     if let Some(id) = &r.secret_id {
-        secret_hosts.by_id.get(id).cloned().into_iter().collect()
+        secret_hosts.by_id.get(id).cloned().unwrap_or_default()
     } else if let Some(scope) = &r.secret_scope {
         match scope.as_str() {
             "project" => secret_hosts.project_hosts.clone(),
@@ -221,7 +221,7 @@ mod tests {
         let mut hosts = SecretHosts::default();
         hosts
             .by_id
-            .insert("s1".to_string(), "api.example.com".to_string());
+            .insert("s1".to_string(), vec!["api.example.com".to_string()]);
         hosts.project_hosts.push("p.example.com".to_string());
         let rows = vec![row(|r| {
             r.targets = Json(vec![
@@ -239,6 +239,35 @@ mod tests {
         );
         assert!(
             matches!(&rules[0].targets[2], Target::Secret { host_patterns } if host_patterns.is_empty())
+        );
+    }
+
+    #[test]
+    fn openai_secret_target_resolves_every_injected_host() {
+        // `find_secret_hosts` expands an OpenAI secret to its full injection
+        // surface (`secret_host_patterns`); a specific-secret rule then enforces
+        // on ALL of them — so a block/approval rule can't be dodged via ChatGPT /
+        // the other OpenAI hosts the one credential is injected on.
+        let mut hosts = SecretHosts::default();
+        hosts.by_id.insert(
+            "s1".to_string(),
+            crate::secret_inject::secret_host_patterns("openai", "api.openai.com"),
+        );
+        let rows = vec![row(|r| {
+            r.targets = Json(vec![target(json!({"kind": "secret", "secretId": "s1"}))]);
+        })];
+        let rules = assemble(&rows, &hosts, &ConnectionProviders::default());
+        let Target::Secret { host_patterns } = &rules[0].targets[0] else {
+            panic!("expected a secret target");
+        };
+        assert_eq!(
+            host_patterns,
+            &[
+                "api.openai.com".to_string(),
+                "chatgpt.com".to_string(),
+                "*.chatgpt.com".to_string(),
+                "*.openai.com".to_string(),
+            ]
         );
     }
 

--- a/apps/gateway/src/policy_engine/catalog.generated.json
+++ b/apps/gateway/src/policy_engine/catalog.generated.json
@@ -682,6 +682,15 @@
         "GET"
       ]
     },
+    "graphql": {
+      "hostPattern": "api.fly.io",
+      "paths": [
+        "/graphql"
+      ],
+      "methods": [
+        "POST"
+      ]
+    },
     "list_apps": {
       "hostPattern": "api.machines.dev",
       "paths": [
@@ -854,6 +863,15 @@
       "methods": [
         "GET"
       ]
+    },
+    "read_raw_content": {
+      "hostPattern": "raw.githubusercontent.com",
+      "paths": [
+        "/*"
+      ],
+      "methods": [
+        "GET"
+      ]
     }
   },
   "github-app": {
@@ -960,6 +978,15 @@
       "hostPattern": "api.github.com",
       "paths": [
         "/user/repos"
+      ],
+      "methods": [
+        "GET"
+      ]
+    },
+    "read_raw_content": {
+      "hostPattern": "raw.githubusercontent.com",
+      "paths": [
+        "/*"
       ],
       "methods": [
         "GET"

--- a/apps/gateway/src/policy_engine/catalog.rs
+++ b/apps/gateway/src/policy_engine/catalog.rs
@@ -37,6 +37,20 @@ fn catalog() -> &'static Catalog {
     CATALOG.get_or_init(|| serde_json::from_str(BASE_CATALOG_JSON).expect("parse base catalog"))
 }
 
+/// Whether ALL of a provider's catalog tools share a single `host_pattern`. For
+/// such an app every host it injects on is the same API served under a twin host
+/// (a regional/apex mirror), so a tool-scoped rule may safely fold the app's full
+/// injection surface. For a MULTI-host-family app (AWS's per-service subdomains),
+/// the host discriminates which tool, so folding would let a tool rule bleed
+/// across sibling services — those are excluded.
+fn single_host_family(provider_tools: &HashMap<String, CatalogTool>) -> bool {
+    let mut hosts = provider_tools.values().map(|t| t.host_pattern.as_str());
+    match hosts.next() {
+        Some(first) => hosts.all(|h| h == first),
+        None => false,
+    }
+}
+
 /// A throwaway `policy::PolicyRule` so one path×method variant routes through
 /// the gateway's exact `matches_request` (the action is irrelevant to
 /// matching). Conditions ride from the owning rule — vacuous in OSS, where the
@@ -55,11 +69,28 @@ fn variant_rule(
     }
 }
 
-/// Does the request hit the app target? Named tools match when the request host
-/// matches the tool's host AND any of its path×method variants matches. An
-/// EMPTY tool set is the WHOLE app: host-only against every catalog tool host
-/// of the provider (any path/method). Unknown provider or tool id → false
-/// (fail-closed).
+/// Does the request hit the app target? The host decision defers to the
+/// **injection registry** (`crate::apps`), the authority for what traffic is the
+/// app's — so a rule governs exactly the hosts the app's credential is injected
+/// on and can't fall short of it (the class where a request is credentialed but
+/// no rule matches it, e.g. Gmail's legacy `www.googleapis.com/gmail/` mirror of
+/// `gmail.googleapis.com`). It is a UNION with the catalog's own tool host, so it
+/// only ever widens matching (never drops an existing match) and still covers a
+/// catalog provider absent from the injection registry. Unknown provider or tool
+/// id → false (fail-closed).
+///
+/// - **Whole-app** (empty tools): matches any host the app injects on — the app's
+///   FULL injection surface, including a broad credential zone like AWS's
+///   `*.amazonaws.com`.
+/// - **Tool-scoped**: a tool matches on its own catalog host OR an injection
+///   **mirror** of the app — a path-scoped mirror (`www.googleapis.com/gmail/`),
+///   or, for a single-host-family app (all tools on one host), any host the app
+///   injects on (its regional/apex twins, e.g. datadog `.datadoghq.eu`, sentry
+///   apex) — then its path×method. It deliberately does NOT fold a MULTI-host
+///   injection zone (AWS's per-service `*.amazonaws.com`), so a tool rule can't
+///   bleed across sibling services. A truly distinct endpoint host (github
+///   `raw.githubusercontent.com`, fly.io GraphQL) is a separate catalog tool of
+///   its own; whole-app rules also cover it.
 pub(super) fn app_target_matches(
     provider: &str,
     tools: &[String],
@@ -75,13 +106,30 @@ pub(super) fn app_target_matches(
     if tools.is_empty() {
         return provider_tools
             .values()
-            .any(|tool| host_matches(request_host, &tool.host_pattern));
+            .any(|tool| host_matches(request_host, &tool.host_pattern))
+            || crate::apps::provider_matches_host_and_path(provider, request_host, request_path);
     }
+    // The host is the app's per-tool catalog host OR an injection MIRROR of the
+    // app (tool-independent → computed once): a path-scoped mirror (Gmail's
+    // `www.googleapis.com/gmail/`), or — for a single-host-family app (all its
+    // tools on one host, so its other injection hosts are regional/apex twins of
+    // the same API, e.g. datadog `.datadoghq.eu`, sentry apex) — any host the app
+    // injects on. A multi-host-family app (AWS's per-service `ec2.*`/`s3.*`/…) is
+    // excluded, so a tool rule can never bleed across sibling services on a
+    // shared credential zone.
+    let host_via_mirror =
+        crate::apps::provider_matches_path_scoped(provider, request_host, request_path)
+            || (single_host_family(provider_tools)
+                && crate::apps::provider_matches_host_and_path(
+                    provider,
+                    request_host,
+                    request_path,
+                ));
     tools.iter().any(|tool_id| {
         let Some(tool) = provider_tools.get(tool_id) else {
             return false;
         };
-        if !host_matches(request_host, &tool.host_pattern) {
+        if !host_matches(request_host, &tool.host_pattern) && !host_via_mirror {
             return false;
         }
         let methods: Vec<Option<&str>> = if tool.methods.is_empty() {
@@ -155,5 +203,150 @@ mod tests {
             "GET",
             "/"
         ));
+    }
+
+    // ── Injection-surface coverage (credential-injection bypass fix) ──────────
+    // The host decision folds in the injection registry so a rule governs every
+    // host the app's credential is injected on — closing the legacy-alias class
+    // (`www.googleapis.com/gmail/...`) where a request was credentialed but no
+    // rule matched it.
+
+    #[test]
+    fn gmail_rule_covers_the_legacy_www_endpoint() {
+        // The reported bypass: Gmail injects on gmail.googleapis.com AND the
+        // legacy www.googleapis.com/gmail/*, but the catalog lists only the
+        // former. Both a whole-app and a tool-scoped Gmail rule must now match
+        // the legacy host (so a Block rule denies it), while the primary host
+        // still matches unchanged.
+        let path = "/gmail/v1/users/me/drafts";
+        // Whole-app.
+        assert!(matches("gmail", &[], "www.googleapis.com", "POST", path));
+        assert!(matches("gmail", &[], "gmail.googleapis.com", "POST", path));
+        // Tool-scoped (create_draft = POST /gmail/v1/users/*/drafts).
+        assert!(matches(
+            "gmail",
+            &["create_draft"],
+            "www.googleapis.com",
+            "POST",
+            path
+        ));
+        assert!(matches(
+            "gmail",
+            &["create_draft"],
+            "gmail.googleapis.com",
+            "POST",
+            path
+        ));
+        // A non-Gmail path on the shared host is NOT Gmail's traffic.
+        assert!(!matches(
+            "gmail",
+            &[],
+            "www.googleapis.com",
+            "GET",
+            "/calendar/v3/calendars"
+        ));
+    }
+
+    #[test]
+    fn aws_whole_app_covers_uncataloged_services_but_tool_scope_stays_precise() {
+        // AWS injects SigV4 on the whole `*.amazonaws.com` zone, but the catalog
+        // lists only ~10 services. A WHOLE-APP AWS rule must cover an
+        // uncataloged service (rds) — closing the highest-impact bypass...
+        assert!(matches(
+            "aws",
+            &[],
+            "rds.us-east-1.amazonaws.com",
+            "POST",
+            "/"
+        ));
+        // ...but a TOOL-scoped AWS rule must NOT bleed onto a sibling service
+        // (AWS's rule is a bare suffix with no path prefix), even though the
+        // tool's path pattern is a wildcard. It still matches its own service.
+        assert!(!matches(
+            "aws",
+            &["ec2_access"],
+            "rds.us-east-1.amazonaws.com",
+            "POST",
+            "/"
+        ));
+        assert!(matches(
+            "aws",
+            &["ec2_access"],
+            "ec2.us-east-1.amazonaws.com",
+            "POST",
+            "/"
+        ));
+    }
+
+    #[test]
+    fn catalog_only_provider_is_unaffected() {
+        // A provider matched purely via its catalog host (no broader injection
+        // surface) keeps matching exactly as before — the union never narrows.
+        assert!(matches(
+            "github",
+            &["create_issue"],
+            "api.github.com",
+            "POST",
+            "/repos/o/r/issues"
+        ));
+        assert!(!matches(
+            "github",
+            &["create_issue"],
+            "example.com",
+            "POST",
+            "/repos/o/r/issues"
+        ));
+    }
+
+    #[test]
+    fn distinct_endpoint_hosts_are_now_their_own_tools() {
+        // The alternate-access hosts are cataloged as their own tools, so a
+        // TOOL-scoped rule can target them (and whole-app/wildcard cover them).
+        // github raw file content — reading a private file via raw is governed.
+        assert!(matches(
+            "github",
+            &["read_raw_content"],
+            "raw.githubusercontent.com",
+            "GET",
+            "/owner/repo/main/secrets.txt"
+        ));
+        // The raw tool does not leak onto the API host (different tool there).
+        assert!(!matches(
+            "github",
+            &["read_raw_content"],
+            "api.github.com",
+            "GET",
+            "/repos/o/r/contents/x"
+        ));
+        // fly.io GraphQL control-plane endpoint.
+        assert!(matches(
+            "flyio",
+            &["graphql"],
+            "api.fly.io",
+            "POST",
+            "/graphql"
+        ));
+    }
+
+    /// The invariant (enforcement ⊇ injection): for EVERY provider the gateway
+    /// injects credentials for, a WHOLE-APP rule for that provider must match a
+    /// request on each host it injects on. This is the structural guarantee that
+    /// the two host lists can't diverge into a bypass again — it fails if the
+    /// engine regresses to catalog-only matching, or an injection host is added
+    /// that the app-target matcher can't reach.
+    #[test]
+    fn whole_app_rules_cover_the_entire_injection_surface() {
+        for (provider, host, path) in crate::apps::injection_surface_samples() {
+            // Only providers with a permission catalog are targetable by an
+            // app/connection rule (no tools → no rule); the rest have no
+            // enforcement surface to diverge from.
+            if catalog().get(provider).is_none() {
+                continue;
+            }
+            assert!(
+                app_target_matches(provider, &[], &host, "POST", &path, None, &None),
+                "whole-app rule for `{provider}` must cover its injection host `{host}` (path `{path}`)"
+            );
+        }
     }
 }

--- a/apps/gateway/src/secret_inject.rs
+++ b/apps/gateway/src/secret_inject.rs
@@ -159,6 +159,34 @@ pub(crate) fn build_injections(
     }
 }
 
+/// The host-match patterns a secret of `secret_type` injects its credential on,
+/// given its stored `host_pattern`. Single source of truth shared by the
+/// connect-time injection filter (`connect::resolve_secret_injections`) AND policy
+/// enforcement (`db::find_secret_hosts` → v2 `Target::Secret`), so injection
+/// coverage == enforcement coverage BY CONSTRUCTION — the secret analog of the
+/// provider-registry host fix. Every secret covers its own stored `host_pattern`;
+/// only `openai` adds the extra hosts one OpenAI credential is valid across
+/// (`api.openai.com`, ChatGPT, and their subdomains) regardless of which host it
+/// was stored under. Returned as `host_matches` patterns, so `*.openai.com` covers
+/// every `.openai.com` subdomain.
+#[must_use]
+pub(crate) fn secret_host_patterns(secret_type: &str, host_pattern: &str) -> Vec<String> {
+    let mut patterns = vec![host_pattern.to_string()];
+    if secret_type == "openai" {
+        for extra in [
+            "api.openai.com",
+            "chatgpt.com",
+            "*.chatgpt.com",
+            "*.openai.com",
+        ] {
+            if !patterns.iter().any(|p| p == extra) {
+                patterns.push(extra.to_string());
+            }
+        }
+    }
+    patterns
+}
+
 /// If the OpenAI OAuth access_token is expired, refresh it and persist the
 /// updated credentials. Returns `Some(updated_json)` on successful refresh,
 /// or `None` to fall through with the original (possibly expired) value.
@@ -472,5 +500,49 @@ mod tests {
     fn build_injections_unknown_type() {
         let injections = build_injections("unknown", "value", None, None);
         assert!(injections.is_empty());
+    }
+
+    // ── secret_host_patterns (injection == enforcement, the OpenAI bypass) ────
+
+    #[test]
+    fn secret_host_patterns_openai_covers_all_its_hosts() {
+        // One OpenAI credential is valid across api.openai.com, ChatGPT, and the
+        // subdomains — enforcement must resolve the same set injection does.
+        assert_eq!(
+            secret_host_patterns("openai", "api.openai.com"),
+            vec![
+                "api.openai.com".to_string(),
+                "chatgpt.com".to_string(),
+                "*.chatgpt.com".to_string(),
+                "*.openai.com".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn secret_host_patterns_openai_dedups_the_stored_host() {
+        // Stored under chatgpt.com (Codex/OAuth mode): same set, no duplicate.
+        assert_eq!(
+            secret_host_patterns("openai", "chatgpt.com"),
+            vec![
+                "chatgpt.com".to_string(),
+                "api.openai.com".to_string(),
+                "*.chatgpt.com".to_string(),
+                "*.openai.com".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn secret_host_patterns_other_types_are_just_their_host() {
+        // No expansion for symmetric types — enforcement already == injection.
+        assert_eq!(
+            secret_host_patterns("anthropic", "api.anthropic.com"),
+            vec!["api.anthropic.com".to_string()]
+        );
+        assert_eq!(
+            secret_host_patterns("generic", "internal.example.com"),
+            vec!["internal.example.com".to_string()]
+        );
     }
 }

--- a/packages/api/src/apps/app-permissions/flyio.ts
+++ b/packages/api/src/apps/app-permissions/flyio.ts
@@ -139,6 +139,15 @@ export const flyioPermissions: AppPermissionDefinition = {
           pathPattern: "/v1/apps/*/secrets",
           method: "POST",
         },
+        {
+          id: "graphql",
+          name: "GraphQL API",
+          description:
+            "Query or mutate via the Fly.io GraphQL API (api.fly.io/graphql — the legacy control-plane endpoint).",
+          hostPattern: "api.fly.io",
+          pathPattern: "/graphql",
+          method: "POST",
+        },
       ],
     },
   ],

--- a/packages/api/src/apps/app-permissions/github.ts
+++ b/packages/api/src/apps/app-permissions/github.ts
@@ -53,6 +53,15 @@ const githubGroups: AppToolGroup[] = [
         pathPattern: "/graphql",
         method: "POST",
       },
+      {
+        id: "read_raw_content",
+        name: "Read raw file content",
+        description:
+          "Fetch raw file contents directly from raw.githubusercontent.com (the legacy/CDN read host).",
+        hostPattern: "raw.githubusercontent.com",
+        pathPattern: "/*",
+        method: "GET",
+      },
     ],
   },
   {


### PR DESCRIPTION
## What & why

An agent under a block or approval rule could bypass it by switching to a host where the credential is still injected but the policy engine doesn't match — e.g. `POST www.googleapis.com/gmail/v1/users/me/drafts` was injected but unenforced, while `gmail.googleapis.com/...` was correctly denied. Root cause: enforcement derived its host coverage from a different list than injection, and the two diverged.

## Fix

Enforcement now derives from the injection registry, so enforcement host coverage always contains the injection surface. Every change only ever widens enforcement (fail-safe); injection is untouched.

- **App/connection targets** union the per-tool catalog hosts with the provider's full injection surface — closes the Gmail `www.googleapis.com` bypass and every whole-app equivalent (AWS included), guarded by an invariant test asserting a whole-app rule covers every injected host of every provider.
- **Tool-scoped rules** fold regional/apex/alt-domain mirror hosts only for single-host-family providers, while multi-service zones (AWS, GitHub) stay precise — no cross-service bleed.
- **Secrets** enforce every host their credential injects on via a shared `secret_host_patterns` source, not just the stored host.
- **Distinct-endpoint hosts** (GitHub `raw.githubusercontent.com`, Fly.io GraphQL `api.fly.io`) become catalog tools, so they're tool-targetable.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean; the `policy_engine` and `secret_inject` test suites pass.
- `pnpm --filter @onecli/api check-types` clean.
