### PR TITLE
feat(gateway): opt-in model routing on outbound LLM calls, plus Nadir app connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,10 @@ GATEWAY_API_DOMAIN=localhost:10255
 # Gateway proxy — where containers connect for the CONNECT proxy
 # OSS: host.docker.internal:10255, Cloud: gateway.onecli.sh:10255 (no protocol prefix)
 GATEWAY_BASE_URL=host.docker.internal:10255
+
+# Nadir model routing — rewrites `model` on outbound LLM completion requests to
+# the cheapest tier that can do the task. OFF unless NADIR_MODEL_ROUTING=1.
+# NOTE: when enabled, the prompt text of routed requests is sent to
+# api.getnadir.com to be classified. See docs/nadir-integration.md.
+NADIR_MODEL_ROUTING=
+NADIR_API_KEY=

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Open **http://localhost:10254**, create an agent, add your secrets, and point yo
 - **Two auth modes**: single-user (no login) for local use, or Google OAuth for teams
 - **Rust gateway**: fast, memory-safe HTTP gateway with MITM interception for HTTPS
 - **[Vault integration](docs/vault-integration.md)**: connect Bitwarden (or other password managers) for on-demand credential injection without storing secrets on the server
+- **[Model routing](docs/nadir-integration.md)**: opt-in, right-size the model on outbound LLM calls so agents stop paying top-tier prices for trivial prompts
 
 ## Project Structure
 
@@ -127,13 +128,14 @@ Dashboard at **http://localhost:10254**, gateway at **http://localhost:10255**.
 
 All environment variables are optional for local development:
 
-| Variable                | Description                       | Default            |
-| ----------------------- | --------------------------------- | ------------------ |
-| `DATABASE_URL`          | PostgreSQL connection string      | See `.env.example` |
-| `NEXTAUTH_SECRET`       | Enables Google OAuth (multi-user) | Single-user mode   |
-| `GOOGLE_CLIENT_ID`      | Google OAuth client ID            | —                  |
-| `GOOGLE_CLIENT_SECRET`  | Google OAuth client secret        | —                  |
-| `SECRET_ENCRYPTION_KEY` | AES-256-GCM encryption key        | Auto-generated     |
+| Variable                | Description                                            | Default            |
+| ----------------------- | ------------------------------------------------------ | ------------------ |
+| `DATABASE_URL`          | PostgreSQL connection string                           | See `.env.example` |
+| `NEXTAUTH_SECRET`       | Enables Google OAuth (multi-user)                      | Single-user mode   |
+| `GOOGLE_CLIENT_ID`      | Google OAuth client ID                                 | —                  |
+| `GOOGLE_CLIENT_SECRET`  | Google OAuth client secret                             | —                  |
+| `SECRET_ENCRYPTION_KEY` | AES-256-GCM encryption key                             | Auto-generated     |
+| `NADIR_MODEL_ROUTING`   | Enables LLM [model routing](docs/nadir-integration.md) | Off                |
 
 ## Contributing
 

--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -40,6 +40,9 @@ pub(crate) enum RequestFinalizer {
 pub(crate) enum BodyTransform {
     /// Inject agent identity trailer into GitHub commit messages.
     GitHubCommitTrailer,
+    /// Right-size the `model` field on outbound LLM completion requests using
+    /// Nadir's complexity classifier. Opt-in per project.
+    NadirModelRoute,
 }
 
 /// How a host rule matches incoming hostnames.
@@ -803,6 +806,30 @@ static APP_PROVIDERS: &[AppProvider] = &[
         body_transform: None,
     },
     AppProvider {
+        provider: "nadir",
+        display_name: "Nadir",
+        host_rules: &[HostRule {
+            pattern: HostPattern::Exact("api.getnadir.com"),
+            path_prefix: None,
+            // Nadir authenticates with `X-API-Key`, not `Authorization`.
+            strategy: AuthStrategy::None,
+            intercept: false,
+            credential_host_field: None,
+        }],
+        refresh: None,
+        metadata_headers: &[],
+        credential_headers: &[CredentialHeader {
+            credential_field: "apiKey",
+            header_name: "x-api-key",
+        }],
+        credential_params: &[],
+        host_rewrite: None,
+        finalizer: None,
+        // Rewrites the `model` field on outbound LLM requests. Attached to the
+        // LLM hosts (not to `api.getnadir.com`) via `body_transform_for_host`.
+        body_transform: None,
+    },
+    AppProvider {
         provider: "cloudflare",
         display_name: "Cloudflare",
         host_rules: &[HostRule {
@@ -1135,6 +1162,18 @@ pub(crate) fn finalizer_for_host(hostname: &str) -> Option<RequestFinalizer> {
 #[must_use]
 pub(crate) fn finalizer_for_provider(provider: &str) -> Option<RequestFinalizer> {
     all_providers().find_map(|p| (p.provider == provider).then_some(p.finalizer).flatten())
+}
+
+/// Return the body transform for a hostname, mirroring `finalizer_for_host`.
+#[must_use]
+pub(crate) fn body_transform_for_host(hostname: &str) -> Option<BodyTransform> {
+    all_providers().find_map(|p| {
+        p.host_rules
+            .iter()
+            .any(|r| host_rule_matches(r, hostname))
+            .then_some(p.body_transform)
+            .flatten()
+    })
 }
 
 #[must_use]
@@ -2424,6 +2463,37 @@ mod tests {
                 value: "Bearer vca_test123".to_string(),
             }
         );
+    }
+
+    // ── Nadir ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn providers_for_nadir_host() {
+        assert_eq!(providers_for_host("api.getnadir.com"), vec!["nadir"]);
+    }
+
+    #[test]
+    fn nadir_injects_api_key_header() {
+        let headers = credential_headers("nadir");
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].credential_field, "apiKey");
+        assert_eq!(headers[0].header_name, "x-api-key");
+    }
+
+    /// Nadir authenticates with `X-API-Key`, so it must not also acquire an
+    /// `Authorization` header — that would leak the key into a second slot.
+    #[test]
+    fn nadir_does_not_need_access_token() {
+        assert!(!needs_access_token("nadir"));
+        assert!(build_app_injections("nadir", "api.getnadir.com", "sk-test123").is_empty());
+    }
+
+    /// Model routing hangs off the LLM host, never off Nadir's own host, so
+    /// the registry entry must not carry a body transform.
+    #[test]
+    fn nadir_host_carries_no_body_transform() {
+        assert_eq!(body_transform_for_host("api.getnadir.com"), None);
+        assert_eq!(body_transform_for_provider("nadir"), None);
     }
 
     // ── Resend ────────────────────────────────────────────────────────

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -714,7 +714,25 @@ pub(crate) async fn forward_request(
         };
 
     // ── Provider-specific body transformation ────────────────────
