### PR TITLE
fix dashboard auth session

### DIFF
--- a/apps/web/src/lib/auth/auth-provider.tsx
+++ b/apps/web/src/lib/auth/auth-provider.tsx
@@ -1,15 +1,20 @@
 "use client";
 
-import { useCallback, useMemo, type ReactNode } from "react";
 import {
-  SessionProvider,
-  useSession,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
   signIn as nextAuthSignIn,
   signOut as nextAuthSignOut,
 } from "next-auth/react";
 import { AuthContext } from "@/providers/auth-provider";
 import type { AuthUser, AuthContextValue } from "@/lib/auth/types";
 import type { AuthMode } from "@/lib/auth/auth-mode";
+import { apiFetch } from "@/lib/api-fetch";
 
 const LOCAL_USER: AuthUser = {
   id: "local-admin",
@@ -33,16 +38,32 @@ const LocalAuthProvider = ({ children }: { children: ReactNode }) => {
 };
 
 const OAuthInner = ({ children }: { children: ReactNode }) => {
-  const { data: session, status } = useSession();
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const user = useMemo<AuthUser | null>(() => {
-    if (!session?.user?.id || !session.user.email) return null;
-    return {
-      id: session.user.id,
-      email: session.user.email,
-      name: session.user.name ?? undefined,
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadSession = async () => {
+      try {
+        const res = await apiFetch("/v1/auth/session");
+        if (!res.ok) return;
+        const session = (await res.json()) as Partial<AuthUser>;
+        if (!session.id || !session.email) return;
+        if (!cancelled) setUser(session as AuthUser);
+      } catch {
+        // Treat a failed session probe as signed out; route guards handle redirect.
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
     };
-  }, [session]);
+
+    void loadSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const signIn = useCallback(async () => {
     await nextAuthSignIn("google");
@@ -54,13 +75,13 @@ const OAuthInner = ({ children }: { children: ReactNode }) => {
 
   const value = useMemo<AuthContextValue>(
     () => ({
-      isAuthenticated: status === "authenticated",
-      isLoading: status === "loading",
+      isAuthenticated: user !== null,
+      isLoading,
       user,
       signIn,
       signOut,
     }),
-    [status, user, signIn, signOut],
+    [user, isLoading, signIn, signOut],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
@@ -77,9 +98,5 @@ export const AuthProviderImpl = ({
     return <LocalAuthProvider>{children}</LocalAuthProvider>;
   }
 
-  return (
-    <SessionProvider>
-      <OAuthInner>{children}</OAuthInner>
-    </SessionProvider>
-  );
+  return <OAuthInner>{children}</OAuthInner>;
 };


### PR DESCRIPTION
fixes #390

## changes
- read the dashboard auth state from `/v1/auth/session`, matching the flat API response shape
- keep next-auth for sign-in/sign-out redirects only
- treat failed session probes as signed out so route guards can redirect

## verification
- `pnpm --filter @onecli/web check-types`
- `pnpm --filter @onecli/web lint`
- `git diff --check`