### PR TITLE
fix anthropic oauth token help

### DIFF
--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -887,7 +887,13 @@ export const SecretDialog = ({
                       ) : (
                         <p className="text-muted-foreground text-xs">
                           {type === "anthropic" ? (
-                            "Paste your API key or OAuth token from the Anthropic Console."
+                            <>
+                              Paste your API key, or run{" "}
+                              <code className="text-[11px]">
+                                claude setup-token
+                              </code>{" "}
+                              for a long-lived OAuth token.
+                            </>
                           ) : type === "openai" ? (
                             <>
                               Paste your API key, or{" "}


### PR DESCRIPTION
fixes #459

## changes
- points Anthropic OAuth users to `claude setup-token` for a long-lived token

## verification
- `pnpm --filter @onecli/db prisma generate`
- `pnpm --filter @onecli/web check-types`
- `pnpm --filter @onecli/web lint`
- `pnpm exec prettier --check 'apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx'
- pre-push `pnpm check` hook passed