-    let forward_body = match rules.body_transform {
+    let forward_body = match rules
+        .body_transform
+        .or_else(|| crate::apps::body_transform_for_host(super::strip_port(host)))
+        .or_else(|| super::transforms::nadir_model_route::transform_for_host(host))
+    {
+        Some(crate::apps::BodyTransform::NadirModelRoute) => {
+            // Unlike the arm below, a failure here must not swallow the body:
+            // the only error `try_route_model` returns is an unbufferable
+            // request, which cannot be forwarded at all. Every other failure
+            // (classifier down, timeout, unmapped model) already returns the
+            // original bytes, so `?` only fires on the unrecoverable case.
+            super::transforms::nadir_model_route::try_route_model(
+                host,
+                &method,
+                &path,
+                forward_body,
+            )
+            .await?
+        }
         Some(crate::apps::BodyTransform::GitHubCommitTrailer) => {
             if let (Some(agent_name), Some(project_id)) = (
                 proxy_ctx.agent_name.as_deref(),

--- a/apps/gateway/src/gateway/transforms.rs
+++ b/apps/gateway/src/gateway/transforms.rs
@@ -1,1 +1,2 @@
 pub(crate) mod github_commit_trailer;
+pub(crate) mod nadir_model_route;

--- a/apps/gateway/src/gateway/transforms/nadir_model_route.rs
+++ b/apps/gateway/src/gateway/transforms/nadir_model_route.rs
@@ -1,0 +1,592 @@
+//! Right-size the `model` field on outbound LLM completion requests.
+//!
+//! Agents habitually pin their most capable model for every call. Most calls
+//! do not need it. This transform sends the outbound prompt to Nadir's
+//! complexity classifier, gets back a `simple` / `medium` / `complex` bucket,
+//! and rewrites `model` to the tier the operator mapped that bucket to.
+//! The agent's code, credentials, and SDK are untouched.
+//!
+//! Invoked via the `BodyTransform::NadirModelRoute` dispatch in `forward.rs`.
+//! All Nadir-specific logic (host, method, path, config) is encapsulated here.
+//!
+//! **Off unless configured.** `transform_for_host` claims nothing until the
+//! operator sets `NADIR_MODEL_ROUTING=1`, and even then a request is only
+//! rewritten when its current model is one the operator listed on a tier
+//! ladder (see `Ladder::rank`). An unrecognised model is never touched.
+//!
+//! **Fails open.** A classifier timeout, a non-200, a malformed body, or an
+//! unmapped bucket all forward the original bytes unchanged. The only error
+//! this returns is an unbufferable request body, which is unrecoverable
+//! because the stream has already been consumed.
+//!
+//! **Privacy.** When enabled, the prompt text of routed requests is sent to
+//! `api.getnadir.com` for classification. This is the explicit trade the
+//! operator opts into; see `docs/nadir-integration.md`.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use hyper::body::Bytes;
+use hyper::Method;
+use tracing::{debug, warn};
+
+const BUCKET_URL: &str = "https://api.getnadir.com/v1/bucket";
+
+/// Requests larger than this skip classification and forward unchanged. A
+/// prompt this large is not a "simple" task under any classifier, and the
+/// round-trip would cost more than the routing saves.
+const MAX_CLASSIFY_BYTES: usize = 256 * 1024;
+
+/// Cap on the classifier round-trip. Nadir buckets in ~10ms server-side; this
+/// is a generous ceiling that still keeps a hung classifier from being felt.
+const DEFAULT_TIMEOUT_MS: u64 = 1500;
+
+// ── Config ──────────────────────────────────────────────────────────────
+
+/// A bucket → model mapping for one API flavour.
+#[derive(Debug, Default)]
+struct Ladder {
+    simple: Option<String>,
+    medium: Option<String>,
+    complex: Option<String>,
+}
+
+impl Ladder {
+    fn from_env(prefix: &str, defaults: [Option<&str>; 3]) -> Self {
+        let read = |suffix: &str, default: Option<&str>| {
+            std::env::var(format!("{prefix}_{suffix}"))
+                .ok()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .or_else(|| default.map(String::from))
+        };
+        Self {
+            simple: read("SIMPLE", defaults[0]),
+            medium: read("MEDIUM", defaults[1]),
+            complex: read("COMPLEX", defaults[2]),
+        }
+    }
+
+    fn model_for(&self, bucket: &str) -> Option<&str> {
+        match bucket {
+            "simple" => self.simple.as_deref(),
+            "medium" => self.medium.as_deref(),
+            "complex" => self.complex.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Position of `model` on this ladder, cheapest first. `None` means the
+    /// model is not on the ladder and must not be rewritten — the operator
+    /// never told us where it sits, so we cannot know a swap is a downgrade.
+    fn rank(&self, model: &str) -> Option<u8> {
+        for (idx, entry) in [&self.simple, &self.medium, &self.complex]
+            .into_iter()
+            .enumerate()
+        {
+            if entry.as_deref() == Some(model) {
+                return Some(idx as u8);
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug)]
+struct NadirConfig {
+    enabled: bool,
+    api_key: Option<String>,
+    /// Allow routing a request *up* the ladder. Off by default: a gateway that
+    /// silently makes calls more expensive is a bad surprise.
+    allow_upgrade: bool,
+    timeout: Duration,
+    anthropic: Ladder,
+    openai: Ladder,
+}
+
+fn config() -> &'static NadirConfig {
+    static CONFIG: OnceLock<NadirConfig> = OnceLock::new();
+    CONFIG.get_or_init(|| {
+        let flag = |name: &str| {
+            matches!(
+                std::env::var(name).ok().as_deref(),
+                Some("1") | Some("true") | Some("TRUE")
+            )
+        };
+        NadirConfig {
+            enabled: flag("NADIR_MODEL_ROUTING"),
+            api_key: std::env::var("NADIR_API_KEY")
+                .ok()
+                .filter(|k| !k.trim().is_empty()),
+            allow_upgrade: flag("NADIR_ALLOW_UPGRADE"),
+            timeout: Duration::from_millis(
+                std::env::var("NADIR_TIMEOUT_MS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(DEFAULT_TIMEOUT_MS),
+            ),
+            // Anthropic ships a clean three-tier family, so it gets defaults.
+            anthropic: Ladder::from_env(
+                "NADIR_ANTHROPIC",
+                [
+                    Some("claude-haiku-4-5"),
+                    Some("claude-sonnet-4-6"),
+                    Some("claude-opus-4-6"),
+                ],
+            ),
+            // OpenAI model names change too often to hardcode a ladder that
+            // would silently route to a model the operator never chose.
+            openai: Ladder::from_env("NADIR_OPENAI", [None, None, None]),
+        }
+    })
+}
+
+/// Claim this host for model routing, or leave it alone.
+///
+/// LLM endpoints are reached with a plain API-key secret rather than an OAuth
+/// app connection, so they have no entry in the provider registry to hang a
+/// transform on and must be matched by host here. Returning `None` while
+/// routing is off is what keeps a disabled gateway from ever buffering an LLM
+/// request body.
+pub(crate) fn transform_for_host(host: &str) -> Option<crate::apps::BodyTransform> {
+    (config().enabled && crate::policy::is_llm_host(host))
+        .then_some(crate::apps::BodyTransform::NadirModelRoute)
+}
+
+fn client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+// ── Request shape ───────────────────────────────────────────────────────
+
+/// Which completion API this request speaks, which decides both where the
+/// prompt lives in the body and which ladder applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Flavor {
+    /// `POST /v1/messages` — Anthropic Messages API.
+    AnthropicMessages,
+    /// `POST /v1/chat/completions` — OpenAI and the many APIs that clone it.
+    OpenAiChat,
+}
+
+impl Flavor {
+    fn detect(host: &str, method: &Method, path: &str) -> Option<Self> {
+        if method != Method::POST || !crate::policy::is_llm_host(host) {
+            return None;
+        }
+        // Ignore any query string.
+        let route = path.split('?').next().unwrap_or(path);
+        match route {
+            "/v1/messages" => Some(Self::AnthropicMessages),
+            "/v1/chat/completions" => Some(Self::OpenAiChat),
+            _ => None,
+        }
+    }
+
+    fn ladder(self, cfg: &'static NadirConfig) -> &'static Ladder {
+        match self {
+            Self::AnthropicMessages => &cfg.anthropic,
+            Self::OpenAiChat => &cfg.openai,
+        }
+    }
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────
+
+/// Attempt to right-size the model on an LLM completion request.
+///
+/// Returns the body unchanged whenever routing does not apply or anything at
+/// all goes wrong. `Err` is reserved for a request body that could not be
+/// buffered, which cannot be forwarded because the stream is already consumed.
+pub(crate) async fn try_route_model(
+    host: &str,
+    method: &Method,
+    path: &str,
+    body: reqwest::Body,
+) -> anyhow::Result<reqwest::Body> {
+    let cfg = config();
+    let Some(flavor) = Flavor::detect(host, method, path) else {
+        return Ok(body);
+    };
+
+    let bytes = super::super::body::buffer_body(body).await?;
+    if bytes.len() > MAX_CLASSIFY_BYTES {
+        debug!(
+            len = bytes.len(),
+            "nadir: request above classify size cap, forwarding unchanged"
+        );
+        return Ok(reqwest::Body::from(bytes));
+    }
+
+    match route(&bytes, flavor, cfg).await {
+        Some(rewritten) => Ok(reqwest::Body::from(rewritten)),
+        None => Ok(reqwest::Body::from(bytes)),
+    }
+}
+
+/// The routing decision. `None` means "forward the original bytes" — every
+/// failure path lands here.
+async fn route(bytes: &Bytes, flavor: Flavor, cfg: &'static NadirConfig) -> Option<Vec<u8>> {
+    let mut json: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let obj = json.as_object_mut()?;
+
+    let current = obj.get("model")?.as_str()?.to_string();
+    let ladder = flavor.ladder(cfg);
+
+    // Only models the operator placed on the ladder are eligible. Anything
+    // else is a model we cannot rank, so a swap could silently cost more.
+    let current_rank = ladder.rank(&current)?;
+
+    let prompt = extract_prompt(obj, flavor)?;
+    let bucket = classify(&prompt, cfg).await?;
+
+    let target = ladder.model_for(&bucket)?;
+    if target == current {
+        return None;
+    }
+
+    let target_rank = ladder.rank(target)?;
+    if target_rank > current_rank && !cfg.allow_upgrade {
+        debug!(
+            from = %current,
+            to = %target,
+            %bucket,
+            "nadir: skipping upgrade (set NADIR_ALLOW_UPGRADE=1 to permit)"
+        );
+        return None;
+    }
+
+    obj.insert(
+        "model".to_string(),
+        serde_json::Value::String(target.to_string()),
+    );
+    clamp_max_tokens(obj, target);
+
+    debug!(from = %current, to = %target, %bucket, "nadir: routed model");
+    serde_json::to_vec(&json).ok()
+}
+
+/// Pull the classifiable text out of a completion request.
+///
+/// Anthropic carries the system prompt in a sibling `system` field rather than
+/// a message, so it is folded in as a leading system message — the classifier
+/// reads instructions there that materially change a task's difficulty.
+fn extract_prompt(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    flavor: Flavor,
+) -> Option<Vec<serde_json::Value>> {
+    let messages = obj.get("messages")?.as_array()?;
+    if messages.is_empty() {
+        return None;
+    }
+
+    let mut out: Vec<serde_json::Value> = Vec::with_capacity(messages.len() + 1);
+    if flavor == Flavor::AnthropicMessages {
+        if let Some(system) = obj.get("system") {
+            let text = match system {
+                serde_json::Value::String(s) => Some(s.clone()),
+                // Anthropic also accepts system as an array of text blocks.
+                serde_json::Value::Array(blocks) => {
+                    let joined: Vec<&str> = blocks
+                        .iter()
+                        .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                        .collect();
+                    (!joined.is_empty()).then(|| joined.join("\n"))
+                }
+                _ => None,
+            };
+            if let Some(text) = text {
+                out.push(serde_json::json!({ "role": "system", "content": text }));
+            }
+        }
+    }
+    out.extend(messages.iter().cloned());
+    Some(out)
+}
+
+/// Ask Nadir which bucket this prompt falls in. `None` on any failure.
+async fn classify(messages: &[serde_json::Value], cfg: &'static NadirConfig) -> Option<String> {
+    let payload = serde_json::json!({
+        "messages": messages,
+        "source": "onecli",
+    });
+
+    let mut req = client()
+        .post(BUCKET_URL)
+        .timeout(cfg.timeout)
+        .json(&payload);
+    if let Some(ref key) = cfg.api_key {
+        req = req.header("x-api-key", key);
+    }
+
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "nadir: classifier unreachable, forwarding unchanged");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        warn!(
+            status = resp.status().as_u16(),
+            "nadir: classifier returned non-success, forwarding unchanged"
+        );
+        return None;
+    }
+
+    #[derive(serde::Deserialize)]
+    struct BucketResponse {
+        bucket: String,
+    }
+    match resp.json::<BucketResponse>().await {
+        Ok(b) => Some(b.bucket),
+        Err(e) => {
+            warn!(error = %e, "nadir: unreadable classifier response, forwarding unchanged");
+            None
+        }
+    }
+}
+
+/// Keep `max_tokens` inside the target model's output ceiling.
+///
+/// Routing down can land on a model whose ceiling is lower than the one the
+/// caller asked for, which the provider rejects with a 400. Only ever lowers.
+fn clamp_max_tokens(obj: &mut serde_json::Map<String, serde_json::Value>, target: &str) {
+    let Some(ceiling) = output_ceiling(target) else {
+        return;
+    };
+    for field in ["max_tokens", "max_completion_tokens"] {
+        if let Some(requested) = obj.get(field).and_then(serde_json::Value::as_u64) {
+            if requested > ceiling {
+                obj.insert(field.to_string(), serde_json::json!(ceiling));
+                debug!(field, from = requested, to = ceiling, "nadir: clamped");
+            }
+        }
+    }
+}
+
+/// Published max output tokens for models we ship a default ladder for.
+/// `None` means unknown — leave `max_tokens` alone rather than guess.
+fn output_ceiling(model: &str) -> Option<u64> {
+    match model {
+        "claude-haiku-4-5" => Some(64_000),
+        "claude-sonnet-4-6" | "claude-opus-4-6" => Some(64_000),
+        _ => None,
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_cfg(allow_upgrade: bool) -> &'static NadirConfig {
+        // Leaked rather than shared through the OnceLock so tests can vary the
+        // config without depending on process-wide env or ordering.
+        Box::leak(Box::new(NadirConfig {
+            enabled: true,
+            api_key: None,
+            allow_upgrade,
+            timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+            anthropic: Ladder {
+                simple: Some("claude-haiku-4-5".into()),
+                medium: Some("claude-sonnet-4-6".into()),
+                complex: Some("claude-opus-4-6".into()),
+            },
+            openai: Ladder::default(),
+        }))
+    }
+
+    #[test]
+    fn detects_anthropic_messages() {
+        assert_eq!(
+            Flavor::detect("api.anthropic.com", &Method::POST, "/v1/messages"),
+            Some(Flavor::AnthropicMessages)
+        );
+    }
+
+    #[test]
+    fn detects_openai_chat_ignoring_query() {
+        assert_eq!(
+            Flavor::detect(
+                "api.openai.com",
+                &Method::POST,
+                "/v1/chat/completions?beta=1"
+            ),
+            Some(Flavor::OpenAiChat)
+        );
+    }
+
+    #[test]
+    fn ignores_non_completion_traffic() {
+        // Right host, wrong endpoint.
+        assert_eq!(
+            Flavor::detect("api.anthropic.com", &Method::POST, "/v1/models"),
+            None
+        );
+        // Right endpoint shape, wrong host.
+        assert_eq!(
+            Flavor::detect("api.github.com", &Method::POST, "/v1/messages"),
+            None
+        );
+        // Right host and endpoint, wrong method.
+        assert_eq!(
+            Flavor::detect("api.anthropic.com", &Method::GET, "/v1/messages"),
+            None
+        );
+    }
+
+    #[test]
+    fn ranks_only_ladder_models() {
+        let ladder = &test_cfg(false).anthropic;
+        assert_eq!(ladder.rank("claude-haiku-4-5"), Some(0));
+        assert_eq!(ladder.rank("claude-opus-4-6"), Some(2));
+        assert_eq!(ladder.rank("gpt-5"), None);
+    }
+
+    #[test]
+    fn extracts_anthropic_system_as_leading_message() {
+        let body = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "system": "You are terse.",
+            "messages": [{ "role": "user", "content": "hi" }],
+        });
+        let prompt =
+            extract_prompt(body.as_object().unwrap(), Flavor::AnthropicMessages).expect("prompt");
+        assert_eq!(prompt.len(), 2);
+        assert_eq!(prompt[0]["role"], "system");
+        assert_eq!(prompt[0]["content"], "You are terse.");
+        assert_eq!(prompt[1]["content"], "hi");
+    }
+
+    #[test]
+    fn extracts_anthropic_system_from_block_array() {
+        let body = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "system": [{ "type": "text", "text": "Block one." }],
+            "messages": [{ "role": "user", "content": "hi" }],
+        });
+        let prompt =
+            extract_prompt(body.as_object().unwrap(), Flavor::AnthropicMessages).expect("prompt");
+        assert_eq!(prompt[0]["content"], "Block one.");
+    }
+
+    #[test]
+    fn openai_flavor_ignores_sibling_system_field() {
+        let body = serde_json::json!({
+            "model": "gpt-5",
+            "system": "ignored on this API",
+            "messages": [{ "role": "user", "content": "hi" }],
+        });
+        let prompt = extract_prompt(body.as_object().unwrap(), Flavor::OpenAiChat).expect("prompt");
+        assert_eq!(prompt.len(), 1);
+    }
+
+    #[test]
+    fn clamps_max_tokens_down_only() {
+        let mut obj = serde_json::json!({ "max_tokens": 200_000u64 })
+            .as_object()
+            .unwrap()
+            .clone();
+        clamp_max_tokens(&mut obj, "claude-haiku-4-5");
+        assert_eq!(obj["max_tokens"], 64_000u64);
+
+        let mut small = serde_json::json!({ "max_tokens": 512u64 })
+            .as_object()
+            .unwrap()
+            .clone();
+        clamp_max_tokens(&mut small, "claude-haiku-4-5");
+        assert_eq!(small["max_tokens"], 512u64);
+    }
+
+    #[test]
+    fn clamp_leaves_unknown_models_alone() {
+        let mut obj = serde_json::json!({ "max_tokens": 200_000u64 })
+            .as_object()
+            .unwrap()
+            .clone();
+        clamp_max_tokens(&mut obj, "some-unknown-model");
+        assert_eq!(obj["max_tokens"], 200_000u64);
+    }
+
+    /// End-to-end against the live classifier. Ignored by default because it
+    /// needs network; run with `cargo test -- --ignored live_classifier`.
+    #[tokio::test]
+    #[ignore = "hits api.getnadir.com"]
+    async fn live_classifier_routes_a_trivial_prompt_down() {
+        let bytes = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "claude-opus-4-6",
+                "max_tokens": 1024,
+                "messages": [{
+                    "role": "user",
+                    "content": "Rename the variable `x` to `count` in this one line.",
+                }],
+            }))
+            .unwrap(),
+        );
+
+        let out = route(&bytes, Flavor::AnthropicMessages, test_cfg(false))
+            .await
+            .expect("a trivial prompt should route below opus");
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+
+        let routed = json["model"].as_str().unwrap();
+        assert_ne!(routed, "claude-opus-4-6", "expected a downgrade");
+        assert!(
+            ["claude-haiku-4-5", "claude-sonnet-4-6"].contains(&routed),
+            "routed to an off-ladder model: {routed}"
+        );
+        // Everything else must survive the rewrite untouched.
+        assert_eq!(json["max_tokens"], 1024);
+        assert_eq!(json["messages"][0]["role"], "user");
+    }
+
+    /// The classifier is never called for a model the operator did not rank,
+    /// so an off-ladder request cannot be rewritten even if Nadir is reachable.
+    #[tokio::test]
+    async fn off_ladder_model_is_untouched() {
+        let bytes = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "some-self-hosted-model",
+                "messages": [{ "role": "user", "content": "hi" }],
+            }))
+            .unwrap(),
+        );
+        let out = route(&bytes, Flavor::AnthropicMessages, test_cfg(false)).await;
+        assert!(out.is_none(), "off-ladder model must not be rewritten");
+    }
+
+    #[tokio::test]
+    async fn missing_model_field_is_untouched() {
+        let bytes = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "messages": [{ "role": "user", "content": "hi" }],
+            }))
+            .unwrap(),
+        );
+        let out = route(&bytes, Flavor::AnthropicMessages, test_cfg(false)).await;
+        assert!(out.is_none());
+    }
+
+    #[tokio::test]
+    async fn malformed_body_is_untouched() {
+        let bytes = Bytes::from_static(b"not json at all");
+        let out = route(&bytes, Flavor::AnthropicMessages, test_cfg(false)).await;
+        assert!(out.is_none());
+    }
+
+    #[tokio::test]
+    async fn unroutable_request_forwards_original_bytes() {
+        // A GET to a non-completion path never reaches the classifier, and the
+        // body must survive the pass-through byte for byte.
+        let body = reqwest::Body::from("original");
+        let out = try_route_model("api.github.com", &Method::GET, "/x", body)
+            .await
+            .expect("passthrough must not error");
+        let buffered = super::super::super::body::buffer_body(out).await.unwrap();
+        assert_eq!(buffered.as_ref(), b"original");
+    }
+}

