### PR TITLE
fix: resolve public URLs from what we configured, not from request headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,21 +26,31 @@ SECRET_ENCRYPTION_KEY=change-me-to-secure-key
 INTERNAL_API_URL=http://localhost:10254
 GATEWAY_INTERNAL_SECRET=
 
-# Public URL — the canonical address browsers reach OneCLI on. Used for OAuth
-# redirects and for the absolute links OneCLI hands out.
+# ── Public URL ──────────────────────────────────────────────────────────
 #
-# Optional. When it is unset, the web app derives the address from each incoming
+# APP_URL is the canonical external URL: the address users actually reach OneCLI
+# on. It is deliberately not derived from the address the server binds to — those
+# are different things, and only you know the first one. Everything OneCLI hands
+# out that has to be openable later resolves from it: OAuth redirects, and the
+# links the gateway writes into agent-facing responses.
+#
+# The web app can manage without it — it derives the address from each incoming
 # request (X-Forwarded-Host / Host), so localhost, a LAN IP, a reverse proxy, and
-# tunnels like Cloudflare Tunnel or ngrok all work with no configuration. Set it
-# to pin one address instead — e.g. a provider that requires a fixed,
-# pre-registered redirect URI.
+# tunnels like Cloudflare Tunnel or ngrok all work unconfigured.
 #
-# The gateway always needs it: it builds absolute links inside its own proxy
-# responses, where there is no incoming browser request to derive an origin from,
-# and falls back to localhost:10254 without this. (docker-compose currently sets
-# APP_URL from ONECLI_BIND_HOST so those links resolve; a value set here is
-# overridden by that.)
+# The gateway cannot. It answers proxy traffic, so there is no browser request to
+# read an address from; without APP_URL it falls back to localhost:10254 and says
+# so loudly at startup. Set this whenever users reach OneCLI at anything other
+# than that fallback.
+#
+# docker-compose defaults it to the bind address, which is right for a local or
+# single-host install. Override it here, or export it, when it isn't.
 # APP_URL=https://onecli.example.com
+#
+# (Forward note for a future Helm chart: this is the value a chart should expose
+# as a required `externalURL`, conventionally defaulted from the Ingress host —
+# Kubernetes has no bind address that could stand in for it, which is why charts
+# like GitLab's and Harbor's require it outright.)
 
 # API domain — where the API server runs (no protocol prefix).
 # OSS: localhost:10255 (gateway serves API too), Cloud: api.onecli.sh

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -29,7 +29,9 @@ pub(crate) mod hooks;
 #[path = "ee/hooks.rs"]
 pub(crate) mod hooks;
 mod mitm;
