### PR TITLE
feat(api): read-only activity API for agents and automations

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -57,6 +57,7 @@ import { vaultRoutes } from "./routes/vaults";
 import { gatewayUrlRoutes, gatewayCaRoutes } from "./routes/gateway";
 import { containerConfigRoutes } from "./routes/container-config";
 import { countsRoutes } from "./routes/counts";
+import { activityRoutes } from "./routes/activity";
 import { skillRoutes } from "./routes/skill";
 import { credentialStubRoutes } from "./routes/credential-stubs";
 import { migrateRoutes } from "./routes/migrate";
@@ -157,6 +158,7 @@ export const createApiApp = (
   app.route("/gateway", gatewayCaRoutes());
   app.route("/container-config", containerConfigRoutes());
   app.route("/counts", countsRoutes());
+  app.route("/activity", activityRoutes());
   app.route("/skill", skillRoutes());
   app.route("/credential-stubs", credentialStubRoutes());
   app.route("/migrate", migrateRoutes());

--- a/packages/api/src/routes/activity.test.ts
+++ b/packages/api/src/routes/activity.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Hono } from "hono";
+import type { ApiEnv } from "../types";
+
+/**
+ * Route-level tests for the agent-facing activity API (#411).
+ *
+ * Two things this surface must get right, both asserted here:
+ *
+ * 1. **It is the dashboard's data, not a way around it** — every read is
+ *    project-scoped and carries the caller as the `viewer`, so the org-rule
+ *    redaction the Activity page applies also applies here. The service owns
+ *    that logic; these tests pin that the route actually hands it the viewer.
+ * 2. **Bad input fails loudly** — an automation polling for "did my call land?"
+ *    must never read a silently-ignored filter as "no such event".
+ */
+
+const PROJECT_KEY = "oc_activity_test_key";
+
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_EDITION = "onprem-slim";
+  process.env.SECRET_ENCRYPTION_KEY = "test-secret";
+});
+
+vi.mock("@onecli/db", () => ({
+  Prisma: {},
+  db: {
+    apiKey: {
+      findUnique: async ({ where }: { where: { key: string } }) =>
+        where.key === PROJECT_KEY
+          ? { userId: "user-1", projectId: "proj-1" }
+          : null,
+    },
+    project: {
+      findUnique: async () => ({ id: "proj-1", organizationId: "org-1" }),
+    },
+    user: { findUnique: async () => ({ email: "dev@example.com" }) },
+  },
+}));
+
+// Capture what the route asks the service for — the assertions below are about
+// the arguments (scope, viewer, parsed filters), not about Prisma.
+const calls = vi.hoisted(() => ({
+  list: [] as unknown[][],
+  byId: [] as unknown[][],
+}));
+
+vi.mock("../services/request-log-service", () => ({
+  getRequestLogs: vi.fn(async (...args: unknown[]) => {
+    calls.list.push(args);
+    return { logs: [], nextCursor: null };
+  }),
+  getRequestLogById: vi.fn(async (...args: unknown[]) => {
+    calls.byId.push(args);
+    const [, id] = args as [string, string];
+    return id === "known" ? { id: "known", host: "api.github.com" } : null;
+  }),
+}));
+
+import { createApiApp } from "../app";
+
+const app: Hono<ApiEnv> = createApiApp({ getSession: async () => null });
+const headers = { authorization: `Bearer ${PROJECT_KEY}` };
+
+const get = (url: string) => app.request(url, { headers });
+
+beforeEach(() => {
+  calls.list.length = 0;
+  calls.byId.length = 0;
+});
+
+describe("GET /v1/activity", () => {
+  it("requires authentication", async () => {
+    const res = await app.request("/v1/activity");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns a page and scopes it to the caller's project", async () => {
+    const res = await get("/v1/activity");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ logs: [], nextCursor: null });
+    expect(calls.list[0]?.[0]).toBe("proj-1");
+  });
+
+  // The load-bearing one: without the viewer the service fails safe to
+  // redaction, but an admin would then never see org rules here — and a future
+  // refactor that passes a WRONG viewer would silently widen visibility.
+  it("passes the caller as the viewer so org-rule redaction applies", async () => {
+    await get("/v1/activity");
+
+    expect(calls.list[0]?.[2]).toEqual({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+  });
+
+  it("threads the automation filters through to the service", async () => {
+    await get(
+      "/v1/activity?agentId=agent-1&host=api.github.com&provider=github" +
+        "&method=post&status=403&since=2026-07-01T00:00:00Z" +
+        "&until=2026-07-02T00:00:00Z&filter=blocked&limit=10",
+    );
+
+    const params = calls.list[0]?.[1] as {
+      filter?: string;
+      limit?: number;
+      query?: Record<string, unknown>;
+    };
+
+    expect(params.filter).toBe("blocked");
+    expect(params.limit).toBe(10);
+    expect(params.query).toEqual({
+      agentId: "agent-1",
+      host: "api.github.com",
+      provider: "github",
+      method: "post",
+      status: 403,
+      since: new Date("2026-07-01T00:00:00Z"),
+      until: new Date("2026-07-02T00:00:00Z"),
+    });
+  });
+
+  it("forwards a complete keyset cursor", async () => {
+    await get(
+      "/v1/activity?cursorCreatedAt=2026-07-01T00:00:00Z&cursorId=log-9",
+    );
+
+    const params = calls.list[0]?.[1] as {
+      cursor?: { createdAt: string; id: string };
+    };
+    expect(params.cursor).toEqual({
+      createdAt: "2026-07-01T00:00:00Z",
+      id: "log-9",
+    });
+  });
+
+  // A half-cursor silently restarting at page one is how a paging automation
+  // loops forever on the first page instead of finishing.
+  it("rejects a half-supplied cursor rather than restarting at page one", async () => {
+    const res = await get("/v1/activity?cursorCreatedAt=2026-07-01T00:00:00Z");
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("cursorCreatedAt and cursorId");
+    expect(calls.list).toHaveLength(0);
+  });
+
+  it("rejects an unparseable timestamp instead of dropping the bound", async () => {
+    const res = await get("/v1/activity?since=last-tuesday");
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("since");
+    expect(calls.list).toHaveLength(0);
+  });
+
+  it("rejects an inverted time window", async () => {
+    const res = await get(
+      "/v1/activity?since=2026-07-02T00:00:00Z&until=2026-07-01T00:00:00Z",
+    );
+
+    expect(res.status).toBe(400);
+    expect(calls.list).toHaveLength(0);
+  });
+
+  it("rejects an out-of-range limit and an unknown filter", async () => {
+    expect((await get("/v1/activity?limit=5000")).status).toBe(400);
+    expect((await get("/v1/activity?limit=0")).status).toBe(400);
+    expect((await get("/v1/activity?filter=everything")).status).toBe(400);
+    expect(calls.list).toHaveLength(0);
+  });
+});
+
+describe("GET /v1/activity/:id", () => {
+  it("returns the event, scoped to the caller's project", async () => {
+    const res = await get("/v1/activity/known");
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).id).toBe("known");
+    expect(calls.byId[0]?.[0]).toBe("proj-1");
+    expect(calls.byId[0]?.[2]).toEqual({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+  });
+
+  it("404s for an unknown or foreign id", async () => {
+    const res = await get("/v1/activity/nope");
+    expect(res.status).toBe(404);
+  });
+
+  it("requires authentication", async () => {
+    expect((await app.request("/v1/activity/known")).status).toBe(401);
+  });
+});

