### PR TITLE
fix(gateway): require API key auth even in AUTH_MODE=local

### DIFF
--- a/apps/gateway/src/auth.rs
+++ b/apps/gateway/src/auth.rs
@@ -1,7 +1,9 @@
 //! Gateway authentication for browser requests.
 //!
 //! Supports two modes controlled by the `AUTH_MODE` env var:
-//! - `local`: bypasses JWT validation, looks up the "local-admin" user directly.
+//! - `local`: no session mechanism at all (single-user dev, no login) — the
+//!   only accepted credential is an `Authorization: Bearer oc_...` API key,
+//!   checked by `validate_api_key` before mode-specific logic even runs.
 //! - `oauth` (default): validates a NextAuth session cookie JWT (HS256).
 
 use std::sync::OnceLock;
@@ -142,26 +144,17 @@ async fn validate_api_key(pool: &PgPool, headers: &HeaderMap) -> Option<AuthUser
 /// The caller resolves the project ID from the user's membership.
 async fn validate_request(pool: &PgPool, headers: &HeaderMap) -> Result<String, AuthError> {
     match auth_mode() {
-        "local" => validate_local(pool).await,
+        // Local mode has no cookie/session mechanism to fall back to (no
+        // login flow exists). A request reaching here already failed the API
+        // key check above, so it is unauthenticated — reject it rather than
+        // auto-trusting it as local-admin. This is the only credential path
+        // in local mode, so it must hold even when the gateway is bound to
+        // loopback: anything else on the same host could otherwise reach it.
+        "local" => Err(AuthError(
+            "missing API key (Authorization: Bearer oc_...)".to_string(),
+        )),
         _ => validate_oauth(pool, headers).await,
     }
-}
-
-// ── Local mode ───────────────────────────────────────────────────────────
-
-async fn validate_local(pool: &PgPool) -> Result<String, AuthError> {
-    let user = db::find_user_by_external_auth_id(pool, "local-admin")
-        .await
-        .map_err(|e| {
-            warn!(error = %e, "local auth: db error");
-            AuthError("internal error".to_string())
-        })?
-        .ok_or_else(|| {
-            warn!("local auth: local-admin user not found");
-            AuthError("user not found".to_string())
-        })?;
-
-    Ok(user.id)
 }
 
 // ── OAuth mode ───────────────────────────────────────────────────────────
@@ -258,5 +251,22 @@ mod tests {
     #[test]
     fn parse_cookie_empty() {
         assert_eq!(parse_cookie("", "authjs.session-token"), None);
+    }
+
+    /// Regression test for the loopback auth bypass (local gateway API did
+    /// not enforce ONECLI_API_KEY when bound to TCP loopback): a bare
+    /// request with no `Authorization` header must be rejected in `local`
+    /// mode instead of silently authenticating as local-admin.
+    #[tokio::test]
+    async fn validate_request_local_mode_rejects_bare_request() {
+        std::env::set_var("AUTH_MODE", "local");
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://localhost/nonexistent")
+            .expect("lazy pool never fails to construct");
+        let headers = HeaderMap::new();
+
+        let result = validate_request(&pool, &headers).await;
+
+        assert!(result.is_err());
     }
 }

--- a/apps/web/src/lib/api/approvals.ts
+++ b/apps/web/src/lib/api/approvals.ts
@@ -1,8 +1,8 @@
 // Pending-approval value picker — list and resolve held requests through the
 // gateway. Like the 1Password client, these hit the gateway directly (different
 // base URL + auth) rather than the typed JSON API, so they use
-// getGatewayApiUrl() + getGatewayFetchOptions() (edition-aware: Cognito Bearer +
-// X-Project-Id in cloud, cookie credentials in OSS).
+// getGatewayApiUrl() + getGatewayFetchOptions(), which authenticates as the
+// acting user via their own API key (see gateway-auth.ts).
 import { getGatewayApiUrl } from "@/hooks/use-vault-status";
 import { getGatewayFetchOptions } from "@/lib/gateway-auth";
 

--- a/apps/web/src/lib/api/cache.ts
+++ b/apps/web/src/lib/api/cache.ts
@@ -5,11 +5,10 @@
 //
 // Like the approvals and 1Password value pickers, this hits the gateway
 // directly (different base URL + auth than the typed JSON API), so it uses
