### PR TITLE
fix(web): point to claude setup-token for Anthropic OAuth tokens

### DIFF
--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -887,7 +887,25 @@ export const SecretDialog = ({
                       ) : (
                         <p className="text-muted-foreground text-xs">
                           {type === "anthropic" ? (
-                            "Paste your API key or OAuth token from the Anthropic Console."
+                            detectAnthropicAuthMode(value) === "oauth" ? (
+                              <>
+                                Claude Code&rsquo;s own token rotates every few
+                                hours. Run{" "}
+                                <code className="bg-muted rounded px-1 py-0.5 text-[11px]">
+                                  claude setup-token
+                                </code>{" "}
+                                for a long-lived one.
+                              </>
+                            ) : (
+                              <>
+                                Paste your API key from the Anthropic Console,
+                                or run{" "}
+                                <code className="bg-muted rounded px-1 py-0.5 text-[11px]">
+                                  claude setup-token
+                                </code>{" "}
+                                for an OAuth token.
+                              </>
+                            )
                           ) : type === "openai" ? (
                             <>
                               Paste your API key, or{" "}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Bug fix (web/UX). Closes #459. Follow-up to #322.

## What is the current behavior?
The Anthropic secret form says "Paste your API key or OAuth token from the Anthropic Console." Two different OAuth tokens share the `sk-ant-oat` prefix, the one Claude Code rotates internally every few hours, and the long-lived one from `claude setup-token` and nothing distinguishes them. Pasting the former means 401s a few hours later, which is what #322 hit. The doc note promised there was never added (`grep -rn "setup-token"` → no hits). The current copy also misattributes the OAuth token to the Console, which isn't where it comes from.

## What is the new behavior?
The helper text now names `claude setup-token`, and when the entered value is detected as OAuth (`detectAnthropicAuthMode(value) === "oauth"`) it warns that Claude Code's own token rotates every few hours and points at the long-lived one. Styling matches the existing Codex OAuth hint.

Feel free to include screenshots if it includes visual changes.

## Additional context
Screenshots of both states:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/76f86762-29a1-42a4-a628-b9210143f03c" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/1d312d6a-da14-407e-b2d9-7683d8767af2" />