--- a/packages/api/src/routes/activity.ts
+++ b/packages/api/src/routes/activity.ts
@@ -1,0 +1,132 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import type { ApiEnv } from "../types";
+import { authMiddleware, requireProjectId } from "../middleware/auth";
+import {
+  getRequestLogById,
+  getRequestLogs,
+  type ActivityQuery,
+} from "../services/request-log-service";
+
+/**
+ * A bounded page size. The service already clamps to 200; declaring it here
+ * turns an out-of-range `limit` into a 400 the caller can act on rather than a
+ * silently different page.
+ */
+const MAX_LIMIT = 200;
+
+/**
+ * `since`/`until` accept anything `Date` parses (ISO-8601 in practice).
+ * Rejected explicitly rather than coerced, because a silently-dropped bound
+ * would answer "no events since X" with events from all time — the failure
+ * mode most likely to be read as "OneCLI isn't logging".
+ */
+const dateParam = z
+  .string()
+  .refine((v) => !Number.isNaN(Date.parse(v)), "must be an ISO-8601 timestamp")
+  .transform((v) => new Date(v));
+
+const listQuerySchema = z.object({
+  agentId: z.string().min(1).optional(),
+  host: z.string().min(1).optional(),
+  provider: z.string().min(1).optional(),
+  method: z.string().min(1).optional(),
+  status: z.coerce.number().int().min(100).max(599).optional(),
+  since: dateParam.optional(),
+  until: dateParam.optional(),
+  filter: z.enum(["all", "hide-llm", "blocked"]).optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).optional(),
+  // Keyset cursor, echoed back from a previous page's `nextCursor`.
+  cursorCreatedAt: z.string().optional(),
+  cursorId: z.string().optional(),
+});
+
+export const activityRoutes = () => {
+  const app = new Hono<ApiEnv>();
+  app.use("*", authMiddleware);
+
+  /**
+   * GET /activity
+   *
+   * Read-only, project-scoped feed of gateway request activity — the API behind
+   * "did my agent's call actually go through OneCLI?" (#411). Same rows, same
+   * ordering, and the same org-rule redaction the dashboard's Activity page
+   * gets; this is a second surface over one service, never a way around it.
+   */
+  app.get("/", async (c) => {
+    const auth = c.get("auth");
+    const projectId = requireProjectId(auth);
+
+    const parsed = listQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      return c.json(
+        {
+          error: issue
+            ? `Invalid query parameter "${issue.path.join(".")}": ${issue.message}`
+            : "Invalid query parameters",
+        },
+        400,
+      );
+    }
+
+    const { filter, limit, cursorCreatedAt, cursorId, since, until, ...rest } =
+      parsed.data;
+
+    // Both halves or neither: a half-cursor would silently restart at page one
+    // and an automation paging through would loop forever on the first page.
+    if (!!cursorCreatedAt !== !!cursorId) {
+      return c.json(
+        {
+          error:
+            "cursorCreatedAt and cursorId must be provided together — pass back the `nextCursor` object from the previous page.",
+        },
+        400,
+      );
+    }
+
+    if (since && until && since >= until) {
+      return c.json({ error: "since must be earlier than until" }, 400);
+    }
+
+    const query: ActivityQuery = { ...rest, since, until };
+
+    const page = await getRequestLogs(
+      projectId,
+      {
+        ...(filter ? { filter } : {}),
+        ...(limit ? { limit } : {}),
+        ...(cursorCreatedAt && cursorId
+          ? { cursor: { createdAt: cursorCreatedAt, id: cursorId } }
+          : {}),
+        query,
+      },
+      { userId: auth.userId, organizationId: auth.organizationId },
+    );
+
+    return c.json(page);
+  });
+
+  /**
+   * GET /activity/:id
+   *
+   * One event. 404 covers both "no such id" and "not this project's id" — the
+   * service scopes the lookup, so the two are indistinguishable to the caller
+   * by design.
+   */
+  app.get("/:id", async (c) => {
+    const auth = c.get("auth");
+    const projectId = requireProjectId(auth);
+
+    const entry = await getRequestLogById(projectId, c.req.param("id"), {
+      userId: auth.userId,
+      organizationId: auth.organizationId,
+    });
+
+    if (!entry) return c.json({ error: "Activity event not found" }, 404);
+
+    return c.json(entry);
+  });
+
+  return app;
+};

