### PR TITLE
fix(gateway): accept the __Secure- prefixed NextAuth session cookie

### DIFF
--- a/apps/gateway/src/auth.rs
+++ b/apps/gateway/src/auth.rs
@@ -176,7 +176,7 @@ async fn validate_oauth(pool: &PgPool, headers: &HeaderMap) -> Result<String, Au
             AuthError("missing cookie".to_string())
         })?;
 
-    let token = parse_cookie(cookie_header, "authjs.session-token").ok_or_else(|| {
+    let token = session_token_from_cookies(cookie_header).ok_or_else(|| {
         warn!("oauth auth: session token cookie not found");
         AuthError("missing session token".to_string())
     })?;
@@ -221,6 +221,24 @@ async fn validate_oauth(pool: &PgPool, headers: &HeaderMap) -> Result<String, Au
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
+/// The NextAuth session cookie, under either spelling Auth.js may have used.
+///
+/// Auth.js prefixes the cookie with `__Secure-` whenever it considers the
+/// deployment secure, which it decides from the scheme of the resolved
+/// `AUTH_URL` / `NEXTAUTH_URL`. Every instance reached over https therefore
+/// sends `__Secure-authjs.session-token`, and a self-hosted one cannot opt out:
+/// the OAuth spec (and Google's redirect-URI validation) requires an https
+/// callback for anything but localhost, so the single variable that makes login
+/// work also renames this cookie. Matching only the bare name meant session auth
+/// could never succeed on a TLS deployment.
+///
+/// Bare name first: it is what an http/localhost install sends, and checking it
+/// first keeps that path a single comparison.
+fn session_token_from_cookies(cookie_header: &str) -> Option<&str> {
+    parse_cookie(cookie_header, "authjs.session-token")
+        .or_else(|| parse_cookie(cookie_header, "__Secure-authjs.session-token"))
+}
+
 /// Parse a specific cookie value from a Cookie header string.
 fn parse_cookie<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
     cookie_header.split(';').find_map(|pair| {
@@ -258,5 +276,39 @@ mod tests {
     #[test]
     fn parse_cookie_empty() {
         assert_eq!(parse_cookie("", "authjs.session-token"), None);
+    }
+
+    #[test]
+    fn session_token_accepts_bare_name() {
+        let header = "other=abc; authjs.session-token=eyJhbGciOiJIUzI1NiJ9.test";
+        assert_eq!(
+            session_token_from_cookies(header),
+            Some("eyJhbGciOiJIUzI1NiJ9.test")
+        );
+    }
+
+    /// What a browser sends to an https deployment: Auth.js switches the session
+    /// cookie to the `__Secure-` prefix and the CSRF cookie to `__Host-`.
+    #[test]
+    fn session_token_accepts_secure_prefixed_name() {
+        let header = "__Host-authjs.csrf-token=abc; \
+                      __Secure-authjs.session-token=eyJhbGciOiJIUzI1NiJ9.test";
+        assert_eq!(
+            session_token_from_cookies(header),
+            Some("eyJhbGciOiJIUzI1NiJ9.test")
+        );
+    }
+
+    /// The bare name wins when both are somehow present, so an http install's
+    /// behaviour is unchanged.
+    #[test]
+    fn session_token_prefers_bare_name() {
+        let header = "__Secure-authjs.session-token=prefixed; authjs.session-token=bare";
+        assert_eq!(session_token_from_cookies(header), Some("bare"));
+    }
+
+    #[test]
+    fn session_token_missing() {
+        assert_eq!(session_token_from_cookies("other=abc; foo=bar"), None);
     }
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

On a self-hosted instance running multi-user mode (`NEXTAUTH_SECRET` set) **and served over HTTPS**, every browser call to the gateway returns `401`. That covers vault pair/status, pending approvals, approval decisions, and cache invalidation — so the 1Password and Bitwarden panels, the approvals UI, and the 1Password value picker are all unusable, while the rest of the dashboard works normally.

`validate_oauth` reads the session cookie by exact name:

```rust
let token = parse_cookie(cookie_header, "authjs.session-token")
```

Auth.js prefixes that cookie with `__Secure-` whenever it considers the deployment secure, which it derives from the scheme of the resolved `AUTH_URL` / `NEXTAUTH_URL`. A self-hosted instance cannot avoid this: OAuth providers require an `https` redirect URI for anything other than localhost (Google [documents the rule](https://developers.google.com/identity/protocols/oauth2/web-server#redirect-uri_validation) explicitly), so the single variable that makes login work also renames the cookie. The gateway then never finds it and logs `oauth auth: session token cookie not found`.

Local-mode installs are unaffected, because `validate_local` never inspects the cookie — which is likely why this has gone unnoticed.

### Controlled reproduction

Same request, same (fabricated) JWT, only the cookie **name** differs:

```
$ curl -H "Cookie: authjs.session-token=eyJhbGciOiJIUzI1NiJ9.fake.sig"          .../me
$ curl -H "Cookie: __Secure-authjs.session-token=eyJhbGciOiJIUzI1NiJ9.fake.sig" .../me
```

```
WARN onecli_gateway::auth: oauth auth: JWT decode failed error=InvalidSignature   # bare name: found, decoded
WARN onecli_gateway::auth: oauth auth: session token cookie not found             # prefixed name: never seen
```

And the same instance, over HTTPS, confirming which name a browser is actually sent:

```
$ curl -sD - https://<instance>/api/auth/csrf | grep -i set-cookie
set-cookie: __Host-authjs.csrf-token=...
set-cookie: __Secure-authjs.callback-url=...
```

## What is the new behavior?

The lookup accepts either spelling, via a small helper:

```rust
fn session_token_from_cookies(cookie_header: &str) -> Option<&str> {
    parse_cookie(cookie_header, "authjs.session-token")
        .or_else(|| parse_cookie(cookie_header, "__Secure-authjs.session-token"))
}
```

The bare name is checked first, so http/localhost installs keep their existing single-comparison path and behaviour is unchanged for them. Four unit tests cover the bare name, the `__Secure-` prefixed name, precedence when both are present, and neither present.

## Additional context

Found while running a self-hosted instance behind a reverse proxy with TLS and an external IdP. It is reachable from any edition that can run in `oauth` mode over HTTPS, and it becomes considerably easier to hit alongside #430, which lets self-hosters use a non-Google IdP and so brings more TLS deployments into multi-user mode.

#474 would also resolve this, by having the web app attach an API key so the gateway never falls through to the cookie. The two are complementary rather than competing: this change makes the documented session path work as intended and is a few lines, while #474 additionally closes the local-mode trust gap in #263. Happy to close this if #474 is the preferred direction.

## Verification

Run against `apps/gateway` (musl toolchain, matching `docker/Dockerfile`):

- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — no new warnings
- `cargo test auth::` — 7 passed (3 pre-existing, 4 new), 0 failed

Also verified on a live deployment: with the fix in place, a browser request carrying `__Secure-authjs.session-token` reaches JWT validation instead of being rejected as missing.

**It does not, on its own, make session auth work** — see the correction in the comments. Auth.js issues an *encrypted* (JWE) session token, while `validate_oauth` decodes with `jsonwebtoken` under `Algorithm::HS256`, which expects a signed JWS, so validation fails one step later with `Base64 error: Invalid symbol 46`. That is a second, independent problem on the same path and out of scope here. This PR fixes the cookie lookup only, which is a prerequisite either way.

No TypeScript is touched, so `pnpm check` / `pnpm build` are unaffected by this change.
