### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,78 @@
+# Security Policy
+
+OneCLI holds credentials and decides which requests they are attached to, so a
+security report about it is worth handling carefully. Thank you for taking the
+time.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.** A public report
+describes the weakness to everyone running OneCLI before there is a version to
+upgrade to.
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/onecli/onecli/security) of this
+   repository.
+2. Click **Report a vulnerability**.
+3. Fill in what you found.
+
+That opens a private channel visible only to the maintainers, and it can become
+a published advisory with a CVE once a fix is out.
+
+If private reporting is unavailable for any reason, email
+**security@onecli.sh** instead, and we will follow up privately from there.
+
+## What to include
+
+Whatever you already have is enough to start a conversation — please don't wait
+until a report is polished. The things that help most:
+
+- What an attacker gains, and what they need in order to try.
+- The version or commit you observed it on.
+- Steps to reproduce, ideally against a disposable instance with dummy
+  credentials rather than real ones.
+- The relevant code paths, if you found them.
+
+Please use placeholder secrets in anything you send. We do not want your real
+tokens, and a report is not a safe place to put them.
+
+## What to expect
+
+- **Acknowledgement within 5 working days.** If you have not heard back by
+  then, please do follow up — it means the mail went astray, not that the
+  report was dismissed.
+- An assessment of severity and affected versions, shared with you.
+- Progress updates as a fix comes together, and a chance to review it.
+- Credit in the advisory and release notes, unless you would rather stay
+  anonymous.
+
+We ask for a **90-day disclosure window**, and we will usually be done well
+inside it. If you need to move faster — because the issue is being exploited,
+say — tell us and we will work to your timeline instead.
+
+## Scope
+
+In scope is anything that undermines what the gateway promises: an agent
+reaching a credential it was not granted, a credential being attached to a
+request it should not have been attached to, a policy control not applying
+where it says it does, secrets becoming readable outside their intended
+boundary, or authentication and tenant isolation failing.
+
+Out of scope: findings against onecli.sh or other hosted infrastructure rather
+than this codebase; vulnerabilities in dependencies with no OneCLI-specific
+impact (report those upstream); missing hardening headers or scanner output
+with no demonstrated impact; and anything requiring an attacker who already has
+the privileges the attack obtains.
+
+If you are not sure which side of that line something falls on, report it. We
+would rather read a report that turns out to be fine than miss one that is not.
+
+## Safe harbour
+
+We will not pursue or support legal action against anyone who reports in good
+faith under this policy — meaning you tested against your own instance, avoided
+accessing or destroying other people's data, and gave us a private, reasonable
+opportunity to fix the issue before describing it publicly.
+
+OneCLI does not currently run a paid bug bounty.


### PR DESCRIPTION
### Have you read the [Contributing Guidelines](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md)?

YES

### What kind of change does this PR introduce?

Documentation. Adds a `SECURITY.md`.

### What is the current behavior?

There is no `SECURITY.md`, no security section in the README, and GitHub private vulnerability reporting is currently disabled on the repo. `CONTRIBUTING.md` directs all bugs to public issues.

For most bugs that is exactly right. For a vulnerability in a tool whose job is holding credentials and deciding which requests they get attached to, a public issue describes the weakness to everyone running OneCLI before there is a version to upgrade to — and a reporter who wants to do the right thing has no obvious private destination.

### What is the new behavior?

A `SECURITY.md` that:

- points reporters at GitHub's private vulnerability reporting, with an email fallback
- says what to include, and asks for placeholder secrets rather than real ones
- commits to an acknowledgement window, progress updates, and credit
- sets out scope, in both directions, so people can tell whether something is worth sending
- offers a good-faith safe harbour

### Additional context

**Two things need a decision from you, and I'm happy to push either change:**

1. **Private vulnerability reporting is currently off.** The policy leads with it, so it would need enabling under *Settings → Code security → Private vulnerability reporting* for that path to work. It's a checkbox, and it gives you a private thread plus a route to a published advisory and CVE.
2. **`security@onecli.sh` in the email fallback is a placeholder I made up** — I had no way to tell which address you actually monitor. Please replace it with the real one (or tell me and I'll amend the commit).

The specifics — 5 working days, 90 days, no paid bounty — are conventional defaults chosen so the file says something concrete rather than nothing. Adjust any of them to whatever you can actually stand behind; a policy that overpromises is worse than one that doesn't.