-mod response;
+// `pub(crate)` so `main` can report at startup whether dashboard links will be
+// built from a configured APP_URL or from the fallback.
+pub(crate) mod response;
 mod transforms;
 mod tunnel;
 mod websocket;

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -20,15 +20,40 @@ pub(super) fn proxy_auth_required() -> Response<axum::body::Body> {
 /// Response body type used by [`super::forward::forward_request`].
 pub(crate) type ForwardBody<S> = Either<Full<Bytes>, S>;
 
-/// Resolve the OneCLI dashboard base URL from `APP_URL`,
-/// falling back to `http://localhost:10254`. Cached after first call.
+/// Where dashboard links point when `APP_URL` says nothing. Right for a
+/// loopback install, wrong for anyone reaching OneCLI on another address —
+/// which is why `main` warns at startup rather than letting it pass silently.
+pub(crate) const DASHBOARD_URL_FALLBACK: &str = "http://localhost:10254";
+
+/// The configured public URL, or `None` when there isn't one.
+///
+/// Present-but-blank counts as absent: an `APP_URL=` line, or a compose
+/// passthrough that resolved to nothing, must not read as configuration. Mirrors
+/// `configuredAppUrl()` on the Node side so both halves agree on what "set"
+/// means. Split out from [`dashboard_url`] so it is testable — that one caches
+/// in a `OnceLock` and cannot be re-evaluated under a different environment.
+fn normalize_app_url(raw: Option<&str>) -> Option<String> {
+    let trimmed = raw?.trim().trim_end_matches('/');
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Whether the dashboard links are built from a configured `APP_URL` or from
+/// the fallback. Drives the startup warning in `main`.
+///
+/// Deliberately derived from [`dashboard_url`] rather than re-reading the
+/// environment: the warning then describes the value actually in use, and cannot
+/// drift from it if the env changes after the cache is populated.
+pub(crate) fn app_url_is_configured() -> bool {
+    dashboard_url() != DASHBOARD_URL_FALLBACK
+}
+
+/// Resolve the OneCLI dashboard base URL from `APP_URL`, falling back to
+/// [`DASHBOARD_URL_FALLBACK`]. Cached after first call.
 pub(crate) fn dashboard_url() -> &'static str {
     static URL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
     URL.get_or_init(|| {
-        std::env::var("APP_URL")
-            .unwrap_or_else(|_| "http://localhost:10254".to_string())
-            .trim_end_matches('/')
-            .to_string()
+        normalize_app_url(std::env::var("APP_URL").ok().as_deref())
+            .unwrap_or_else(|| DASHBOARD_URL_FALLBACK.to_string())
     })
 }
 
@@ -465,6 +490,50 @@ mod tests {
 
     type TestBody =
         ForwardBody<futures_util::stream::Empty<Result<hyper::body::Frame<Bytes>, reqwest::Error>>>;
+
+    // A blank value must read as "unconfigured", not as a configured empty
+    // string — otherwise every dashboard link becomes "/connections" with no
+    // host, and the startup warning that would have flagged it stays quiet.
+    #[test]
+    fn normalize_app_url_treats_blank_as_unset() {
+        assert_eq!(normalize_app_url(None), None);
+        assert_eq!(normalize_app_url(Some("")), None);
+        assert_eq!(normalize_app_url(Some("   ")), None);
+        assert_eq!(normalize_app_url(Some("\t\n")), None);
+        // A lone slash trims to nothing; it is not a URL.
+        assert_eq!(normalize_app_url(Some("/")), None);
+    }
+
+    #[test]
+    fn normalize_app_url_trims_whitespace_and_trailing_slashes() {
+        assert_eq!(
+            normalize_app_url(Some("  https://onecli.example.com//  ")),
+            Some("https://onecli.example.com".to_string())
+        );
+        assert_eq!(
+            normalize_app_url(Some("http://172.17.0.1:10254")),
+            Some("http://172.17.0.1:10254".to_string())
+        );
+    }
+
+    // `main` branches on this to decide whether to warn. Asserting the two agree
+    // is what keeps the warning honest: if `dashboard_url` ever resolved the
+    // fallback while this reported "configured", the operator would be told
+    // nothing while every link pointed at localhost.
+    //
+    // Env-free: `dashboard_url` caches in a `OnceLock`, so whichever value this
+    // process resolved first is the one under test either way — and mutating
+    // APP_URL here would race the rest of the suite.
+    #[test]
+    fn app_url_is_configured_agrees_with_the_url_actually_in_use() {
+        assert_eq!(
+            app_url_is_configured(),
+            dashboard_url() != DASHBOARD_URL_FALLBACK
+        );
+        if !app_url_is_configured() {
+            assert_eq!(dashboard_url(), DASHBOARD_URL_FALLBACK);
+        }
+    }
 
     #[test]
     fn proxy_auth_required_has_correct_status_and_header() {

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -136,7 +136,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 use crate::ca::CertificateAuthority;
@@ -206,6 +206,20 @@ async fn main() -> Result<()> {
         demo = caps.demo,
         "starting onecli-gateway"
     );
+
+    // The gateway puts absolute links into the responses agents relay to humans
+    // ("open this URL to connect the app"). It answers proxy traffic, so unlike
+    // the web app it has no incoming browser request to derive its own address
+    // from — APP_URL is the only thing that can tell it. Say so once, loudly,
+    // rather than emitting links that look real and go nowhere.
+    if !gateway::response::app_url_is_configured() {
+        warn!(
+            fallback = gateway::response::DASHBOARD_URL_FALLBACK,
+            "APP_URL is not set — links in agent-facing responses will point at \
+             the fallback and will not open for anyone reaching OneCLI on a \
+             different address. Set APP_URL to the URL users browse to."
+        );
+    }
 
     // Load or generate CA
     let ca = CertificateAuthority::load_or_generate(&data_dir).await?;

--- a/apps/gateway/src/vault/onepassword_api.rs
+++ b/apps/gateway/src/vault/onepassword_api.rs
@@ -33,22 +33,30 @@ impl std::fmt::Display for OpError {
     }
 }
 
-/// Base URL of the internal Node API, resolved in order:
-/// 1. `INTERNAL_API_URL` — explicit override (cloud points this at the in-VPC
-///    api-server, e.g. `http://api-server:10256`).
-/// 2. `APP_URL` — the co-located OSS app's own address; in docker-compose this
-///    tracks `ONECLI_BIND_HOST`, so the gateway reaches the app at whatever host
-///    the deployment is bound to without a second env var.
-/// 3. A loopback default for a bare local run.
+/// Where the Node app answers when nothing overrides it. The gateway and the
+/// app share a container in every self-hosted layout, so loopback is the
+/// address, not a guess.
+const INTERNAL_API_URL_DEFAULT: &str = "http://localhost:10254";
+
+/// Base URL of the internal Node API: `INTERNAL_API_URL` when set (cloud points
+/// it at the in-VPC api-server, e.g. `http://api-server:10256`), else loopback.
+///
+/// Deliberately **not** `APP_URL`. That is the *public* URL users browse to —
+/// a different concept, and since it can now name a real external host, using
+/// it here would send in-container vault calls out over the internet. Split out
+/// for testability, as [`super::super::gateway::response::dashboard_url`] is.
+fn resolve_internal_api_url(explicit: Option<&str>) -> String {
+    explicit
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .unwrap_or(INTERNAL_API_URL_DEFAULT)
+        .trim_end_matches('/')
+        .to_string()
+}
+
 fn internal_api_url() -> &'static str {
     static URL: OnceLock<String> = OnceLock::new();
-    URL.get_or_init(|| {
-        std::env::var("INTERNAL_API_URL")
-            .or_else(|_| std::env::var("APP_URL"))
-            .unwrap_or_else(|_| "http://localhost:10254".to_string())
-            .trim_end_matches('/')
-            .to_string()
-    })
+    URL.get_or_init(|| resolve_internal_api_url(std::env::var("INTERNAL_API_URL").ok().as_deref()))
 }
 
 /// Shared secret presented to the internal API as `X-Gateway-Secret`.
@@ -174,3 +182,35 @@ async fn classify(resp: reqwest::Response) -> OpError {
 
 // `op://` reference shape is validated Node-side (`opRefSchema`) at secret
 // write time; the gateway trusts the refs it reads back from validated rows.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_internal_url_wins_and_is_trimmed() {
+        assert_eq!(
+            resolve_internal_api_url(Some("http://api-server:10256/")),
+            "http://api-server:10256"
+        );
+    }
+
+    // The regression guard. This used to fall back to APP_URL — the *public*
+    // URL — which, now that APP_URL can name a real external host, would send
+    // in-container vault calls out over the internet. Loopback is the only
+    // correct answer when nothing explicit is set.
+    //
+    // Asserted through the parameter rather than by setting APP_URL in the
+    // environment: the resolver takes its only input as an argument, so there is
+    // nothing for an env var to reach, and mutating process-wide env here would
+    // race the sibling suites that read APP_URL through a cached `OnceLock`.
+    #[test]
+    fn falls_back_to_loopback_never_to_a_public_url() {
+        assert_eq!(resolve_internal_api_url(None), INTERNAL_API_URL_DEFAULT);
+        assert_eq!(resolve_internal_api_url(Some("")), INTERNAL_API_URL_DEFAULT);
+        assert_eq!(
+            resolve_internal_api_url(Some("   ")),
+            INTERNAL_API_URL_DEFAULT
+        );
+    }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,11 +34,34 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-onecli}:${POSTGRES_PASSWORD:-onecli}@postgres:5432/${POSTGRES_DB:-onecli}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-}
-      APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}
+      # The public URL users reach OneCLI on. The gateway needs it to build the
+      # links it puts in agent-facing responses — it answers proxy calls, so it
+      # has no browser request to derive an address from.
+      #
+      # The default below assumes you reach OneCLI at the address Docker binds
+      # to, which holds for a local or single-host install. When it doesn't — a
+      # tunnel, a reverse proxy, a real domain — set APP_URL instead of relying
+      # on it: either export it, or put it in a `.env` beside this file.
+      APP_URL: ${APP_URL:-http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}}
       GATEWAY_API_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_GATEWAY_PORT:-10255}