--- a/packages/api/src/services/request-log-service.test.ts
+++ b/packages/api/src/services/request-log-service.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LLM_HOST_FRAGMENTS } from "../lib/llm-hosts";
 import { initRoleResolver } from "../providers";
-import { buildActivityWhere, getRequestLogs } from "./request-log-service";
+import {
+  buildActivityWhere,
+  getRequestLogById,
+  getRequestLogs,
+} from "./request-log-service";
 
 const dbState = vi.hoisted(() => ({
   logs: [] as unknown[],
@@ -11,7 +15,19 @@ const dbState = vi.hoisted(() => ({
 vi.mock("@onecli/db", () => ({
   Prisma: {},
   db: {
-    requestLog: { findMany: async () => dbState.logs },
+    requestLog: {
+      findMany: async () => dbState.logs,
+      // Honors BOTH halves of the where — the project scope is what makes a
+      // foreign id indistinguishable from a missing one.
+      findFirst: async ({
+        where,
+      }: {
+        where: { id: string; projectId: string };
+      }) =>
+        (dbState.logs as { id: string; projectId: string }[]).find(
+          (l) => l.id === where.id && l.projectId === where.projectId,
+        ) ?? null,
+    },
     agent: { findMany: async () => [] },
     user: { findMany: async () => [] },
   },
@@ -66,6 +82,75 @@ describe("buildActivityWhere", () => {
       { createdAt: { lt: new Date(cursor.createdAt) } },
       { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
     ]);
+  });
+});
+
+// ── ActivityQuery narrowing (the #411 automation filters) ────────────────
+
+describe("buildActivityWhere — ActivityQuery", () => {
+  it("adds nothing when the query is empty", () => {
+    expect(buildActivityWhere(PROJECT_ID, { query: {} })).toEqual({
+      projectId: PROJECT_ID,
+    });
+  });
+
+  it("matches agent exactly and host/provider case-insensitively", () => {
+    const where = buildActivityWhere(PROJECT_ID, {
+      query: { agentId: "agent-1", host: "GitHub.com", provider: "github" },
+    });
+
+    expect(where.AND).toEqual([
+      { agentId: "agent-1" },
+      { host: { contains: "GitHub.com", mode: "insensitive" } },
+      { provider: { contains: "github", mode: "insensitive" } },
+    ]);
+  });
+
+  it("upper-cases the method so ?method=get matches the stored verb", () => {
+    expect(
+      buildActivityWhere(PROJECT_ID, { query: { method: "get" } }).AND,
+    ).toEqual([{ method: "GET" }]);
+  });
+
+  it("bounds the window with gte/lt so `since` is inclusive and `until` is not", () => {
+    const since = new Date("2026-07-01T00:00:00.000Z");
+    const until = new Date("2026-07-02T00:00:00.000Z");
+
+    expect(
+      buildActivityWhere(PROJECT_ID, { query: { since, until } }).AND,
+    ).toEqual([{ createdAt: { gte: since } }, { createdAt: { lt: until } }]);
+  });
+
+  it("keeps status 0 and 200 distinct from `undefined` (no silent drop)", () => {
+    expect(
+      buildActivityWhere(PROJECT_ID, { query: { status: 200 } }).AND,
+    ).toEqual([{ status: 200 }]);
+    expect(buildActivityWhere(PROJECT_ID, { query: {} }).AND).toBeUndefined();
+  });
+
+  // The reason query conditions are ANDed rather than assigned onto the root:
+  // `filter: "blocked"` owns `status` and the cursor owns `OR`. A root
+  // assignment would drop one of them — here it would turn a contradictory
+  // "blocked AND status=200" into "every 200", the opposite of what was asked.
+  it("preserves the blocked filter's own status clause alongside a status query", () => {
+    const where = buildActivityWhere(PROJECT_ID, {
+      filter: "blocked",
+      query: { status: 200 },
+    });
+
+    expect(where.status).toEqual({ gte: 400 });
+    expect(where.AND).toEqual([{ status: 200 }]);
+  });
+
+  it("preserves the cursor's OR alongside query conditions", () => {
+    const cursor = { createdAt: "2026-06-26T12:00:00.000Z", id: "log_42" };
+    const where = buildActivityWhere(PROJECT_ID, {
+      cursor,
+      query: { agentId: "agent-1" },
+    });
+
+    expect(where.OR).toHaveLength(2);
+    expect(where.AND).toEqual([{ agentId: "agent-1" }]);
   });
 });
 
@@ -215,5 +300,68 @@ describe("getRequestLogs — org matched-rule redaction", () => {
       },
     );
     expect(JSON.stringify(nullRole)).not.toContain(ORG_BAIT);
+  });
+});
+
+// ── getRequestLogById (the #411 single-event read) ───────────────────────
+
+describe("getRequestLogById", () => {
+  beforeEach(() => {
+    dbState.logs = [orgDecidedRow(), projectDecidedRow()];
+  });
+
+  it("returns the event when it belongs to the project", async () => {
+    initRoleResolver({ getUserRole: async () => "admin" });
+
+    const entry = await getRequestLogById(PROJECT_ID, "log-2", {
+      userId: "u1",
+      organizationId: "org-1",
+    });
+
+    expect(entry?.id).toBe("log-2");
+    expect(entry?.host).toBe("gmail.googleapis.com");
+  });
+
+  it("returns null for another project's id — never leaks across the fence", async () => {
+    initRoleResolver({ getUserRole: async () => "admin" });
+
+    // The row exists; it just isn't this project's. Indistinguishable from
+    // "no such id", which is what stops id probing.
+    const entry = await getRequestLogById("someone-elses-project", "log-2", {
+      userId: "u1",
+      organizationId: "org-1",
+    });
+
+    expect(entry).toBeNull();
+  });
+
+  it("returns null for an unknown id", async () => {
+    expect(await getRequestLogById(PROJECT_ID, "nope")).toBeNull();
+  });
+
+  // The reason this goes through the shared redaction rather than returning
+  // the row: a single-row read must not become the way to see what the feed
+  // hides from a non-admin.
+  it("applies the SAME org-rule redaction as the feed", async () => {
+    initRoleResolver({ getUserRole: async () => "member" });
+
+    const entry = await getRequestLogById(PROJECT_ID, "log-1", {
+      userId: "u1",
+      organizationId: "org-1",
+    });
+
+    expect(JSON.stringify(entry)).not.toContain(ORG_BAIT);
+    expect(entry?.matchedRuleLogicalId).toBeNull();
+    expect(
+      (entry?.extraData as Record<string, unknown>).matched_rule_scope,
+    ).toBe("organization");
+  });
+
+  it("fails SAFE to redaction when there is no viewer", async () => {
+    initRoleResolver({ getUserRole: async () => "admin" });
+
+    const entry = await getRequestLogById(PROJECT_ID, "log-1");
+
+    expect(JSON.stringify(entry)).not.toContain(ORG_BAIT);
   });
 });

--- a/packages/api/src/services/request-log-service.ts
+++ b/packages/api/src/services/request-log-service.ts
@@ -185,10 +185,34 @@ export interface RequestLogPage {
 
 export type ActivityFilter = "all" | "hide-llm" | "blocked";
 
+/**
+ * Field-level narrowing on top of {@link ActivityFilter} — what an automation
+ * asks for when it wants "did MY call land?" rather than a browsable feed
+ * (#411): the agent, the upstream it went to, and when.
+ *
+ * ANDed with the filter and the project scope, never instead of them. `host`
+ * and `provider` are contains-matches (case-insensitive) so a caller can pass
+ * `api.github.com` or just `github`; the rest are exact/range.
+ */
+export interface ActivityQuery {
+  agentId?: string;
+  /** Case-insensitive substring of the upstream host. */
+  host?: string;
+  /** Case-insensitive substring of the resolved provider id. */
+  provider?: string;
+  method?: string;
+  status?: number;
+  /** Inclusive lower bound on `createdAt`. */
+  since?: Date;
+  /** Exclusive upper bound on `createdAt`. */
+  until?: Date;
+}
+
 export interface ActivityPageParams {
   cursor?: { createdAt: string; id: string };
   limit?: number;
   filter?: ActivityFilter;
+  query?: ActivityQuery;
 }
 
 const resolveAgentNames = async (
@@ -272,15 +296,48 @@ export const getRecentRequestLogs = async (
 };
 
 /**
+ * Field-level conditions for an {@link ActivityQuery}, as an AND array.
+ *
+ * Deliberately NOT assigned onto the `where` root: `filter: "blocked"` already
+ * owns `status` and the cursor owns `OR`, so a root assignment would silently
+ * drop one of them (a caller passing `filter=blocked&status=200` must get an
+ * empty page, not "every 200"). ANDing keeps every condition load-bearing.
+ */
+const activityQueryConditions = (
+  query: ActivityQuery,
+): Prisma.RequestLogWhereInput[] => {
+  const conditions: Prisma.RequestLogWhereInput[] = [];
+
+  if (query.agentId) conditions.push({ agentId: query.agentId });
+  if (query.host) {
+    conditions.push({ host: { contains: query.host, mode: "insensitive" } });
+  }
+  if (query.provider) {
+    conditions.push({
+      provider: { contains: query.provider, mode: "insensitive" },
+    });
+  }
+  if (query.method) {
+    conditions.push({ method: query.method.toUpperCase() });
+  }
+  if (query.status !== undefined) conditions.push({ status: query.status });
+  if (query.since) conditions.push({ createdAt: { gte: query.since } });
+  if (query.until) conditions.push({ createdAt: { lt: query.until } });
+
+  return conditions;
+};
+
+/**
  * Build the Prisma `where` for an activity query: project scope, the selected
- * {@link ActivityFilter}, and the keyset-pagination cursor. Pure and synchronous
- * so it can be unit-tested without a database.
+ * {@link ActivityFilter}, any {@link ActivityQuery} narrowing, and the keyset-
+ * pagination cursor. Pure and synchronous so it can be unit-tested without a
+ * database.
  */
 export const buildActivityWhere = (
   projectId: string,
-  params: Pick<ActivityPageParams, "cursor" | "filter"> = {},
+  params: Pick<ActivityPageParams, "cursor" | "filter" | "query"> = {},
 ): Prisma.RequestLogWhereInput => {
-  const { cursor, filter = "all" } = params;
+  const { cursor, filter = "all", query } = params;
   const where: Prisma.RequestLogWhereInput = { projectId };
 
   if (filter === "blocked") {
@@ -304,7 +361,37 @@ export const buildActivityWhere = (
     ];
   }
 
+  if (query) {
+    const conditions = activityQueryConditions(query);
+    if (conditions.length > 0) where.AND = conditions;
+  }
+
   return where;
+};
+
+/**
+ * One activity event by id, or null when it doesn't exist **or belongs to
+ * another project** — the project scope rides the `where`, so a caller can't
+ * probe foreign ids. Goes through the same agent/approver resolution and
+ * org-rule redaction as the list, so a single-row read can never surface
+ * details the feed would hide from this viewer.
+ */
+export const getRequestLogById = async (
+  projectId: string,
+  id: string,
+  viewer?: RequestLogViewer,
+): Promise<RequestLogEntry | null> => {
+  const log = await db.requestLog.findFirst({ where: { id, projectId } });
+  if (!log) return null;
+
+  const [agentMap, userMap, seesOrgRules] = await Promise.all([
+    resolveAgentNames(projectId, [log.agentId]),
+    resolveUserNames(collectApproverIds([log])),
+    viewerSeesOrgRules(viewer),
+  ]);
+
+  const entry = toEntry(log, agentMap, userMap);
+  return seesOrgRules ? entry : redactOrgMatchedRule(entry);
 };
 
 export const getRequestLogs = async (


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Feature — a read-only HTTP surface over data that already exists. Closes #411.

## What is the current behavior?

Activity verification is dashboard-only. `request-log-service` is reachable from a Next.js server action (`lib/actions/request-logs.ts`), but there is **no API route** for it, so an agent cannot confirm its own calls actually flowed through OneCLI without driving a browser. As @fireharp put it, for an agent-first product the agent should be able to check "did my request land, with the expected agent/credential mapping?" itself.

## What is the new behavior?

**`GET /v1/activity`** — keyset-paginated feed, and **`GET /v1/activity/:id`** — one event. Both project-scoped, both read-only.

On top of the existing `all` / `hide-llm` / `blocked` filter, the field-level narrowing an automation actually needs:

| param | match |
|---|---|
| `agentId` | exact |
| `host`, `provider` | case-insensitive substring (`api.github.com` or just `github`) |
| `method` | exact, upper-cased |
| `status` | exact |
| `since` / `until` | inclusive lower / exclusive upper bound |
| `limit` (≤200), `cursorCreatedAt` + `cursorId` | paging |

```bash
curl -H "Authorization: Bearer $ONECLI_KEY" \
  "$ONECLI_URL/v1/activity?agentId=$AGENT&host=api.github.com&since=$T0&limit=10"
```

### Two properties this had to get right

**1. It's a second surface over one service, never a way around it.** Both reads pass the caller as the `viewer`, so the admin-only org-rule redaction the Activity page applies is applied here identically — a non-admin cannot use the API to read org rule names the dashboard hides from them. The single-event read scopes the lookup in its `where`, so a foreign id is indistinguishable from a missing one and ids can't be probed. Both are pinned by tests, including a serialize-the-whole-payload check that no org rule identifier leaks.

**2. Invalid input fails loudly.** An unparseable timestamp, an inverted window, an out-of-range `limit`, an unknown `filter`, or a half-supplied cursor all 400. A silently dropped bound would answer "nothing since X" with everything — which reads as "OneCLI isn't logging", the exact confusion this endpoint exists to remove. A half-cursor would restart at page one and loop a paging automation forever.

One implementation note worth flagging for review: query conditions are **ANDed** rather than assigned onto the `where` root, because `filter=blocked` already owns `status` and the cursor owns `OR` — a root assignment would silently drop one of them (`filter=blocked&status=200` would return every 200 instead of nothing). There's a regression test for exactly that.

## Tests

- `routes/activity.test.ts` (12): auth required; project scoping; viewer threading; all filters parsed through to the service; cursor forwarding; and each 400 path asserting the service was **not** called.
- `services/request-log-service.test.ts` (+10): `ActivityQuery` → Prisma `where` (including the AND-vs-root regression and the cursor/filter coexistence), plus `getRequestLogById` for hit, unknown id, **foreign project id**, redaction parity with the feed, and fail-safe with no viewer.
- Full `packages/api` suite: **835 passed**. `apps/web` suite: 13 passed. `turbo run lint check-types` green for api/web/db/ui; prettier clean.

## Deliberately out of scope

- **The MCP/skill surface** the issue mentions as optional — that's a product-shaped decision (which tools, what naming) I'd rather have your direction on. This PR is the minimal read-only API the issue specifies; the MCP layer can wrap it without further backend changes.
- **`extraData` shaping.** The payload is returned exactly as the dashboard receives it, so this endpoint exposes nothing new. Worth noting for the issue's "no sensitive credential values" requirement: that guarantee comes from what the gateway writes into `extra_data`, not from this route — if you'd like an explicit allow-list projection for the API, happy to add it in a follow-up.
- **Org-scoped activity** (`/v1/activity` across a whole org) — the underlying service is project-scoped today; say the word if you want that axis too.
