### PR TITLE
fix(docker): keep the admin api and postgres on loopback; only the gateway binds the bridge

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,8 +10,13 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-onecli}
     volumes:
       - pgdata:/var/lib/postgresql
+    # Postgres is internal to the install: the app talks to it over the
+    # compose network, so the published port exists only for the operator's
+    # psql. Keep it on loopback — publishing it on ONECLI_BIND_HOST puts the
+    # database on the docker bridge where unrelated containers can reach it
+    # (#268).
     ports:
-      - "${ONECLI_BIND_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
+      - "${ONECLI_POSTGRES_BIND_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-onecli}"]
       interval: 5s
@@ -28,8 +33,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # The gateway is the only service that must be reachable from agent
+    # containers, so it binds ONECLI_BIND_HOST (the docker bridge IP on bare-
+    # metal Linux). The admin API stays on loopback unless the operator
+    # opts into exposing it with ONECLI_APP_BIND_HOST (#268).
     ports:
-      - "${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}:10254"
+      - "${ONECLI_APP_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}:10254"
       - "${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_GATEWAY_PORT:-10255}:10255"
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-onecli}:${POSTGRES_PASSWORD:-onecli}@postgres:5432/${POSTGRES_DB:-onecli}
@@ -42,7 +51,10 @@ services:
       # to, which holds for a local or single-host install. When it doesn't — a
       # tunnel, a reverse proxy, a real domain — set APP_URL instead of relying
       # on it: either export it, or put it in a `.env` beside this file.
-      APP_URL: ${APP_URL:-http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}}
+      # APP_URL follows the app bind: the admin API defaults to loopback, so
+      # the advertised URL does too. Remote dashboard access means setting
+      # ONECLI_APP_BIND_HOST (and APP_URL if it differs).
+      APP_URL: ${APP_URL:-http://${ONECLI_APP_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}}
       GATEWAY_API_URL: http://${ONECLI_BIND_HOST:-127.0.0.1}:${ONECLI_GATEWAY_PORT:-10255}
       # Where the gateway reaches the Node API. Both run in this one container
       # (see docker/entrypoint.sh), so it is a loopback call and never leaves it.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,12 @@
 #
 # Usage: curl -fsSL https://onecli.sh/install | sh
 #
-# Custom bind host:
-#   export ONECLI_BIND_HOST=192.168.1.50
+# Custom bind hosts (the gateway binds for agent containers; the admin API
+# and Postgres bind 127.0.0.1 by default so unrelated containers can't reach
+# them — expose them only if you actually need remote access):
+#   export ONECLI_BIND_HOST=192.168.1.50           # gateway
+#   export ONECLI_APP_BIND_HOST=192.168.1.50       # dashboard (admin API)
+#   export ONECLI_POSTGRES_BIND_HOST=192.168.1.50  # psql
 #   curl -fsSL https://onecli.sh/install | sh
 #
 # Custom PostgreSQL port (if 5432 is already in use):
@@ -185,10 +189,15 @@ main() {
 
   echo ""
   echo "  OneCLI is running!"
-  echo "  ONECLI_URL:  http://$ONECLI_BIND_HOST:${ONECLI_APP_PORT:-10254}"
+  echo "  ONECLI_URL:  http://${ONECLI_APP_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}"
   echo ""
-  echo "  Dashboard:  http://$ONECLI_BIND_HOST:${ONECLI_APP_PORT:-10254}"
+  echo "  Dashboard:  http://${ONECLI_APP_BIND_HOST:-127.0.0.1}:${ONECLI_APP_PORT:-10254}"
   echo "  Gateway:    http://$ONECLI_BIND_HOST:${ONECLI_GATEWAY_PORT:-10255}"
+  echo ""
+  echo "  Serving the dashboard remotely? The admin API and Postgres bind to"
+  echo "  127.0.0.1 by default so unrelated containers can't reach them. Set"
+  echo "  ONECLI_APP_BIND_HOST=<your-ip> (and APP_URL) in $INSTALL_DIR/.env to"
+  echo "  expose the dashboard, ONECLI_POSTGRES_BIND_HOST to expose psql."
   echo ""
   echo "  Reaching OneCLI at another address (tunnel, proxy, domain)? Set APP_URL in $INSTALL_DIR/.env"
   echo ""


### PR DESCRIPTION
closes #268

on bare-metal linux, `detect_bind_host` picks the docker0 bridge ip and `ONECLI_BIND_HOST` feeds all three published ports — gateway (:10255), admin api (:10254) and postgres (:5432). the same setting that lets agent containers reach the gateway also publishes the admin api and the database on the docker bridge, where unrelated containers can read every agent token and secret metadata.

changes:
- split the bind per service. the admin api and postgres now bind `127.0.0.1` by default, reachable only from the host
- the gateway keeps `ONECLI_BIND_HOST` (the bridge ip on bare-metal linux), so agent containers still work
- new opt-in overrides for exposing them: `ONECLI_APP_BIND_HOST` (dashboard/remote access) and `ONECLI_POSTGRES_BIND_HOST` (psql)
- `APP_URL` follows the app bind so the advertised url matches what's actually listening; install.sh prints the correct dashboard url and documents the split

verification:
- `docker compose config` with `ONECLI_BIND_HOST=172.17.0.1` resolves: 10254 -> 127.0.0.1, 10255 -> 172.17.0.1, 5432 -> 127.0.0.1
- `bash -n scripts/install.sh` passes
- no tests reference the compose file or install output

behavior note: operators who previously reached the dashboard via the lan/bridge ip need to set `ONECLI_APP_BIND_HOST` now — that's the exposure this closes. related: #228 (rootless containers can't reach the gateway on loopback) is a separate concern on the gateway side, untouched here.