-// getGatewayApiUrl() + getGatewayFetchOptions() — the edition-aware seam that
-// authenticates as the ACTING USER: the Cognito ID token + X-Project-Id in
-// cloud, session-cookie credentials in OSS. The gateway scopes the flush to
-// that authenticated principal's project (its AuthUser extractor), so there is
-// no need to look up — or borrow — an API key from the database.
+// getGatewayApiUrl() + getGatewayFetchOptions() — the seam that authenticates
+// as the ACTING USER via their own API key (see gateway-auth.ts). The gateway
+// scopes the flush to that authenticated principal's project (its AuthUser
+// extractor).
 import { getGatewayApiUrl } from "@/hooks/use-vault-status";
 import { getGatewayFetchOptions } from "@/lib/gateway-auth";
 

--- a/apps/web/src/lib/gateway-auth.ts
+++ b/apps/web/src/lib/gateway-auth.ts
@@ -1,10 +1,25 @@
 import type { GatewayFetchOptions } from "@/lib/gateway-auth-types";
+import { getApiKey } from "@/lib/actions/api-key";
 
 export type { GatewayFetchOptions };
 
-/** Auth options for browser → gateway HTTP API calls. */
+/**
+ * Auth options for browser → gateway HTTP API calls.
+ *
+ * The gateway's `AuthUser` extractor (`apps/gateway/src/auth.rs`) tries
+ * `Authorization: Bearer oc_...` first, before any session/cookie check. In
+ * `local` mode (single-user dev, no login) that API key is the *only*
+ * credential the gateway accepts — there is no session to fall back to — so
+ * we always fetch/provision the caller's key here via the same
+ * `ensureApiKey`-backed action the API Keys settings page uses, and attach
+ * it. This is a no-op in `oauth` mode too: sending a valid key alongside the
+ * session cookie just gives the gateway a stronger credential to check first.
+ */
 export const getGatewayFetchOptions =
-  async (): Promise<GatewayFetchOptions> => ({
-    headers: {},
-    credentials: "include",
-  });
+  async (): Promise<GatewayFetchOptions> => {
+    const { apiKey } = await getApiKey();
+    return {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      credentials: "include",
+    };
+  };


### PR DESCRIPTION
fixes #263

## changes

This is a two-sided fix — a gateway-side hole, and a web-side dependency on that hole that had to be closed first.

**Gateway (`apps/gateway/src/auth.rs`)**: `AuthUser::from_request_parts` tries `validate_api_key` (checks `Authorization: Bearer oc_...` against the DB) and only falls back to `validate_request` → `validate_local` when no such key is presented. `validate_local` then unconditionally authenticated the caller as `local-admin` — full owner — with **no credential of any kind**. Every gateway route (vault pair/status, cache invalidate, pending approvals, approval decisions) goes through this same extractor, so in `AUTH_MODE=local` (the shipped single-user-dev default) any bare request reaching the gateway's loopback port was authenticated as the admin. `validate_local` is removed; local mode now rejects a request that already failed the API-key check rather than auto-trusting it — that's the only credential path in local mode (there's no login/session mechanism to fall back to).

**Web (`apps/web/src/lib/gateway-auth.ts`)**: the web app's own gateway calls relied on exactly this bypass — `getGatewayFetchOptions` sent `headers: {}`. Closing the gateway hole without fixing this would have broken vault pairing, cache invalidation, and approvals for every user. `getGatewayFetchOptions` now fetches/provisions the caller's real API key via the existing `ensureApiKey`-backed server action (the same one the API Keys settings page uses) and attaches it as `Authorization: Bearer oc_...`. This works unchanged under `oauth` mode too — sending a valid key alongside the session cookie just gives the gateway a stronger credential to check first.

**Trust model, before → after:**
- Before: `AUTH_MODE=local` + no `Authorization` header → authenticated as `local-admin` (full owner), unconditionally.
- After: `AUTH_MODE=local` + no valid `Authorization: Bearer oc_...` → `401 Unauthorized`. The web app now always sends a valid key. A human hitting the gateway directly (curl, no web UI) gets their key from the existing API Keys settings page (`ensureApiKey`) — no functionality removed, just no longer free for the taking.

Updated two stale comments in `apps/web/src/lib/api/{cache,approvals}.ts` that described the old "edition-aware, no need to borrow an API key" design, which no longer matches.

## verification
- `cargo fmt --manifest-path apps/gateway/Cargo.toml --check`
- `cargo test --manifest-path apps/gateway/Cargo.toml auth::` — 4 passed, including new regression test `validate_request_local_mode_rejects_bare_request` (bare request in local mode → `Err`)
- `pnpm --filter web check-types`
- `pnpm --filter web lint`
- `git diff --check`
- `pnpm check` (full monorepo lint + check-types + format:check, also ran again via the pre-commit hook on commit)