+      # Where the gateway reaches the Node API. Both run in this one container
+      # (see docker/entrypoint.sh), so it is a loopback call and never leaves it.
+      #
+      # Set explicitly because images before this file's release resolve it as
+      # `INTERNAL_API_URL, else APP_URL, else loopback` — and APP_URL is now
+      # settable to a real public address. Naming it here keeps those images from
+      # sending internal vault calls out over the internet, whatever version the
+      # `image:` above pins.
+      INTERNAL_API_URL: http://localhost:10254
     volumes:
       - app-data:/app/data
     env_file:
+      # Beside this file — where an installed layout puts it ($HOME/.onecli/.env,
+      # which is also the file Compose reads for the interpolation above).
+      - path: .env
+        required: false
+      # Repo root, for a checkout where this file lives under docker/. Last, so
+      # it keeps winning in that layout.
       - path: ../.env
         required: false
     networks:

--- a/packages/api/src/lib/app-origin.test.ts
+++ b/packages/api/src/lib/app-origin.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { configuredAppUrl, originFromHeaders } from "./app-origin";
+import {
+  configuredAppUrl,
+  normalizeOrigin,
+  originFromHeaders,
+} from "./app-origin";
 
 describe("configuredAppUrl", () => {
   const orig = {
@@ -48,6 +52,64 @@ describe("configuredAppUrl", () => {
     process.env.APP_URL = "";
     process.env.NEXT_PUBLIC_APP_URL = "https://public.example.com";
     expect(configuredAppUrl()).toBe("https://public.example.com");
+  });
+});
+
+describe("normalizeOrigin", () => {
+  it("accepts http and https origins, with ports and IP literals", () => {
+    expect(normalizeOrigin("https://onecli.example.com")).toBe(
+      "https://onecli.example.com",
+    );
+    expect(normalizeOrigin("http://192.168.1.5:10254")).toBe(
+      "http://192.168.1.5:10254",
+    );
+    expect(normalizeOrigin("http://[::1]:10254")).toBe("http://[::1]:10254");
+  });
+
+  it("strips trailing slashes and lowercases the scheme", () => {
+    expect(normalizeOrigin("HTTPS://onecli.example.com//")).toBe(
+      "https://onecli.example.com",
+    );
+  });
+
+  // Non-strings reach here whenever a state was signed by another release, or
+  // simply never carried an origin — `undefined` is the normal, expected answer.
+  it("is undefined for anything that is not a string", () => {
+    for (const bad of [undefined, null, 42, {}, ["https://x.example"]]) {
+      expect(normalizeOrigin(bad)).toBeUndefined();
+    }
+  });
+
+  it("rejects non-http(s) schemes and bare hosts", () => {
+    for (const bad of [
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "ftp://example.com",
+      "onecli.example.com",
+      "//example.com",
+      "",
+    ]) {
+      expect(normalizeOrigin(bad)).toBeUndefined();
+    }
+  });
+
+  // Same host rules as originFromHeaders, so a value that would be rejected
+  // coming from a header cannot sneak in via the state instead.
+  it("rejects hosts that aren't syntactically hosts", () => {
+    for (const bad of [
+      "https://evil</script><script>alert(1)</script>",
+      'https://evil"+alert(1)+"',
+      "https://evil.com/path",
+      "https://evil com",
+      // userinfo — the classic "looks like our host" phishing shape
+      "https://onecli.example.com@evil.com",
+      "https://user:pass@evil.com",
+      // a query or fragment would otherwise ride along into the redirect
+      "https://evil.com?next=x",
+      "https://evil.com#x",
+    ]) {
+      expect(normalizeOrigin(bad)).toBeUndefined();
+    }
   });
 });
 

--- a/packages/api/src/lib/app-origin.ts
+++ b/packages/api/src/lib/app-origin.ts
@@ -66,6 +66,31 @@ export const configuredAppUrl = (): string | undefined =>
   )?.replace(/\/+$/, "");
 
 /**
+ * Validate an origin that reached us as data rather than as request headers —
+ * today, the one signed into the OAuth state at `/authorize`.
+ *
+ * Returns the normalized `scheme://host[:port]`, or `undefined` for anything
+ * that is not a well-formed http(s) origin (including non-strings). Same host
+ * rules as `originFromHeaders`, so the two agree on what an origin may look
+ * like, and `javascript:`/`data:` can never survive into a redirect.
+ *
+ * Fail-*soft* on purpose: a bad value falls through to the caller's next
+ * fallback rather than stranding the user mid-connect. Tampering is not the
+ * threat model here — a modified state fails its HMAC long before this runs, so
+ * a malformed value means we signed something malformed, which is our bug.
+ */
+export const normalizeOrigin = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const match = /^(https?):\/\/(.+)$/i.exec(value.trim().replace(/\/+$/, ""));
+  const [, scheme, host] = match ?? [];
+  // `HOST_PATTERN` allows no `/`, `@` or `?`, so a path, query, or `user:pass@`
+  // prefix lands in `host` and is rejected here rather than surviving into a
+  // redirect — the greedy `.+` above exists to make that happen.
+  if (!scheme || !host || !HOST_PATTERN.test(host)) return undefined;
+  return `${scheme.toLowerCase()}://${host}`;
+};
+
+/**
  * Origin (scheme + host) the client used to reach us, or `undefined` when the
  * headers carry no usable host.
  *

--- a/packages/api/src/lib/oauth-state.test.ts
+++ b/packages/api/src/lib/oauth-state.test.ts
@@ -1,0 +1,115 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// Non-cloud so the signing key may come from SECRET_ENCRYPTION_KEY, and pin the
+// key so signatures are stable across the file.
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_EDITION = "oss";
+  process.env.SECRET_ENCRYPTION_KEY = "test-oauth-state-secret";
+  delete process.env.OAUTH_STATE_SECRET;
+});
+
+import {
+  generateNonce,
+  signOAuthState,
+  verifyOAuthState,
+  type OAuthStatePayload,
+} from "./oauth-state";
+
+/** Re-wrap a decoded envelope, so a test can alter one half and re-encode. */
+const reencode = (envelope: { data: unknown; sig: string }) =>
+  Buffer.from(JSON.stringify(envelope)).toString("base64url");
+
+const decode = (state: string) =>
+  JSON.parse(Buffer.from(state, "base64url").toString()) as {
+    data: OAuthStatePayload;
+    sig: string;
+  };
+
+describe("oauth state", () => {
+  let nonce: string;
+
+  beforeAll(() => {
+    nonce = generateNonce();
+  });
+
+  it("round trips a payload", () => {
+    const payload = { projectId: "p1", provider: "gmail", nonce };
+    expect(verifyOAuthState(signOAuthState(payload))).toEqual(payload);
+  });
+
+  // The extension point this change relies on: the payload carries arbitrary
+  // extra keys (origin, connectionId, agentName, …) through the signature.
+  it("carries unknown keys through the signature", () => {
+    const payload = {
+      projectId: "p1",
+      provider: "gmail",
+      nonce,
+      origin: "https://onecli.example.com",
+      agentName: "my-agent",
+    };
+    expect(verifyOAuthState(signOAuthState(payload))).toEqual(payload);
+  });
+
+  // The compatibility case that matters on deploy: states minted by a release
+  // that predates `origin` are still in flight and must keep verifying.
+  it("verifies a state that carries no origin", () => {
+    const verified = verifyOAuthState(
+      signOAuthState({ projectId: "p1", provider: "gmail", nonce }),
+    );
+    expect(verified).not.toBeNull();
+    expect(verified?.origin).toBeUndefined();
+  });
+
+  it("rejects a tampered payload", () => {
+    const envelope = decode(
+      signOAuthState({
+        projectId: "p1",
+        provider: "gmail",
+        nonce,
+        origin: "https://onecli.example.com",
+      }),
+    );
+    // Repoint the origin while keeping the original signature.
+    const tampered = reencode({
+      data: { ...envelope.data, origin: "https://evil.example.com" },
+      sig: envelope.sig,
+    });
+    expect(verifyOAuthState(tampered)).toBeNull();
+  });
+
+  it("rejects a tampered signature", () => {
+    const envelope = decode(
+      signOAuthState({ projectId: "p1", provider: "gmail", nonce }),
+    );
+    const flipped = envelope.sig.startsWith("a")
+      ? `b${envelope.sig.slice(1)}`
+      : `a${envelope.sig.slice(1)}`;
+    expect(
+      verifyOAuthState(reencode({ ...envelope, sig: flipped })),
+    ).toBeNull();
+  });
+
+  it("rejects a signature of the wrong length without throwing", () => {
+    const envelope = decode(
+      signOAuthState({ projectId: "p1", provider: "gmail", nonce }),
+    );
+    expect(
+      verifyOAuthState(reencode({ ...envelope, sig: "short" })),
+    ).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    for (const bad of [
+      "",
+      "not-base64url!!",
+      Buffer.from("{}").toString("base64url"),
+    ]) {
+      expect(verifyOAuthState(bad)).toBeNull();
+    }
+  });
+
+  it("mints distinct nonces", () => {
+    expect(generateNonce()).not.toBe(generateNonce());
+    expect(generateNonce()).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/packages/api/src/lib/request-origin.test.ts
+++ b/packages/api/src/lib/request-origin.test.ts
@@ -6,7 +6,8 @@ vi.mock("./env", () => ({
   APP_URL: "http://localhost:10254",
 }));
 
-import { getRequestOrigin } from "./request-origin";
+import { getAppOrigin, getRequestOrigin } from "./request-origin";
+import { normalizeOrigin } from "./app-origin";
 
 const req = (headers: Record<string, string>) =>
   new Request("http://internal.local/x", { headers });
@@ -50,5 +51,68 @@ describe("getRequestOrigin (self-hosted)", () => {
         }),
       ),
     ).toBe("https://proxy.example.com");
+  });
+});
+
+describe("getAppOrigin", () => {
+  const orig = {
+    APP_URL: process.env.APP_URL,
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  };
+  afterEach(() => {
+    for (const key of ["APP_URL", "NEXT_PUBLIC_APP_URL"] as const) {
+      if (orig[key] === undefined) delete process.env[key];
+      else process.env[key] = orig[key];
+    }
+  });
+
+  const unconfigured = () => {
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  };
+
+  it("prefers a signed origin over the request's own", () => {
+    unconfigured();
+    expect(
+      getAppOrigin(req({ host: "arrived.example" }), "https://signed.example"),
+    ).toBe("https://signed.example");
+  });
+
+  it("keeps a configured APP_URL ahead of a signed origin", () => {
+    process.env.APP_URL = "https://configured.example";
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    expect(
+      getAppOrigin(req({ host: "arrived.example" }), "https://signed.example"),
+    ).toBe("https://configured.example");
+  });
+
+  it("ignores an absent or unusable signed origin", () => {
+    unconfigured();
+    for (const bad of [undefined, "", "javascript:alert(1)", 42]) {
+      expect(getAppOrigin(req({ host: "arrived.example" }), bad)).toBe(
+        "http://arrived.example",
+      );
+    }
+  });
+
+  // The round trip that keeps the two halves honest: `/authorize` signs whatever
+  // this returns, and `/callback` reads it back through normalizeOrigin. If the
+  // producer could emit something the reader rejects, the signed origin would
+  // silently drop out and the hardening would be a no-op.
+  it("produces an origin that normalizeOrigin accepts", () => {
+    unconfigured();
+    const cases: Record<string, string>[] = [
+      { host: "box.local" },
+      { host: "box.local:10254" },
+      { "x-forwarded-host": "proxy.example.com", "x-forwarded-proto": "https" },
+    ];
+    for (const headers of cases) {
+      const produced = getAppOrigin(req(headers));
+      expect(normalizeOrigin(produced)).toBe(produced);
+    }
+
+    process.env.APP_URL = "https://onecli.example.com/";
+    const configured = getAppOrigin(req({ host: "box.local" }));
+    expect(normalizeOrigin(configured)).toBe(configured);
   });
 });

