### PR TITLE
fix container-config auth mode for 1Password-sourced Anthropic secrets

### DIFF
--- a/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/connections/_components/secret-dialog.tsx
@@ -223,6 +223,12 @@ export const SecretDialog = ({
 
   const [type, setType] = useState<SecretType>("anthropic");
   const [openaiMode, setOpenaiMode] = useState<"api-key" | "codex">("api-key");
+  // 1Password never hands the server the resolved value, so an anthropic
+  // secret sourced from it can't have its auth mode detected the way an
+  // inline value's can (see AnthropicKeyBadge) — the user has to say which.
+  const [opAnthropicAuthMode, setOpAnthropicAuthMode] = useState<
+    "api-key" | "oauth"
+  >("api-key");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState("");
   const [nameTouched, setNameTouched] = useState(false);
@@ -277,6 +283,7 @@ export const SecretDialog = ({
       setNameTouched(false);
       setAdvancedOpen("");
       setOpenaiMode("api-key");
+      setOpAnthropicAuthMode("api-key");
       setOpSelection(null);
       setPickerOpen(false);
       // Path-injection fields reset here; only the edit branches below repopulate
@@ -296,6 +303,11 @@ export const SecretDialog = ({
             opRef: secret.opRef,
             opDisplay: readOpDisplay(secret.metadata, secret.opRef),
           });
+          if (
+            secret.type === "anthropic" &&
+            secret.metadata?.authMode === "oauth"
+          )
+            setOpAnthropicAuthMode("oauth");
         }
         setName(secret.name);
         setValue("");
@@ -449,6 +461,9 @@ export const SecretDialog = ({
                 valueSource: "onepassword" as const,
                 opRef: opSelection.opRef,
                 opDisplay: opSelection.opDisplay,
+                ...(type === "anthropic" && {
+                  authMode: opAnthropicAuthMode,
+                }),
               }
             : value.trim()
               ? { valueSource: "inline" as const, value: value.trim() }
@@ -467,6 +482,9 @@ export const SecretDialog = ({
                 valueSource: "onepassword",
                 opRef: opSelection.opRef,
                 opDisplay: opSelection.opDisplay,
+                ...(type === "anthropic" && {
+                  authMode: opAnthropicAuthMode,
+                }),
                 hostPattern,
                 pathPattern: pathPattern || undefined,
                 injectionConfig: buildInjectionConfig() ?? null,
@@ -777,11 +795,43 @@ export const SecretDialog = ({
                 />
 
                 {opSelection ? (
-                  <OnePasswordSelectedField
-                    display={opSelection.opDisplay}
-                    onChange={() => setPickerOpen(true)}
-                    onClear={() => setOpSelection(null)}
-                  />
+                  <>
+                    <OnePasswordSelectedField
+                      display={opSelection.opDisplay}
+                      onChange={() => setPickerOpen(true)}
+                      onClear={() => setOpSelection(null)}
+                    />
+                    {type === "anthropic" && (
+                      <div
+                        className="mt-2 flex w-full items-center gap-1 rounded-lg border p-1"
+                        role="radiogroup"
+                        aria-label="Anthropic auth method"
+                      >
+                        {(
+                          [
+                            ["api-key", "API Key"],
+                            ["oauth", "OAuth Token"],
+                          ] as const
+                        ).map(([mode, label]) => (
+                          <button
+                            key={mode}
+                            type="button"
+                            role="radio"
+                            aria-checked={opAnthropicAuthMode === mode}
+                            className={cn(
+                              "flex-1 rounded-md px-3 py-1 text-sm font-medium transition-colors",
+                              opAnthropicAuthMode === mode
+                                ? "bg-brand/10 text-brand"
+                                : "text-muted-foreground hover:bg-brand/5 hover:text-brand/80",
+                            )}
+                            onClick={() => setOpAnthropicAuthMode(mode)}
+                          >
+                            {label}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </>
                 ) : isOAuthMode ? (
                   <>
                     {value ? (

--- a/packages/api/src/services/secret-service.test.ts
+++ b/packages/api/src/services/secret-service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+// buildOnePasswordMetadata doesn't touch the DB; stub it so importing the
+// module doesn't pull in a real Prisma client.
+vi.mock("@onecli/db", () => ({ db: {}, Prisma: { JsonNull: Symbol("null") } }));
+
+import { buildOnePasswordMetadata } from "./secret-service";
+
+// Regression for onecli/onecli#387: a 1Password-sourced anthropic secret has
+// no value the server can inspect, so `authMode` used to be hardcoded to
+// "api-key" no matter what was actually stored — container-config then always
+// emitted ANTHROPIC_API_KEY, so OAuth injection silently never fired.
+describe("buildOnePasswordMetadata", () => {
+  it("uses the caller-supplied authMode for an anthropic secret", () => {
+    expect(buildOnePasswordMetadata("anthropic", undefined, "oauth")).toEqual({
+      authMode: "oauth",
+    });
+  });
+
+  it("defaults an anthropic secret to api-key when authMode is omitted", () => {
+    expect(buildOnePasswordMetadata("anthropic", undefined, undefined)).toEqual(
+      { authMode: "api-key" },
+    );
+  });
+
+  it("still hardcodes api-key for openai (no 1Password OAuth path)", () => {
+    expect(buildOnePasswordMetadata("openai", undefined, "oauth")).toEqual({
+      authMode: "api-key",
+    });
+  });
+
+  it("carries opDisplay through alongside authMode", () => {
+    const opDisplay = { vault: "V", item: "I", field: "F" };
+    expect(buildOnePasswordMetadata("anthropic", opDisplay, "oauth")).toEqual({
+      authMode: "oauth",
+      opDisplay,
+    });
+  });
+});

--- a/packages/api/src/services/secret-service.ts
+++ b/packages/api/src/services/secret-service.ts
@@ -114,13 +114,18 @@ const buildMetadata = (
   return Prisma.JsonNull;
 };
 
-const buildOnePasswordMetadata = (
+export const buildOnePasswordMetadata = (
   type: string,
   opDisplay: CreateSecretInput["opDisplay"],
+  authMode: CreateSecretInput["authMode"],
 ): Prisma.InputJsonValue | typeof Prisma.JsonNull => {
   const meta: Record<string, unknown> = {};
-  // LLM keys resolved from 1Password are always API-key mode (no value to inspect, no OAuth).
-  if (type === "anthropic" || type === "openai") meta.authMode = "api-key";
+  // The server never sees a 1Password-resolved value, so unlike an inline
+  // value's auth mode can't be detected from it — the caller says which it
+  // is. OpenAI has no such choice: a 1Password value there is always a raw
+  // API key (OAuth is a JSON blob uploaded directly, never 1Password-sourced).
+  if (type === "anthropic") meta.authMode = authMode ?? "api-key";
+  else if (type === "openai") meta.authMode = "api-key";
   if (opDisplay) meta.opDisplay = opDisplay;
   return Object.keys(meta).length > 0
     ? (meta as Prisma.InputJsonValue)
@@ -223,7 +228,11 @@ export const createSecret = async (
         hostPattern,
         pathPattern,
         injectionConfig,
-        metadata: buildOnePasswordMetadata(input.type, input.opDisplay),
+        metadata: buildOnePasswordMetadata(
+          input.type,
+          input.opDisplay,
+          input.authMode,
+        ),
         ...scopeCreate(scope),
       },
       select: {
@@ -324,7 +333,11 @@ export const updateSecret = async (
     data.opRef = input.opRef;
     if (secret.type === "anthropic") data.hostPattern = "api.anthropic.com";
     if (secret.type === "openai") data.hostPattern = "api.openai.com";
-    data.metadata = buildOnePasswordMetadata(secret.type, input.opDisplay);
+    data.metadata = buildOnePasswordMetadata(
+      secret.type,
+      input.opDisplay,
+      input.authMode,
+    );
   } else if (input.value !== undefined) {
     let value = input.value.trim();
     if (!value)

--- a/packages/api/src/validations/secret.test.ts
+++ b/packages/api/src/validations/secret.test.ts
@@ -108,6 +108,32 @@ describe("path injection config validation", () => {
   });
 });
 
+describe("createSecretSchema authMode (onecli/onecli#387)", () => {
+  const base = {
+    name: "Anthropic OAuth",
+    type: "anthropic" as const,
+    valueSource: "onepassword" as const,
+    opRef: "op://vault/item/field",
+    hostPattern: "api.anthropic.com",
+  };
+
+  it("accepts an explicit oauth authMode for a 1Password-sourced secret", () => {
+    const result = createSecretSchema.safeParse({ ...base, authMode: "oauth" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.authMode).toBe("oauth");
+  });
+
+  it("allows omitting authMode", () => {
+    expect(createSecretSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("rejects an authMode outside api-key/oauth", () => {
+    expect(
+      createSecretSchema.safeParse({ ...base, authMode: "bogus" }).success,
+    ).toBe(false);
+  });
+});
+
 describe("injection config type guards", () => {
   it("classifies path template and regex configs", () => {
     expect(isPathTemplateInjection({ pathTemplate: "/bot{value}" })).toBe(true);

--- a/packages/api/src/validations/secret.ts
+++ b/packages/api/src/validations/secret.ts
@@ -198,6 +198,13 @@ const opDisplaySchema = z
   .object({ vault: z.string(), item: z.string(), field: z.string() })
   .optional();
 
+// Moved above the schemas that reference it: a 1Password-sourced Anthropic
+// secret's value is never seen by the server, so the auth mode can't be
+// detected from it the way an inline value's can — the caller has to say
+// which it is.
+export const anthropicAuthModes = ["api-key", "oauth"] as const;
+export type AnthropicAuthMode = (typeof anthropicAuthModes)[number];
+
 export const createSecretSchema = z
   .object({
     name: z.string().trim().min(1).max(255),
@@ -206,6 +213,8 @@ export const createSecretSchema = z
     value: z.string().max(10000).optional(),
     opRef: opRefSchema.optional(),
     opDisplay: opDisplaySchema,
+    // Only meaningful for a 1Password-sourced anthropic secret; see comment above.
+    authMode: z.enum(anthropicAuthModes).optional(),
     hostPattern: hostPatternSchema,
     pathPattern: z.string().max(1000).optional(),
     injectionConfig: injectionConfigSchema,
@@ -237,6 +246,7 @@ export const updateSecretSchema = z
     value: z.string().max(10000).optional(),
     opRef: opRefSchema.optional(),
     opDisplay: opDisplaySchema,
+    authMode: z.enum(anthropicAuthModes).optional(),
     hostPattern: hostPatternSchema.optional(),
     pathPattern: z.string().max(1000).nullable().optional(),
     injectionConfig: injectionConfigSchema,
@@ -267,9 +277,6 @@ export const updateSecretSchema = z
 export type UpdateSecretInput = z.infer<typeof updateSecretSchema>;
 
 export const ANTHROPIC_KEY_MIN_LENGTH = 40;
-
-export const anthropicAuthModes = ["api-key", "oauth"] as const;
-export type AnthropicAuthMode = (typeof anthropicAuthModes)[number];
 
 export interface AnthropicSecretMetadata {
   authMode: AnthropicAuthMode;


### PR DESCRIPTION
fixes #387

## changes
- `buildOnePasswordMetadata` (secret-service.ts) hardcoded `authMode: "api-key"` for every 1Password-sourced anthropic secret — the server never resolves the 1Password value, so it can't detect the mode from it the way it does for an inline value. `container-config` reads that stored `authMode` and always emitted `ANTHROPIC_API_KEY`, so OAuth token injection silently never fired for 1Password-sourced Anthropic OAuth tokens.
- add an optional `authMode` field to `createSecretSchema`/`updateSecretSchema`, threaded through `buildOnePasswordMetadata` so the caller can say which mode a 1Password-sourced anthropic secret is
- add an API Key / OAuth Token toggle in the secret dialog, shown once a 1Password field is picked for an anthropic secret, mirroring the existing OpenAI API Key/Codex toggle
- OpenAI is left untouched: a 1Password-sourced OpenAI value is still always treated as a raw API key (Codex OAuth is only ever a directly-uploaded auth.json)

## verification
- `pnpm --filter @onecli/api exec vitest run` (all passing; pre-existing `.prisma/client` failure resolved after `pnpm db:generate`, unrelated to this change)
- `pnpm --filter @onecli/api exec tsc --noEmit -p .`
- `pnpm --filter web exec tsc --noEmit -p .`
- `pnpm --filter web exec eslint "src/app/(dashboard)/connections/_components/secret-dialog.tsx"`
- `git diff --check`
- `pnpm check` (full monorepo lint/check-types/format, ran via pre-push hook)