### PR TITLE
fix google oauth token routing

### DIFF
--- a/apps/gateway/src/apps.rs
+++ b/apps/gateway/src/apps.rs
@@ -53,6 +53,7 @@ pub(crate) enum HostPattern {
 }
 
 /// A host pattern and its injection strategy for an app provider.
+#[derive(Clone, Copy)]
 pub(crate) struct HostRule {
     pub(crate) pattern: HostPattern,
     /// Optional path prefix to scope this rule (e.g., `"/calendar/"` for Google Calendar).
@@ -191,6 +192,14 @@ static GOOGLE_REFRESH: RefreshConfig = RefreshConfig {
     client_secret_env: "GOOGLE_CLIENT_SECRET",
     body_format: TokenBodyFormat::Form,
     client_auth: ClientCredentialMethod::Body,
+};
+
+const GOOGLE_TOKEN_RULE: HostRule = HostRule {
+    pattern: HostPattern::Exact("oauth2.googleapis.com"),
+    path_prefix: Some("/token"),
+    strategy: AuthStrategy::Bearer,
+    intercept: true,
+    credential_host_field: None,
 };
 
 /// Refresh config for Supabase Management API OAuth (uses Basic auth).
@@ -335,6 +344,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
                 intercept: false,
                 credential_host_field: None,
             },
+            GOOGLE_TOKEN_RULE,
         ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
@@ -362,6 +372,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
                 intercept: false,
                 credential_host_field: None,
             },
+            GOOGLE_TOKEN_RULE,
         ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
@@ -396,6 +407,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
                 intercept: false,
                 credential_host_field: None,
             },
+            GOOGLE_TOKEN_RULE,
         ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
@@ -408,13 +420,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-contacts",
         display_name: "Google Contacts",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("people.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("people.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -426,13 +441,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-docs",
         display_name: "Google Docs",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("docs.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("docs.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -444,13 +462,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-sheets",
         display_name: "Google Sheets",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("sheets.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("sheets.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -462,13 +483,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-slides",
         display_name: "Google Slides",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("slides.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("slides.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -480,13 +504,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-tasks",
         display_name: "Google Tasks",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("tasks.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("tasks.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -498,13 +525,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-chat",
         display_name: "Google Chat",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("chat.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("chat.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -516,13 +546,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-forms",
         display_name: "Google Forms",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("forms.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("forms.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -534,13 +567,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-classroom",
         display_name: "Google Classroom",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("classroom.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("classroom.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -552,13 +588,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-admin",
         display_name: "Google Admin",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("admin.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("admin.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -570,13 +609,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-analytics",
         display_name: "Google Analytics",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("analyticsdata.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("analyticsdata.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -603,6 +645,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
                 intercept: false,
                 credential_host_field: None,
             },
+            GOOGLE_TOKEN_RULE,
         ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
@@ -615,13 +658,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-meet",
         display_name: "Google Meet",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("meet.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("meet.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -633,13 +679,16 @@ static APP_PROVIDERS: &[AppProvider] = &[
     AppProvider {
         provider: "google-photos",
         display_name: "Google Photos",
-        host_rules: &[HostRule {
-            pattern: HostPattern::Exact("photoslibrary.googleapis.com"),
-            path_prefix: None,
-            strategy: AuthStrategy::Bearer,
-            intercept: false,
-            credential_host_field: None,
-        }],
+        host_rules: &[
+            HostRule {
+                pattern: HostPattern::Exact("photoslibrary.googleapis.com"),
+                path_prefix: None,
+                strategy: AuthStrategy::Bearer,
+                intercept: false,
+                credential_host_field: None,
+            },
+            GOOGLE_TOKEN_RULE,
+        ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
         credential_headers: &[],
@@ -727,6 +776,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
                 intercept: false,
                 credential_host_field: None,
             },
+            GOOGLE_TOKEN_RULE,
         ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[],
@@ -747,13 +797,7 @@ static APP_PROVIDERS: &[AppProvider] = &[
                 intercept: false,
                 credential_host_field: None,
             },
-            HostRule {
-                pattern: HostPattern::Exact("oauth2.googleapis.com"),
-                path_prefix: Some("/token"),
-                strategy: AuthStrategy::Bearer,
-                intercept: true,
-                credential_host_field: None,
-            },
+            GOOGLE_TOKEN_RULE,
         ],
         refresh: Some(&GOOGLE_REFRESH),
         metadata_headers: &[MetadataHeader {
@@ -2093,6 +2137,14 @@ mod tests {
         assert!(patterns.contains(&"/batch/calendar/*"));
     }
 
+    #[test]
+    fn google_calendar_produces_token_intercept_rule() {
+        let rules =
+            build_app_injection_rules("google-calendar", "oauth2.googleapis.com", "ya29.cal_test");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].0, "/token*");
+    }
+
     // ── Google Drive ──────────────────────────────────────────────────
 
     #[test]
@@ -3046,11 +3098,10 @@ mod tests {
     }
 
     #[test]
-    fn oauth2_token_endpoint_maps_to_vertex_ai() {
-        assert_eq!(
-            providers_for_host("oauth2.googleapis.com"),
-            vec!["vertex-ai"]
-        );
+    fn oauth2_token_endpoint_maps_to_google_oauth_apps() {
+        let providers = providers_for_host("oauth2.googleapis.com");
+        assert!(providers.contains(&"google-calendar"));
+        assert!(providers.contains(&"vertex-ai"));
         assert!(is_intercept_target("oauth2.googleapis.com", "/token"));
         assert!(!is_intercept_target("oauth2.googleapis.com", "/authorize"));
     }


### PR DESCRIPTION
fixes #307

## changes
- share the `oauth2.googleapis.com/token` intercept rule across Google OAuth app providers
- keep the token endpoint as an intercept target instead of routing all refreshes through Vertex AI
- add regression coverage for Google Calendar and shared Google OAuth token routing

## verification
- `cargo fmt --manifest-path apps/gateway/Cargo.toml --check`
- `cargo test --manifest-path apps/gateway/Cargo.toml google_calendar_produces_token_intercept_rule`
- `cargo test --manifest-path apps/gateway/Cargo.toml oauth2_token_endpoint_maps_to_google_oauth_apps`
- `cargo test --manifest-path apps/gateway/Cargo.toml oauth2`
- `cargo test --manifest-path apps/gateway/Cargo.toml intercept_token_comes_from_app_rules_only`
- `pnpm check`
- `pnpm build`
- `git diff --check`