--- a/packages/api/src/lib/request-origin.ts
+++ b/packages/api/src/lib/request-origin.ts
@@ -1,6 +1,10 @@
 import { IS_CLOUD } from "./env";
 import { getSelfUrl } from "../providers/self-url";
-import { configuredAppUrl, originFromHeaders } from "./app-origin";
+import {
+  configuredAppUrl,
+  normalizeOrigin,
+  originFromHeaders,
+} from "./app-origin";
 
 /**
  * Derive the public origin (scheme + host) from an incoming HTTP request.
@@ -44,6 +48,20 @@ export const getRequestOrigin = (request: Request): string => {
  *
  * Reach for this, not `getRequestOrigin`, whenever the result becomes a
  * `Location` header or a link a human will click.
+ *
+ * `signedOrigin` is an origin recovered from data we signed earlier in the same
+ * flow — the OAuth state minted at the authenticated `/authorize`. Preferring it
+ * over `request` matters because the OAuth *callback* is unauthenticated: taking
+ * the answer decided at the trusted end keeps a forged `X-Forwarded-Host` on the
+ * callback from steering where the browser lands. It still loses to a configured
+ * `APP_URL`, which is the only thing that can be right when the API and the
+ * dashboard are on different hosts. Absent, unparseable, or signed by a release
+ * that predates it, it drops out and the behavior is exactly as before.
  */
