### PR TITLE
feat(api): one OAuth redirect URI for all providers via a unified callback

### DIFF
--- a/apps/web/src/app/(dashboard)/connections/_components/app-config-form.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/app-config-form.tsx
@@ -364,7 +364,10 @@ export const AppConfigForm = ({
               </div>
             ))}
 
-            <RedirectUri provider={provider} />
+            <RedirectUri
+              provider={provider}
+              unified={pageScope === "project"}
+            />
 
             <div className="flex items-center gap-3">
               <Button

--- a/apps/web/src/app/(dashboard)/connections/_components/configure-credentials-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/configure-credentials-dialog.tsx
@@ -81,7 +81,7 @@ export const ConfigureCredentialsDialog = ({
 
         <div className="space-y-4 pt-2">
           {hint && <p className="text-muted-foreground text-xs">{hint}</p>}
-          <RedirectUri provider={provider} />
+          <RedirectUri provider={provider} unified={pageScope === "project"} />
           {fields.map((field, i) => (
             <div key={field.name} className="grid gap-1.5">
               <Label htmlFor={`config-${field.name}`}>

--- a/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/redirect-uri.tsx
@@ -15,8 +15,22 @@ const useBaseUrl = () => {
   return typeof window !== "undefined" ? window.location.origin : APP_URL;
 };
 
-export const RedirectUri = ({ provider }: { provider: string }) => {
-  const redirectUri = `${useBaseUrl()}/v1/apps/${provider}/callback`;
+export interface RedirectUriProps {
+  provider: string;
+  /**
+   * Whether the surface saving this config records the unified redirect style
+   * (project app configs stamp `redirectStyle: "unified"` on save, so their
+   * flows use the shared `/v1/apps/callback`). Org-scoped config forms keep
+   * showing the per-provider path until org flows adopt the stamp.
+   */
+  unified: boolean;
+}
+
+export const RedirectUri = ({ provider, unified }: RedirectUriProps) => {
+  const baseUrl = useBaseUrl();
+  const redirectUri = unified
+    ? `${baseUrl}/v1/apps/callback`
+    : `${baseUrl}/v1/apps/${provider}/callback`;
   const { copied, copy } = useCopyToClipboard();
 
   return (
@@ -68,6 +82,7 @@ export const RedirectUri = ({ provider }: { provider: string }) => {
         }
       >
         Add this to your OAuth app&apos;s allowed redirect URIs.
+        {unified && " The same URI works for every app on this instance."}
       </p>
     </div>
   );

--- a/packages/api/src/apps/resolve-credentials.ts
+++ b/packages/api/src/apps/resolve-credentials.ts
@@ -11,6 +11,15 @@ export interface ResolvedAppCredentials {
    * it on the connection so refresh and config-removal know the provenance.
    */
   appConfigId?: string;
+  /**
+   * Redirect style recorded on the AppConfig row when it was saved. "unified"
+   * means the config form displayed the shared `/v1/apps/callback` URI, so
+   * that is what the user registered on their OAuth app and what the OAuth
+   * flow must send. Absent — a row saved before the unified path existed, or
+   * env/org credentials — keeps the per-provider callback those OAuth apps
+   * have registered.
+   */
+  redirectStyle?: "unified";
 }
 
 /**
@@ -36,7 +45,14 @@ export const resolveAppCredentials = async (
   if (config && requiredFields.every((f) => !!config.fields[f])) {
     const values: Record<string, string> = {};
     for (const f of requiredFields) values[f] = config.fields[f]!;
-    return { values, source: "app_config", appConfigId: config.appConfigId };
+    return {
+      values,
+      source: "app_config",
+      appConfigId: config.appConfigId,
+      ...(config.fields.redirectStyle === "unified" && {
+        redirectStyle: "unified" as const,
+      }),
+    };
   }
 
   const orgAppConfig = getOrgAppConfig();

--- a/packages/api/src/routes/apps-unified-callback.test.ts
+++ b/packages/api/src/routes/apps-unified-callback.test.ts
@@ -1,0 +1,307 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Hono } from "hono";
+import type { ApiEnv } from "../types";
+
+/**
+ * The unified OAuth callback (#301): one redirect URI — `/v1/apps/callback` —
+ * shared by every provider, with the provider recovered from the HMAC-signed
+ * state instead of the path.
+ *
+ * The rollout contract under test: `/authorize` sends the unified URI ONLY for
+ * AppConfig rows stamped `redirectStyle: "unified"` at save time. Everything
+ * else — older rows, env credentials — keeps the per-provider URI its OAuth
+ * app already has registered. Both callbacks must hand the token exchange the
+ * exact URI their flow's authorization request used, or the exchange fails at
+ * the provider.
+ */
+
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_EDITION = "onprem-slim";
+  process.env.SECRET_ENCRYPTION_KEY = "test-oauth-state-secret";
+  process.env.OAUTH_STATE_SECRET = "test-oauth-state-secret";
+});
+
+// Captures for the provider hooks the routes call — filled by the registry
+// mock below, asserted on by the tests.
+const captured = vi.hoisted(() => ({
+  authUrl: [] as Array<{ redirectUri: string; state: string }>,
+  exchange: [] as Array<{
+    redirectUri: string;
+    callbackParams: Record<string, string>;
+  }>,
+}));
+
+const PROJECT_KEY = "oc_test-project-key";
+
+vi.mock("@onecli/db", () => ({
+  Prisma: {},
+  db: {
+    apiKey: {
+      findUnique: async ({ where }: { where: { key: string } }) =>
+        where.key === PROJECT_KEY
+          ? { userId: "user-1", projectId: "proj-1" }
+          : null,
+    },
+    project: {
+      findUnique: async () => ({ id: "proj-1", organizationId: "org-1" }),
+    },
+    user: {
+      findUnique: async () => ({ email: "dev@example.com" }),
+    },
+  },
+}));
+
+// One plain OAuth provider and one fragment-callback provider (Trello-shaped),
+// both instrumented so the redirect_uri each hook receives can be asserted.
+vi.mock("../apps/registry", () => ({
+  getApp: (id: string) =>
+    id === "unifiedapp"
+      ? {
+          id,
+          name: "Unified App",
+          available: true,
+          connectionMethod: {
+            type: "oauth",
+            defaultScopes: ["scope.read"],
+            buildAuthUrl: (params: { redirectUri: string; state: string }) => {
+              captured.authUrl.push({
+                redirectUri: params.redirectUri,
+                state: params.state,
+              });
+              return `https://provider.example.com/authorize?redirect_uri=${encodeURIComponent(params.redirectUri)}`;
+            },
+            exchangeCode: async (params: {
+              redirectUri: string;
+              callbackParams: Record<string, string>;
+            }) => {
+              captured.exchange.push({
+                redirectUri: params.redirectUri,
+                callbackParams: params.callbackParams,
+              });
+              if (!params.callbackParams.code) {
+                throw new Error("missing authorization code");
+              }
+              return {
+                credentials: { access_token: "tok" },
+                scopes: ["scope.read"],
+                metadata: { username: "user@example.com" },
+              };
+            },
+          },
+          configurable: {
+            fields: [
+              { name: "clientId" },
+              { name: "clientSecret", secret: true },
+            ],
+          },
+        }
+      : id === "fragmentapp"
+        ? {
+            id,
+            name: "Fragment App",
+            available: true,
+            connectionMethod: {
+              type: "oauth",
+              fragmentCallback: { paramName: "token" },
+            },
+          }
+        : undefined,
+  getApps: () => [],
+}));
+
+vi.mock("../apps/resolve-credentials", () => ({
+  resolveAppCredentials: vi.fn(),
+}));
+
+// Keep the pure helpers (extractLabel) real; stub only what would hit the
+// database or the crypto provider.
+vi.mock("../services/connection-service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../services/connection-service")>();
+  return {
+    ...actual,
+    listConnections: vi.fn(async () => []),
+    listConnectionsByProvider: vi.fn(async () => []),
+    createConnection: vi.fn(async () => ({ id: "conn-new", label: null })),
+    reconnectConnection: vi.fn(async () => ({ id: "conn-new" })),
+    linkConnectionToAppConfig: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock("../lib/gateway-invalidate", () => ({
+  invalidateGatewayCache: vi.fn(),
+  invalidateGatewayCacheForAccount: vi.fn(),
+}));
+
+import { createApiApp } from "../app";
+import { signOAuthState, generateNonce } from "../lib/oauth-state";
+import { resolveAppCredentials } from "../apps/resolve-credentials";
+import type { ResolvedAppCredentials } from "../apps/resolve-credentials";
+
+const resolveMock = vi.mocked(resolveAppCredentials);
+
+const CREDS: ResolvedAppCredentials = {
+  values: { clientId: "cid", clientSecret: "sec" },
+  source: "app_config",
+  appConfigId: "cfg-1",
+};
+
+const API_ORIGIN = "http://api.example.com";
+const authorizeHeaders = {
+  host: "api.example.com",
+  authorization: `Bearer ${PROJECT_KEY}`,
+};
+
+describe("unified OAuth callback (#301)", () => {
+  let app: Hono<ApiEnv>;
+
+  beforeAll(() => {
+    app = createApiApp({ getSession: async () => null });
+  });
+
+  beforeEach(() => {
+    captured.authUrl.length = 0;
+    captured.exchange.length = 0;
+    resolveMock.mockReset();
+  });
+
+  describe("GET /apps/:provider/authorize — redirect URI selection", () => {
+    it("sends the unified redirect URI for a config stamped at save time", async () => {
+      resolveMock.mockResolvedValue({ ...CREDS, redirectStyle: "unified" });
+
+      const res = await app.request("/v1/apps/unifiedapp/authorize", {
+        headers: authorizeHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      expect(captured.authUrl.at(-1)?.redirectUri).toBe(
+        `${API_ORIGIN}/v1/apps/callback`,
+      );
+      // The state cookie must be scoped to the path the flow will land on.
+      expect(res.headers.get("set-cookie")).toContain("Path=/v1/apps/callback");
+    });
+
+    it("keeps the per-provider redirect URI for an unstamped config", async () => {
+      resolveMock.mockResolvedValue(CREDS);
+
+      const res = await app.request("/v1/apps/unifiedapp/authorize", {
+        headers: authorizeHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      expect(captured.authUrl.at(-1)?.redirectUri).toBe(
+        `${API_ORIGIN}/v1/apps/unifiedapp/callback`,
+      );
+      expect(res.headers.get("set-cookie")).toContain(
+        "Path=/v1/apps/unifiedapp/callback",
+      );
+    });
+  });
+
+  describe("GET /apps/callback — provider from the signed state", () => {
+    const signedState = (extra: Record<string, unknown> = {}) =>
+      signOAuthState({
+        provider: "unifiedapp",
+        projectId: "proj-1",
+        nonce: generateNonce(),
+        origin: API_ORIGIN,
+        ...extra,
+      });
+
+    it("completes the flow and hands the exchange the unified redirect URI", async () => {
+      resolveMock.mockResolvedValue({ ...CREDS, redirectStyle: "unified" });
+
+      const res = await app.request(
+        `/v1/apps/callback?code=abc&state=${encodeURIComponent(signedState())}`,
+        { headers: { host: "api.example.com" } },
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(
+        `${API_ORIGIN}/app-connect/unifiedapp?status=success&connected=conn-new&projectId=proj-1`,
+      );
+      // The exchange must repeat the URI the authorization request used — the
+      // unified path, not the per-provider one.
+      expect(captured.exchange.at(-1)?.redirectUri).toBe(
+        `${API_ORIGIN}/v1/apps/callback`,
+      );
+    });
+
+    it("serves the fragment bridge from the state cookie alone", async () => {
+      // Fragment providers return everything in the URL fragment: the request
+      // has no query params at all, so the provider can only come from the
+      // oauth_state cookie /authorize scoped to the unified path.
+      const state = signOAuthState({
+        provider: "fragmentapp",
+        nonce: generateNonce(),
+        origin: "https://signed.example.com",
+      });
+
+      const res = await app.request("/v1/apps/callback", {
+        headers: {
+          host: "api.example.com",
+          cookie: `oauth_state=${state}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain(
+        "https://signed.example.com/app-connect/fragmentapp",
+      );
+    });
+
+    it("fails flat with 400 when there is no state at all", async () => {
+      const res = await app.request("/v1/apps/callback?code=abc", {
+        headers: { host: "api.example.com" },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("fails flat with 400 on a state that does not verify", async () => {
+      const res = await app.request(
+        "/v1/apps/callback?code=abc&state=not-a-signed-state",
+        { headers: { host: "api.example.com" } },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("fails flat with 400 when the signed provider is not registered", async () => {
+      const ghost = signOAuthState({
+        provider: "ghost",
+        projectId: "proj-1",
+        nonce: generateNonce(),
+      });
+      const res = await app.request(
+        `/v1/apps/callback?code=abc&state=${encodeURIComponent(ghost)}`,
+        { headers: { host: "api.example.com" } },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /apps/:provider/callback — unchanged for legacy flows", () => {
+    it("still hands the exchange the per-provider redirect URI", async () => {
+      resolveMock.mockResolvedValue(CREDS);
+
+      const state = signOAuthState({
+        provider: "unifiedapp",
+        projectId: "proj-1",
+        nonce: generateNonce(),
+        origin: API_ORIGIN,
+      });
+
+      const res = await app.request(
+        `/v1/apps/unifiedapp/callback?code=abc&state=${encodeURIComponent(state)}`,
+        { headers: { host: "api.example.com" } },
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(
+        `${API_ORIGIN}/app-connect/unifiedapp?status=success&connected=conn-new&projectId=proj-1`,
+      );
+      expect(captured.exchange.at(-1)?.redirectUri).toBe(
+        `${API_ORIGIN}/v1/apps/unifiedapp/callback`,
+      );
+    });
+  });
+});

--- a/packages/api/src/routes/apps.ts
+++ b/packages/api/src/routes/apps.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { setCookie, getCookie, deleteCookie } from "hono/cookie";
 import { z } from "zod";
 import { db } from "@onecli/db";
@@ -67,6 +67,16 @@ import {
 import { logger } from "../lib/logger";
 
 const docsBaseURL = "https://onecli.sh/docs/guides/credential-stubs";
+
+/**
+ * The shared OAuth callback path (#301): one redirect URI to register on an
+ * OAuth app instead of one per provider — the biggest win for Google OAuth
+ * apps, which back a dozen providers and otherwise need a dozen URIs. Flows
+ * land here only when `/authorize` chose it, which it does only for AppConfig
+ * rows stamped `redirectStyle: "unified"` at save time; every other flow keeps
+ * `/v1/apps/:provider/callback`.
+ */
+const UNIFIED_CALLBACK_PATH = "/v1/apps/callback";
 
 const toggleSchema = z.object({ enabled: z.boolean() });
 
@@ -280,6 +290,28 @@ export const appRoutes = () => {
     },
   );
 
+  // ── GET /apps/callback ── unified OAuth callback (#301) ────────────────
+  // One redirect URI for every provider: the provider comes from the signed
+  // state (committed at the authenticated /authorize, HMAC-verified here)
+  // instead of from the path. Registered before GET /:provider so "callback"
+  // isn't read as a provider id.
+  app.get("/callback", async (c) => {
+    // Same two state sources as the per-provider route: the query param, or
+    // the oauth_state cookie /authorize scoped to this exact path — which is
+    // how fragment-callback providers, whose redirects carry no query params,
+    // still resolve here.
+    const stateParam = c.req.query("state") ?? getCookie(c, "oauth_state");
+    const state = stateParam ? verifyOAuthState(stateParam) : null;
+    const provider = state?.provider;
+    // No verified provider means there is no per-provider error page to send
+    // the browser to — and nothing here an attacker can steer, since a forged
+    // state already failed the HMAC. Fail flat instead of redirecting.
+    if (!provider || !getApp(provider)) {
+      return c.json({ error: "Invalid or missing state parameter" }, 400);
+    }
+    return handleOAuthCallback(c, provider, UNIFIED_CALLBACK_PATH);
+  });
+
   // ── GET /apps/:provider ── single app detail ───────────────────────────
   app.get("/:provider", authMiddleware, async (c) => {
     const auth = c.get("auth");
@@ -438,7 +470,15 @@ export const appRoutes = () => {
 
       const { values: creds } = resolved;
 
-      const redirectUri = `${getRequestOrigin(c.req.raw)}/v1/apps/${provider}/callback`;
+      // The callback this flow lands on must be a URI the user's OAuth app has
+      // registered. Rows stamped at save time committed to the shared path;
+      // env credentials and rows saved before it keep the per-provider path
+      // their OAuth app already knows (#301).
+      const callbackPath =
+        resolved.redirectStyle === "unified"
+          ? UNIFIED_CALLBACK_PATH
+          : `/v1/apps/${provider}/callback`;
+      const redirectUri = `${getRequestOrigin(c.req.raw)}${callbackPath}`;
       const scopes = appDef.connectionMethod.defaultScopes ?? [];
 
       const authUrl = appDef.connectionMethod.buildAuthUrl({
@@ -452,7 +492,7 @@ export const appRoutes = () => {
         httpOnly: true,
         secure: NODE_ENV === "production",
         sameSite: "Lax",
-        path: `/v1/apps/${provider}/callback`,
+        path: callbackPath,
         maxAge: 600,
       });
 
@@ -460,9 +500,17 @@ export const appRoutes = () => {
     },
   );
 
-  // ── GET /apps/:provider/callback ── OAuth callback ─────────────────────
-  app.get("/:provider/callback", async (c) => {
-    const provider = c.req.param("provider")!;
+  // ── OAuth callback ── shared between the per-provider route and the
+  // unified one (#301). `provider` comes from the path on the former and from
+  // the HMAC-verified state on the latter. `callbackPath` is whichever route
+  // actually answered: the token exchange's redirect_uri must repeat the exact
+  // URI the authorization request used, and the state cookie was scoped to
+  // that same path at /authorize.
+  const handleOAuthCallback = async (
+    c: Context<ApiEnv>,
+    provider: string,
+    callbackPath: string,
+  ) => {
     const apiOrigin = getRequestOrigin(c.req.raw);
 
     // Resolve the state before anything else can redirect or render. It arrives
@@ -580,7 +628,7 @@ export const appRoutes = () => {
         return errorRedirect(`${appDef.name} is not configured`);
       }
 
-      const redirectUri = `${apiOrigin}/v1/apps/${provider}/callback`;
+      const redirectUri = `${apiOrigin}${callbackPath}`;
 
       // Extract all query params as callback params
       const url = new URL(c.req.url);
@@ -666,7 +714,7 @@ export const appRoutes = () => {
       }
 
       deleteCookie(c, "oauth_state", {
-        path: `/v1/apps/${provider}/callback`,
+        path: callbackPath,
       });
 
       return c.redirect(
@@ -678,6 +726,12 @@ export const appRoutes = () => {
         err instanceof Error ? err.message : "An unexpected error occurred";
       return errorRedirect(message);
     }
+  };
+
+  // ── GET /apps/:provider/callback ── OAuth callback ─────────────────────
+  app.get("/:provider/callback", async (c) => {
+    const provider = c.req.param("provider")!;
+    return handleOAuthCallback(c, provider, `/v1/apps/${provider}/callback`);
   });
 
   // ── POST /apps/:provider/connect ── direct connect ─────────────────────

--- a/packages/api/src/services/app-config-service.test.ts
+++ b/packages/api/src/services/app-config-service.test.ts
@@ -35,6 +35,10 @@ const store = vi.hoisted(() => ({
   calls: [] as string[],
   deleteManyWheres: [] as ConnWhere[],
   countWheres: [] as ConnWhere[],
+  upsertArgs: [] as {
+    create: { provider: string; settings: Record<string, string> };
+    update: { settings: Record<string, string> };
+  }[],
 }));
 
 const matches = (conn: Conn, where: ConnWhere) =>
@@ -57,6 +61,14 @@ vi.mock("@onecli/db", () => ({
       update: async () => {
         store.calls.push("configUpdate");
         return { id: store.appConfigRow?.id, enabled: false };
+      },
+      upsert: async (args: {
+        create: { provider: string; settings: Record<string, string> };
+        update: { settings: Record<string, string> };
+      }) => {
+        store.calls.push("configUpsert");
+        store.upsertArgs.push(args);
+        return { id: "cfg-new", provider: args.create.provider };
       },
     },
     appConnection: {
@@ -116,6 +128,7 @@ import {
   countAppConfigDependents,
   getAppConfigCredentials,
   hasAppConfig,
+  upsertAppConfig,
 } from "./app-config-service";
 
 const seedConfig = (id = "cfg-1") => {
@@ -133,6 +146,7 @@ beforeEach(() => {
   store.calls = [];
   store.deleteManyWheres = [];
   store.countWheres = [];
+  store.upsertArgs = [];
 });
 
 describe("disconnectIfConnected via deleteAppConfig — org scope", () => {
@@ -345,6 +359,78 @@ describe("hasAppConfig — configured means usable (enabled + credentials)", () 
       enabled: false,
     };
     expect(await hasAppConfig({ projectId: "p-1" }, "prov")).toBe(false);
+  });
+});
+
+describe("upsertAppConfig — redirect-style stamp (#301)", () => {
+  const FIELDS = [
+    { name: "clientId", label: "Client ID", placeholder: "" },
+    {
+      name: "clientSecret",
+      label: "Client Secret",
+      placeholder: "",
+      secret: true,
+    },
+  ];
+
+  it("stamps project rows unified on create and update alike", async () => {
+    await upsertAppConfig(
+      { projectId: "p-1" },
+      "gmail",
+      { clientId: "cid", clientSecret: "sec" },
+      FIELDS,
+    );
+
+    const args = store.upsertArgs[0]!;
+    expect(args.create.settings).toEqual({
+      clientId: "cid",
+      redirectStyle: "unified",
+    });
+    // An update replaces settings wholesale, so it re-stamps too — this is
+    // exactly how a pre-unified row migrates when its owner re-saves the form
+    // (which also disconnects the provider, so no live flow straddles the
+    // switch).
+    expect(args.update.settings).toEqual({
+      clientId: "cid",
+      redirectStyle: "unified",
+    });
+  });
+
+  it("disconnects the provider before the stamped row lands", async () => {
+    await upsertAppConfig(
+      { projectId: "p-1" },
+      "gmail",
+      { clientId: "cid", clientSecret: "sec" },
+      FIELDS,
+    );
+
+    expect(store.calls).toEqual(["deleteMany", "configUpsert"]);
+  });
+
+  it("ignores a client-supplied redirectStyle — the server owns the stamp", async () => {
+    // parseConfigBody already strips unknown keys at the route; this pins the
+    // service-level behavior regardless.
+    await upsertAppConfig(
+      { projectId: "p-1" },
+      "gmail",
+      { clientId: "cid", clientSecret: "sec", redirectStyle: "legacy" },
+      FIELDS,
+    );
+
+    expect(store.upsertArgs[0]!.create.settings.redirectStyle).toBe("unified");
+  });
+
+  it("leaves org rows unstamped — org flows keep the per-provider URI", async () => {
+    await upsertAppConfig(
+      { organizationId: "org-1" },
+      "gmail",
+      { clientId: "cid", clientSecret: "sec" },
+      FIELDS,
+    );
+
+    const args = store.upsertArgs[0]!;
+    expect(args.create.settings).toEqual({ clientId: "cid" });
+    expect(args.update.settings).toEqual({ clientId: "cid" });
   });
 });
 

--- a/packages/api/src/services/app-config-service.ts
+++ b/packages/api/src/services/app-config-service.ts
@@ -179,6 +179,17 @@ export const upsertAppConfig = async (
     }
   }
 
+  // A save through the project config form commits the user to the redirect
+  // URI that form displayed — the shared `/v1/apps/callback` (#301). Recording
+  // the style on the row, rather than switching flows globally, is what keeps
+  // configs saved before the unified path on the per-provider URI their OAuth
+  // app already has registered: `/authorize` only goes unified when the row
+  // says so. Save is the safe moment to flip — it disconnects the provider's
+  // connections (below), so every surviving flow starts fresh against the URI
+  // shown at save time. Org rows stay unstamped until the org config surfaces
+  // display the unified URI too.
+  if (!isOrgScope(scope)) plainFields.redirectStyle = "unified";
+
   let encryptedCredentials: string | undefined;
   if (Object.keys(secretFields).length > 0) {
     encryptedCredentials = await getCrypto().encrypt(


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Feature — a developer-experience improvement to the OAuth connection flow. Closes #301.

## What is the current behavior?

Every provider has its own OAuth callback (`/v1/apps/:provider/callback`), so connecting Google services against one OAuth app means registering a separate redirect URI in the Google console for each of `gmail`, `google-drive`, `google-calendar`, … (a dozen-plus), each addition subject to Google's propagation lag. Reported in #301, where consolidating to a single callback path via the `state` parameter was named as the direction to go — with rollout safety for existing users as the open question.

## What is the new behavior?

**One shared callback — `GET /v1/apps/callback` — usable by every OAuth provider.** The provider is recovered from the HMAC-signed `state` minted at the authenticated `/authorize` (the state already carried `provider`; the new route verifies the signature before trusting it). Both callback routes share one handler, so the token exchange always repeats the exact redirect URI its authorization request used.

**Rollout is opt-in per config row, so existing users keep working.** The invariant: *a config uses the unified URI if and only if it was saved through a surface that displayed the unified URI.*

- Saving a **project app config** through the dashboard stamps `redirectStyle: "unified"` into the row's `settings`. The config form now displays the unified URI — and saving a config already disconnects the provider's connections (refresh tokens are bound to the OAuth client), so no live flow straddles the switch.
- **Unstamped rows** (saved before this change), **env-default credentials**, and **org-scoped configs** keep sending the per-provider URI their OAuth app already has registered. The per-provider callback route is untouched.
- `parseConfigBody` strips unknown keys, so a client cannot inject or downgrade the stamp; the server owns it.

**Fail-flat on bad state:** the unified route returns a plain 400 when the state is missing, unverifiable, or names an unknown provider — without a verified provider there is no per-provider error page to redirect to, and nothing an attacker-forged state can steer (it already failed the HMAC).

Fragment-callback providers (Trello-shaped) work through the unified path too: their redirects carry no query params, and the `oauth_state` cookie — scoped at `/authorize` to the exact callback path in use — supplies the state, same as on the per-provider route.

### Changes

- `packages/api/src/routes/apps.ts` — unified `GET /apps/callback` route (registered before `GET /:provider`); `/authorize` picks the redirect URI and state-cookie path from the resolved config's redirect style; callback handler extracted and shared by both routes.
- `packages/api/src/services/app-config-service.ts` — `upsertAppConfig` stamps `redirectStyle: "unified"` on project-scope saves (org scope deliberately unstamped until the org surfaces display the unified URI).
- `packages/api/src/apps/resolve-credentials.ts` — surfaces the stamp as `ResolvedAppCredentials.redirectStyle`.
- `apps/web/.../connections/_components/redirect-uri.tsx` (+ two call sites) — project config forms display the unified URI; org-scoped forms keep the per-provider URI.

### Tests

- `apps-unified-callback.test.ts` (8 tests): `/authorize` sends the unified URI + cookie path only for stamped configs and keeps the per-provider URI otherwise; the unified callback completes the flow and hands the exchange the unified redirect URI; the fragment bridge resolves from the state cookie alone; 400 on missing/forged/unknown-provider state; the legacy per-provider callback is pinned unchanged.
- `app-config-service.test.ts` (+4 tests): stamp applied on create and update, disconnect-before-upsert ordering, client-supplied `redirectStyle` ignored, org rows unstamped.
- Full `packages/api` suite: 786 passed, 0 failed. `turbo run lint check-types` green for api/web/db/ui; prettier clean.

## Additional context

- Env-default (platform) credentials intentionally stay on per-provider URIs — there is no config row to record which URI the user registered. If wanted, an explicit env opt-in (e.g. `OAUTH_UNIFIED_REDIRECT=1`) could follow as a small separate PR.
- Docs that walk through Google OAuth app setup may want a note that new configs need only the single URI — happy to add if you point me at the right page.