--- a/apps/web/public/icons/nadir-light.svg
+++ b/apps/web/public/icons/nadir-light.svg
@@ -1,0 +1,1 @@
+<svg fill="#ffffff" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Nadir</title><path d="M2 2h4.94l10.12 12.4V2H22v20h-4.94L6.94 9.6V22H2z"/></svg>

--- a/apps/web/public/icons/nadir.svg
+++ b/apps/web/public/icons/nadir.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Nadir</title><path d="M2 2h4.94l10.12 12.4V2H22v20h-4.94L6.94 9.6V22H2z"/></svg>

--- a/apps/web/src/app/(dashboard)/connections/_components/app-categories.ts
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-categories.ts
@@ -67,6 +67,7 @@ export const APP_CATEGORIES: Record<string, AppCategory> = {
   dropbox: "cloud-data",
   datadog: "cloud-data",
   "vertex-ai": "cloud-data",
+  nadir: "cloud-data",
 
   // Communication
   resend: "communication",

--- a/docs/nadir-integration.md
+++ b/docs/nadir-integration.md
@@ -1,0 +1,83 @@
+# Nadir Integration
+
+Right-size the model on every LLM call that passes through the gateway. Agents keep asking for their most capable model; the gateway rewrites `model` to the cheapest tier that can actually do the task, using [Nadir](https://getnadir.com)'s complexity classifier.
+
+Nadir also appears in **Connections > Apps** as a normal API-key app, so the gateway can inject your Nadir key into calls your agents make to `api.getnadir.com` directly. That part works on its own and needs none of the routing setup below.
+
+## How It Works
+
+1. An agent sends a completion request through the gateway, pinning whatever model it always pins
+2. The gateway recognises the LLM endpoint and buffers the request body
+3. The prompt is sent to Nadir, which classifies it as `simple`, `medium`, or `complex`
+4. The gateway rewrites `model` to the tier you mapped that bucket to, then forwards the request
+
+The agent's code, SDK, and credentials are untouched. It asked for one model and got an answer; only the gateway knows a cheaper one served it.
+
+## What Gets Sent to Nadir
+
+**When routing is enabled, the prompt text of every routed request is sent to `api.getnadir.com` for classification.** That is the trade: classification needs the text. This is why the feature ships off and stays off until you set `NADIR_MODEL_ROUTING=1`.
+
+Only requests to completion endpoints on known LLM hosts are affected. Nothing else your agents do is sent anywhere.
+
+## Setup
+
+Routing is off unless configured. Set these on the gateway:
+
+```bash
+NADIR_MODEL_ROUTING=1
+NADIR_API_KEY=sk-...   # optional
+```
+
+The key is optional: routing works against Nadir's free anonymous tier. Supplying one raises the rate limit and records per-request savings in your Nadir dashboard.
+
+Restart the gateway. Requests to `POST /v1/messages` and `POST /v1/chat/completions` on known LLM hosts are now routed.
+
+## The Tier Ladder
+
+The gateway only rewrites a model you have placed on a ladder. This is deliberate: an unranked model is one the gateway cannot prove a swap makes cheaper, so it is forwarded untouched.
+
+Anthropic ships defaults:
+
+| Bucket    | Default model       | Override                  |
+| --------- | ------------------- | ------------------------- |
+| `simple`  | `claude-haiku-4-5`  | `NADIR_ANTHROPIC_SIMPLE`  |
+| `medium`  | `claude-sonnet-4-6` | `NADIR_ANTHROPIC_MEDIUM`  |
+| `complex` | `claude-opus-4-6`   | `NADIR_ANTHROPIC_COMPLEX` |
+
+OpenAI has no defaults, because its model names move fast enough that a hardcoded ladder would eventually route to a model you never chose. Set them to turn OpenAI routing on:
+
+```bash
+NADIR_OPENAI_SIMPLE=gpt-5-mini
+NADIR_OPENAI_MEDIUM=gpt-5
+NADIR_OPENAI_COMPLEX=gpt-5-pro
+```
+
+A request whose model is not on the matching ladder is forwarded unchanged, and never reaches the classifier.
+
+## Environment Variables
+
+| Variable                  | Default             | Description                                                           |
+| ------------------------- | ------------------- | --------------------------------------------------------------------- |
+| `NADIR_MODEL_ROUTING`     | off                 | `1` enables routing. Nothing happens without it                       |
+| `NADIR_API_KEY`           | —                   | Optional. Higher rate limit and savings analytics                     |
+| `NADIR_ALLOW_UPGRADE`     | off                 | `1` permits routing _up_ the ladder. Off so cost cannot silently rise |
+| `NADIR_TIMEOUT_MS`        | `1500`              | Ceiling on the classifier round-trip                                  |
+| `NADIR_ANTHROPIC_SIMPLE`  | `claude-haiku-4-5`  | Anthropic ladder, cheapest tier                                       |
+| `NADIR_ANTHROPIC_MEDIUM`  | `claude-sonnet-4-6` | Anthropic ladder, middle tier                                         |
+| `NADIR_ANTHROPIC_COMPLEX` | `claude-opus-4-6`   | Anthropic ladder, top tier                                            |
+| `NADIR_OPENAI_SIMPLE`     | —                   | OpenAI ladder, cheapest tier. Unset means OpenAI is not routed        |
+| `NADIR_OPENAI_MEDIUM`     | —                   | OpenAI ladder, middle tier                                            |
+| `NADIR_OPENAI_COMPLEX`    | —                   | OpenAI ladder, top tier                                               |
+
+## Failure Behaviour
+
+Routing never blocks a request. If Nadir is slow, down, returns an error, or returns a bucket with no model mapped, the original request is forwarded byte for byte with its original model. A classifier outage costs you the savings, not the call.
+
+`max_tokens` is clamped down if the routed-to model has a lower output ceiling than the caller asked for, which would otherwise be a provider 400. It is only ever lowered.
+
+## Scope and Limits
+
+- Only `POST /v1/messages` and `POST /v1/chat/completions` are routed. Other endpoints (embeddings, batches, files) pass through
+- Requests above 256 KB skip classification: nothing that large classifies as simple, and the round-trip would cost more than it saves
+- Configuration is per-gateway, not per-project. A per-project toggle in the dashboard is the natural follow-up
+- Streaming is unaffected. Only the request body is buffered; responses stream as normal

--- a/packages/api/src/apps/nadir.ts
+++ b/packages/api/src/apps/nadir.ts
@@ -1,0 +1,49 @@
+import type { AppDefinition } from "./types";
+
+export const nadir: AppDefinition = {
+  id: "nadir",
+  name: "Nadir",
+  icon: "/icons/nadir.svg",
+  darkIcon: "/icons/nadir-light.svg",
+  description: "Right-size the model on every LLM call to cut inference cost.",
+  connectionMethod: {
+    type: "api_key",
+    fields: [
+      {
+        name: "apiKey",
+        label: "API Key",
+        description:
+          "Your Nadir API key. Optional: model routing also works anonymously, but a key raises the rate limit and records per-request savings.",
+        placeholder: "sk-...",
+        optional: true,
+        helpUrl: "https://getnadir.com/dashboard/api-keys",
+        helpLabel: "Create a Nadir API key",
+      },
+    ],
+    resolveMetadata: async (fields) => {
+      if (!fields.apiKey) return null;
+      try {
+        const res = await fetch("https://api.getnadir.com/v1/profile", {
+          headers: { "X-API-Key": fields.apiKey },
+        });
+        if (res.ok) {
+          const profile = (await res.json()) as {
+            name?: string;
+            email?: string;
+          };
+          if (profile.email) {
+            return {
+              name: profile.name ?? profile.email,
+              username: profile.email,
+            };
+          }
+        }
+      } catch {
+        // Non-fatal
+      }
+      return null;
+    },
+  },
+  labelHint: 'e.g. "prod", "batch-jobs"',
+  available: true,
+};

--- a/packages/api/src/apps/registry.ts
+++ b/packages/api/src/apps/registry.ts
@@ -23,6 +23,7 @@ import { googleSheets } from "./google-sheets";
 import { googleSlides } from "./google-slides";
 import { googleTasks } from "./google-tasks";
 import { mongodbAtlas } from "./mongodb-atlas";
+import { nadir } from "./nadir";
 import { notion } from "./notion";
 import { resend } from "./resend";
 import { todoist } from "./todoist";
@@ -73,6 +74,7 @@ const staticApps: AppDefinition[] = [
   aws,
   monday,
   mongodbAtlas,
+  nadir,
   supabase,
   linkedin,
   trello,


### PR DESCRIPTION
> **On process:** CONTRIBUTING asks for an issue before a feature PR. I've opened this as code rather than prose because the design questions here are easier to judge against a diff than a description, and because it's cheap for you to close. Happy to move the discussion to an issue and let this sit, or to close it outright if routing doesn't belong in a credential gateway. **Disclosure: I work on Nadir.**

Adds Nadir to OneCLI in two independent pieces. The first is a plain catalog entry; the second is an opt-in body transform. They can be reviewed, and shipped, separately, and the first is useful without the second.

## The problem

Agents pin one model and use it for everything. The same session that needs Opus for a refactor also uses it to rename a variable, reformat JSON, or answer "does this file exist". Those calls are billed at the top tier for work a small model does identically.

OneCLI is already the one component that sees every outbound LLM call from every agent, and already rewrites request bodies (`BodyTransform::GitHubCommitTrailer`, and `hooks::prepare_request_body` on the cloud build). That makes it the only place this can be fixed once instead of in every agent.

## 1. Nadir as a connectable app

An `api_key` app definition modeled on `resend.ts`, so the gateway injects a stored Nadir key as `X-API-Key` on `api.getnadir.com`. Ordinary credential injection, no routing config, does nothing until a user connects it.

The key field is `optional` because Nadir's classifier has a keyless tier; a key raises the rate limit and records savings.

## 2. `BodyTransform::NadirModelRoute`

On `POST /v1/messages` and `POST /v1/chat/completions` on known LLM hosts (`policy::is_llm_host`), classify the outbound prompt and rewrite `model` to the tier the operator mapped that bucket to. The agent's code, SDK, and credentials are untouched.

Dispatch follows the existing finalizer pattern in `forward.rs`:

```rust
rules.body_transform
    .or_else(|| crate::apps::body_transform_for_host(super::strip_port(host)))
    .or_else(|| super::transforms::nadir_model_route::transform_for_host(host))
```

LLM endpoints are reached with a plain secret rather than an OAuth app connection, so they have no provider-registry entry to hang a transform on and must be matched by host. `body_transform_for_host` is a pure registry mirror of the existing `finalizer_for_host`; the Nadir-specific host logic lives in the transform module, so `apps.rs` stays a provider registry.

The classifier is one vendor behind a self-contained module seam. If you'd rather the seam be explicitly generic so a second backend is a sibling file, say so and I'll restructure.

### One deliberate divergence from the existing arm

The `GitHubCommitTrailer` arm falls back to `reqwest::Body::from(vec![])` when the transform errors, forwarding an **empty body**. I did not reuse that. For an LLM request it would silently replace a real prompt with nothing and bill the user for the result.

Instead `try_route_model` returns the original bytes on every recoverable failure, and `?` propagates only the unrecoverable one (an unbufferable body, where the stream is already consumed and there is nothing left to forward). Happy to fix the GitHub arm the same way in a separate PR if you want it.

### Behaviour

| Condition | Result |
| --- | --- |
| `NADIR_MODEL_ROUTING` unset | No buffering, no classifier call, no change |
| Model not on the configured ladder | Forwarded untouched, classifier never called |
| Bucket maps to a pricier tier | Refused unless `NADIR_ALLOW_UPGRADE=1` |
| Classifier down / slow / non-200 / bad JSON | Original bytes, original model |
| Body > 256 KB | Forwarded unclassified |
| Routed-to model has a lower output ceiling | `max_tokens` clamped down (never up) |

Anthropic gets a default ladder. OpenAI does not, deliberately: its model names move fast enough that a hardcoded ladder would eventually route to a model the operator never chose, so OpenAI routing stays off until the ladder is set.

## The tradeoff you should weigh

**When routing is enabled, prompt text of routed requests is sent to `api.getnadir.com` to be classified.** Classification needs the text; there is no way around that.

For a project whose pitch is "agents never see the keys", shipping anything that forwards prompt content deserves an explicit decision rather than a quiet default. That's why it's opt-in, off by default, and disclosed in `docs/nadir-integration.md`, the README feature bullet, `.env.example`, and the module doc comment. Nothing is sent while the feature is off. If this alone makes it a no, that's a reasonable call and I'd rather hear it early.

## Verification

- `pnpm build` — pass
- `pnpm check` (lint + types + format, 9 tasks) — pass
- `cargo clippy --all-targets` — zero warnings
- `cargo test` — 523 passed, 0 failed (17 new)
- `cargo test -- --ignored live_classifier` — passes against the live API: an Opus request with a trivial prompt routes down, and `max_tokens` / `messages` survive the rewrite byte for byte

New tests cover flavor detection (wrong host, wrong method, wrong path, query strings), ladder ranking, Anthropic's sibling `system` field in both string and block-array form, `max_tokens` clamping in both directions, off-ladder and malformed-body passthrough, and byte-exact passthrough for unroutable requests.

## Not included

Per-project configuration. `AppConfig` already has `provider` / `enabled` / `settings` and would need no migration, but threading it to the gateway means touching the connect path and `ConnectResponse`, which felt like a separate change. Env config matches how the gateway reads its other settings today.