-export const getAppOrigin = (request: Request): string =>
-  configuredAppUrl() ?? getRequestOrigin(request);
+export const getAppOrigin = (
+  request: Request,
+  signedOrigin?: unknown,
+): string =>
+  configuredAppUrl() ??
+  normalizeOrigin(signedOrigin) ??
+  getRequestOrigin(request);

--- a/packages/api/src/routes/apps-callback-origin.test.ts
+++ b/packages/api/src/routes/apps-callback-origin.test.ts
@@ -35,11 +35,15 @@ vi.hoisted(() => {
 vi.mock("@onecli/db", () => ({ Prisma: {}, db: {} }));
 
 vi.mock("../apps/registry", () => ({
-  getApp: () => undefined,
+  getApp: (id: string) =>
+    id === "signedapp"
+      ? { id, name: id, available: true, connectionMethod: { type: "oauth" } }
+      : undefined,
   getApps: () => [],
 }));
 
 import { createApiApp } from "../app";
+import { signOAuthState, generateNonce } from "../lib/oauth-state";
 
 describe("oauth callback redirect origin (split API/dashboard hosts)", () => {
   let app: Hono<ApiEnv>;
@@ -64,6 +68,28 @@ describe("oauth callback redirect origin (split API/dashboard hosts)", () => {
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(
       `${APP_ORIGIN}/app-connect/nosuchprovider?status=error&message=Invalid%20provider`,
+    );
+    expect(res.headers.get("location")).not.toContain(API_ORIGIN);
+  });
+
+  // An origin signed into the state must not become a back door around the one
+  // setting that makes this deployment shape work. Even if a future change
+  // signed the API origin here, the configured APP_URL has to keep winning.
+  it("keeps APP_URL ahead of an origin signed into the state", async () => {
+    const state = signOAuthState({
+      provider: "signedapp",
+      nonce: generateNonce(),
+      origin: API_ORIGIN,
+    });
+
+    const res = await app.request(
+      `/v1/apps/signedapp/callback?state=${encodeURIComponent(state)}`,
+      { headers: { host: "api.example.com" } },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `${APP_ORIGIN}/app-connect/signedapp?status=error&message=Missing%20project%20in%20state`,
     );
     expect(res.headers.get("location")).not.toContain(API_ORIGIN);
   });

--- a/packages/api/src/routes/apps-callback-signed-origin.test.ts
+++ b/packages/api/src/routes/apps-callback-signed-origin.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Hono } from "hono";
+import type { ApiEnv } from "../types";
+
+/**
+ * The OAuth callback is **unauthenticated** — anyone can call it with whatever
+ * headers they like. `/authorize` is not, and it signs the state. These tests
+ * pin the consequence: once a state verifies, the post-consent destination comes
+ * from what `/authorize` committed to, not from the callback's own headers.
+ *
+ * Driven through the real Hono app and the real `signOAuthState`, so the
+ * signature path under test is genuinely exercised rather than stubbed.
+ */
+
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_EDITION = "onprem-slim";
+  process.env.SECRET_ENCRYPTION_KEY = "test-oauth-state-secret";
+  process.env.OAUTH_STATE_SECRET = "test-oauth-state-secret";
+});
+
+vi.mock("@onecli/db", () => ({ Prisma: {}, db: {} }));
+
+// One OAuth provider, no fragmentCallback — enough to walk the callback down to
+// the state check without touching the database.
+vi.mock("../apps/registry", () => ({
+  getApp: (id: string) =>
+    id === "signedapp"
+      ? { id, name: id, available: true, connectionMethod: { type: "oauth" } }
+      : // A fragment-callback provider (Trello-shaped): the token comes back in
+        // the URL fragment, so the first hit has no token query param and the
+        // handler answers with the fragment-bridge page instead of redirecting.
+        id === "fragmentapp"
+        ? {
+            id,
+            name: id,
+            available: true,
+            connectionMethod: {
+              type: "oauth",
+              fragmentCallback: { paramName: "token" },
+            },
+          }
+        : undefined,
+  getApps: () => [],
+}));
+
+import { createApiApp } from "../app";
+import { signOAuthState, generateNonce } from "../lib/oauth-state";
+
+const SIGNED_ORIGIN = "https://signed.example.com";
+const FORGED_HOST = "forged.example.com";
+
+// No projectId, so the handler stops at "Missing project in state" — the first
+// redirect *after* the origin is re-resolved from the verified state, which is
+// exactly the branch under test. Keeps the test off the database entirely.
+const stateWithout = (extra: Record<string, unknown> = {}) =>
+  signOAuthState({ provider: "signedapp", nonce: generateNonce(), ...extra });
+
+const MISSING_PROJECT =
+  "/app-connect/signedapp?status=error&message=Missing%20project%20in%20state";
+
+describe("oauth callback origin comes from the signed state", () => {
+  let app: Hono<ApiEnv>;
+
+  beforeAll(() => {
+    app = createApiApp({ getSession: async () => null });
+  });
+
+  const orig = process.env.APP_URL;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.APP_URL;
+    else process.env.APP_URL = orig;
+  });
+
+  const callback = (state: string, headers: Record<string, string> = {}) =>
+    app.request(
+      `/v1/apps/signedapp/callback?state=${encodeURIComponent(state)}`,
+      {
+        headers: { host: "api.example.com", ...headers },
+      },
+    );
+
+  // The security property. Without the change the forged header wins, because
+  // the destination is re-derived from the request that carries it.
+  it("ignores a forged X-Forwarded-Host when the state carries an origin", async () => {
+    delete process.env.APP_URL;
+
+    const res = await callback(stateWithout({ origin: SIGNED_ORIGIN }), {
+      "x-forwarded-host": FORGED_HOST,
+      "x-forwarded-proto": "https",
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `${SIGNED_ORIGIN}${MISSING_PROJECT}`,
+    );
+    expect(res.headers.get("location")).not.toContain(FORGED_HOST);
+  });
+
+  // Guards PR #713 from the other side: a signed origin must not become a way to
+  // override the one setting that makes split API/dashboard host deploys work.
+  it("still lets a configured APP_URL win over the signed origin", async () => {
+    process.env.APP_URL = "https://configured.example.com";
+
+    const res = await callback(stateWithout({ origin: SIGNED_ORIGIN }));
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `https://configured.example.com${MISSING_PROJECT}`,
+    );
+  });
+
+  // A state minted before this field existed is still in flight during a deploy.
+  it("falls back to the request origin when the state has no origin", async () => {
+    delete process.env.APP_URL;
+
+    const res = await callback(stateWithout(), {
+      "x-forwarded-host": "proxy.example.com",
+      "x-forwarded-proto": "https",
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `https://proxy.example.com${MISSING_PROJECT}`,
+    );
+  });
+
+  // Defence in depth: we signed it, so this should never happen — but if it
+  // does, drop it rather than emit a redirect that goes nowhere.
+  it("ignores a signed origin that is not a usable origin", async () => {
+    delete process.env.APP_URL;
+
+    const res = await callback(
+      stateWithout({ origin: "javascript:alert(1)" }),
+      { "x-forwarded-host": "proxy.example.com", "x-forwarded-proto": "https" },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `https://proxy.example.com${MISSING_PROJECT}`,
+    );
+  });
+
+  // The fragment-bridge page embeds this origin inside a <script> block
+  // (JSON.stringify does not neutralize "</script>"), so it is the worst place
+  // to trust a header. The state reaches it via the `oauth_state` cookie that
+  // /authorize set on this exact path, which is why it can be trusted at all.
+  it("uses the signed origin on the fragment-bridge page, taking the state from the cookie", async () => {
+    delete process.env.APP_URL;
+
+    const state = signOAuthState({
+      provider: "fragmentapp",
+      nonce: generateNonce(),
+      origin: SIGNED_ORIGIN,
+    });
+
+    const res = await app.request("/v1/apps/fragmentapp/callback", {
+      headers: {
+        host: "api.example.com",
+        "x-forwarded-host": FORGED_HOST,
+        "x-forwarded-proto": "https",
+        cookie: `oauth_state=${state}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(`${SIGNED_ORIGIN}/app-connect/fragmentapp`);
+    expect(html).not.toContain(FORGED_HOST);
+  });
+
+  // A state for a different provider is about to be rejected as invalid, so it
+  // must not get to pick the destination on the way out.
+  it("ignores an origin signed for a different provider", async () => {
+    delete process.env.APP_URL;
+
+    const otherProvider = signOAuthState({
+      provider: "fragmentapp",
+      nonce: generateNonce(),
+      origin: SIGNED_ORIGIN,
+    });
+
+    const res = await callback(otherProvider, {
+      "x-forwarded-host": "proxy.example.com",
+      "x-forwarded-proto": "https",
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "https://proxy.example.com/app-connect/signedapp?status=error&message=Invalid%20state%20parameter",
+    );
+    expect(res.headers.get("location")).not.toContain(SIGNED_ORIGIN);
+  });
+
+  // The paths above the state check have nothing verified to read yet, so they
+  // must keep using the request-derived origin.
+  it("uses the request origin for errors raised before the state is checked", async () => {
+    delete process.env.APP_URL;
+
+    const res = await app.request("/v1/apps/signedapp/callback", {
+      headers: { host: "api.example.com" },
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "http://api.example.com/app-connect/signedapp?status=error&message=Missing%20state%20parameter",
+    );
+  });
+});

--- a/packages/api/src/routes/apps.ts
+++ b/packages/api/src/routes/apps.ts
@@ -410,10 +410,14 @@ export const appRoutes = () => {
       const rawAgentName = c.req.query("agent_name");
       const agentName = rawAgentName ? rawAgentName.slice(0, 128) : undefined;
 
+      // Decide where the browser goes *after* consent here, at the authenticated
+      // end, and sign it: the callback is unauthenticated, so re-deriving it
+      // there from request headers lets the caller influence the destination.
       const state = signOAuthState({
         projectId,
         provider,
         nonce: generateNonce(),
+        origin: getAppOrigin(c.req.raw),
         ...(connectionId ? { connectionId } : {}),
         ...(agentName ? { agentName } : {}),
       });
@@ -460,11 +464,30 @@ export const appRoutes = () => {
   app.get("/:provider/callback", async (c) => {
     const provider = c.req.param("provider")!;
     const apiOrigin = getRequestOrigin(c.req.raw);
+
+    // Resolve the state before anything else can redirect or render. It arrives
+    // in the query, or in the `oauth_state` cookie `/authorize` set on this exact
+    // path (SameSite=Lax, so the provider's top-level GET still carries it) —
+    // which is why the fragment-bridge branch below can rely on it even though
+    // its provider returns everything else in the URL fragment. That branch
+    // renders the origin inside a <script>, so it is the last place that should
+    // be trusting request headers.
+    const stateParam = c.req.query("state") ?? getCookie(c, "oauth_state");
+    const state = stateParam ? verifyOAuthState(stateParam) : null;
+    // Only a state this request would actually accept gets to choose the
+    // destination — never one we are about to reject as belonging to another
+    // provider.
+    const signedOrigin =
+      state?.provider === provider ? state.origin : undefined;
+
     // Two different questions, and conflating them is what broke this before.
     // `apiOrigin` is who answered the callback — it must build the redirect_uri
     // for the token exchange below. `appOrigin` is where the browser goes next,
-    // which is a dashboard page and may live on another host entirely.
-    const appOrigin = getAppOrigin(c.req.raw);
+    // which is a dashboard page and may live on another host entirely, so it
+    // comes from the origin committed to at `/authorize` rather than from this
+    // unauthenticated request's headers. A state minted before that field
+    // existed leaves it undefined and resolves exactly as it did before.
+    const appOrigin = getAppOrigin(c.req.raw, signedOrigin);
 
     const appDef = getApp(provider);
     if (
@@ -499,12 +522,11 @@ export const appRoutes = () => {
         return errorRedirect("Invalid provider");
       }
 
-      const stateParam = c.req.query("state") ?? getCookie(c, "oauth_state");
+      // Both resolved at the top so `appOrigin` could be derived from the state;
+      // the checks stay here so the error responses are unchanged.
       if (!stateParam) {
         return errorRedirect("Missing state parameter");
       }
-
-      const state = verifyOAuthState(stateParam);
       if (!state || state.provider !== provider) {
         return errorRedirect("Invalid state parameter");
       }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -190,6 +190,8 @@ main() {
   echo "  Dashboard:  http://$ONECLI_BIND_HOST:${ONECLI_APP_PORT:-10254}"
   echo "  Gateway:    http://$ONECLI_BIND_HOST:${ONECLI_GATEWAY_PORT:-10255}"
   echo ""
+  echo "  Reaching OneCLI at another address (tunnel, proxy, domain)? Set APP_URL in $INSTALL_DIR/.env"
+  echo ""
   echo "  Compose file: $COMPOSE_FILE"
   echo ""
   echo "  To stop:   docker compose -p $PROJECT_NAME -f $COMPOSE_FILE down"


### PR DESCRIPTION
Two related defects around the same question: *where does this instance live?*

## 1. The OAuth callback trusted its own request headers

`/apps/:provider/callback` decided where to send the browser after consent from `X-Forwarded-Host` / `Host` when `APP_URL` was unset. That endpoint is **unauthenticated**, so the destination was influenceable by whoever called it.

`/authorize` *is* authenticated and already signs OAuth state, so the destination is now decided there and signed in — the callback reproduces a committed answer instead of deriving one from untrusted input.

Precedence gains a trusted middle term and keeps its outer two:

> configured **`APP_URL`** → origin **signed at `/authorize`** → origin of the **callback request**

A state minted before this field existed leaves it undefined and resolves exactly as it did before, so states in flight across a deploy are unaffected.

Two details worth review attention:

- **The state is resolved before anything else in the handler can redirect or render.** It arrives in the query *or* in the `oauth_state` cookie `/authorize` set on this path (`SameSite=Lax`, so the provider's top-level GET carries it). That is what lets the **fragment-bridge** branch use it — that branch embeds the origin inside a `<script>`, and `JSON.stringify` does not neutralize `</script>`.
- **Only a state this request would accept may choose the destination.** One signed for another provider is about to be rejected as invalid and gets no say on the way out.

## 2. A public URL was computed from a bind address

`docker-compose.yml` set `APP_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}`. A public URL and a bind address are different concepts — `ONECLI_BIND_HOST=0.0.0.0` yields `http://0.0.0.0:10254` — and because it was hardcoded, **anyone behind a tunnel, a reverse proxy, or a real domain had no way to say so.**

```yaml
APP_URL: ${APP_URL:-http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}}
```

Identical for every deployment that exists today; settable by exporting it or dropping it in a `.env` beside the compose file. `env_file` also gains that compose-dir `.env` — the existing `../.env` entry resolves to `$HOME/.env` in an installed layout, so a user's file next to the compose file was never read.

The gateway invented `http://localhost:10254` in silence when `APP_URL` was unset. Those links go into responses agents relay to humans ("open this URL to connect the app"), and a wrong absolute URL is worse than an absent one — the reader cannot tell it apart from a real one. The fallback stays (it is correct for a loopback install, and failing closed would break link generation for people it works for today), but a blank value now counts as unset and startup says so once:

```
WARN onecli_gateway: APP_URL is not set — links in agent-facing responses will point at
the fallback and will not open for anyone reaching OneCLI on a different address.
Set APP_URL to the URL users browse to. fallback="http://localhost:10254"
```

**One companion change that is required, not tidying.** `internal_api_url()` resolved `INTERNAL_API_URL → APP_URL → loopback`. The gateway reaches the Node app *inside the same container* (`docker/entrypoint.sh` runs the gateway in the background and the Node server in the foreground), so that is a loopback call. Now that `APP_URL` can name a real public host, keeping it in that chain would have sent in-container 1Password vault calls out over the internet. `docker-compose.yml` names `INTERNAL_API_URL` explicitly as well, so images released *before* this change resolve it correctly too — `install.sh` fetches the compose file from `main` while the image comes from a release, so the two can legitimately skew.

## `install.sh` keeps its contract

`ONECLI_BIND_HOST`, `ONECLI_APP_PORT`, `ONECLI_GATEWAY_PORT`, `POSTGRES_PORT`, `ONECLI_VERSION` behave identically. The diff there is **two `echo` lines** — no logic, no inputs, no files written.

This was validated against a real consumer that installs via `curl -fsSL onecli.sh/install | sh` and then **parses the output**, taking the first URL it finds as the API host. The added hint line contains no URL and sits after `ONECLI_URL:`, so that extraction is unchanged; `docker compose config` diffed old vs new is byte-identical for that invocation apart from the new `INTERNAL_API_URL` line.

## Verification

**Compose, resolved with `docker compose config`:**

| Scenario | `APP_URL` |
| --- | --- |
| nothing set (`docker compose up`) | `http://127.0.0.1:10254` — unchanged |
| `ONECLI_BIND_HOST=172.17.0.1` (installer shape) | `http://172.17.0.1:10254` — unchanged |
| with a port remap | `http://172.17.0.1:11254` — unchanged |
| `export APP_URL=…` | honored |
| `.env` beside the compose file | honored |
| both | export wins |

`environment:` also takes precedence over `env_file:` — verified with a `.env` that tries to override `DATABASE_URL` and `GATEWAY_API_URL`; both keep their compose values.

**Gateway binary, run for real:** `APP_URL` unset → warns · set → silent · whitespace-only → warns.

**Callback, driven end to end against a running server:** forged `X-Forwarded-Host` → follows the signed origin · configured `APP_URL` → wins · no signed origin → falls back to the request origin · tampered origin → `Invalid state parameter` · state for another provider → rejected · state via cookie only → follows the signed origin.

**Gates:** `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` (480 + 8) all green with **no features** — the standalone build. `@onecli/api` check-types, lint, and 740 tests; `@onecli/web` check-types and lint. `sh -n scripts/install.sh` clean.
