### PR TITLE
fix(gateway): bound stalled upstream requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,11 @@ GATEWAY_API_DOMAIN=localhost:10255
 # Gateway proxy — where containers connect for the CONNECT proxy
 # OSS: host.docker.internal:10255, Cloud: gateway.onecli.sh:10255 (no protocol prefix)
 GATEWAY_BASE_URL=host.docker.internal:10255
+
+# Gateway upstream transport
+# GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECS defaults to 10 seconds.
+# GATEWAY_UPSTREAM_RESPONSE_HEADER_TIMEOUT_SECS defaults to 120 seconds.
+# The response-header timeout bounds reqwest RequestBuilder::send(), so request
+# upload time counts against it; response bodies after headers are not bounded.
+GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECS=10
+GATEWAY_UPSTREAM_RESPONSE_HEADER_TIMEOUT_SECS=120

--- a/apps/gateway/src/gateway.rs
+++ b/apps/gateway/src/gateway.rs
@@ -34,6 +34,7 @@ mod mitm;
 pub(crate) mod response;
 mod transforms;
 mod tunnel;
+mod upstream;
 mod websocket;
 
 use std::net::SocketAddr;
@@ -53,6 +54,7 @@ use tower::ServiceExt;
 use tower_http::cors::CorsLayer;
 use tracing::{debug, info, info_span, warn, Instrument};
 
+use self::upstream::{UpstreamClients, UpstreamTlsPolicy};
 use crate::approval::{ApprovalDecision, ApprovalStore, APPROVAL_TIMEOUT_SECS};
 use crate::auth::AuthUser;
 use crate::ca::CertificateAuthority;
@@ -84,11 +86,9 @@ pub(crate) struct ProxyContext {
 #[derive(Clone)]
 pub(crate) struct GatewayState {
     pub ca: Arc<CertificateAuthority>,
-    /// Standard upstream client — validates TLS certificates.
-    pub http_client: reqwest::Client,
-    /// No-verify upstream client — skips TLS certificate validation.
-    /// Selected for hosts matched by `skip_verify_hosts`.
-    pub http_client_no_verify: reqwest::Client,
+    /// Shared upstream HTTP clients. Standard and no-verify TLS policies live
+    /// in separate slots and can rotate independently after header timeouts.
+    pub upstream_clients: UpstreamClients,
     /// Hostname patterns for which TLS certificate validation is skipped.
     /// Supports exact match (`internal.corp`) and wildcard prefix (`*.internal.corp`).
     /// Populated from `GATEWAY_SKIP_VERIFY_HOSTS` (comma-separated).
@@ -97,8 +97,8 @@ pub(crate) struct GatewayState {
     /// not serve — validates TLS certificates.
     pub ws_connector: TlsConnector,
     /// No-verify WebSocket connector — skips TLS certificate validation.
-    /// Selected for hosts matched by `skip_verify_hosts`, exactly as
-    /// `http_client_no_verify` is.
+    /// Selected for hosts matched by `skip_verify_hosts`, exactly as the
+    /// no-verify HTTP client slot is.
     pub ws_connector_no_verify: TlsConnector,
     pub policy_engine: Arc<PolicyEngine>,
     pub cache: Arc<dyn CacheStore>,
@@ -113,18 +113,6 @@ pub(crate) struct GatewayState {
 pub struct GatewayServer {
     state: GatewayState,
     port: u16,
-}
-
-/// Build the HTTP client used for upstream requests.
-///
-/// - Redirects are disabled so 3xx responses are forwarded to the client as-is.
-/// - `accept_invalid_certs` skips TLS certificate validation for upstream connections.
-fn build_http_client(accept_invalid_certs: bool) -> reqwest::Client {
-    reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .danger_accept_invalid_certs(accept_invalid_certs)
-        .build()
-        .expect("build HTTP client")
 }
 
 /// Accepts any server certificate, for the hosts an operator has explicitly
@@ -273,9 +261,10 @@ impl GatewayServer {
         vault_service: Arc<vault::VaultService>,
         cache: Arc<dyn CacheStore>,
         approval_store: Arc<dyn ApprovalStore>,
-    ) -> Self {
+    ) -> Result<Self> {
         let global_skip = std::env::var("GATEWAY_DANGER_ACCEPT_INVALID_CERTS").is_ok();
         let skip_verify_hosts = Arc::new(parse_skip_verify_hosts());
+        let upstream_config = upstream::UpstreamTransportConfig::from_env()?;
 
         if global_skip {
             warn!("GATEWAY_DANGER_ACCEPT_INVALID_CERTS is set: TLS verification disabled for ALL upstream hosts");
@@ -285,8 +274,7 @@ impl GatewayServer {
 
         let state = GatewayState {
             ca: Arc::new(ca),
-            http_client: build_http_client(global_skip),
-            http_client_no_verify: build_http_client(true),
+            upstream_clients: UpstreamClients::new(upstream_config, global_skip)?,
             skip_verify_hosts,
             ws_connector: TlsConnector::from(build_ws_tls_config(global_skip)),
             ws_connector_no_verify: TlsConnector::from(build_ws_tls_config(true)),
@@ -296,7 +284,7 @@ impl GatewayServer {
             approval_store,
         };
 
-        Self { state, port }
+        Ok(Self { state, port })
     }
 
     /// Start the gateway TCP listener. Runs forever.
@@ -862,15 +850,16 @@ async fn handle_connect(
     // same upstreams, so a host they disagree about would mean traffic verified
     // on one protocol and not the other. One branch makes that unrepresentable
     // rather than merely true today.
-    let (http_client, ws_connector) = if skip_verify {
+    let (upstream_tls_policy, ws_connector) = if skip_verify {
         info!(parent: &session_span, "TLS verification skipped (GATEWAY_SKIP_VERIFY_HOSTS)");
         (
-            state.http_client_no_verify.clone(),
+            UpstreamTlsPolicy::NoVerify,
             state.ws_connector_no_verify.clone(),
         )
     } else {
-        (state.http_client.clone(), state.ws_connector.clone())
+        (UpstreamTlsPolicy::Verify, state.ws_connector.clone())
     };
+    let upstream_clients = state.upstream_clients.clone();
     let cache = Arc::clone(&state.cache);
     let approval_store = Arc::clone(&state.approval_store);
     let proxy_ctx = Arc::new(ProxyContext {
@@ -899,7 +888,8 @@ async fn handle_connect(
                             upgraded,
                             &host,
                             &ca,
-                            http_client,
+                            upstream_clients,
+                            upstream_tls_policy,
                             ws_connector,
                             vault_injection_rules,
                             cache,
@@ -1116,12 +1106,13 @@ async fn handle_http_proxy(
         budget_bindings: resolved.budget_bindings,
     };
 
-    let http_client =
+    let upstream_tls_policy =
         if scheme == "https" && host_matches_skip_verify(&hostname, &state.skip_verify_hosts) {
-            state.http_client_no_verify.clone()
+            UpstreamTlsPolicy::NoVerify
         } else {
-            state.http_client.clone()
+            UpstreamTlsPolicy::Verify
         };
+    let upstream_client = state.upstream_clients.lease(upstream_tls_policy);
 
     let mut resp = async {
         forward::forward_request(
@@ -1129,7 +1120,7 @@ async fn handle_http_proxy(
             &authority, // forward target (the HTTP-proxy path never host-rewrites)
             &hostname,  // policy_host: host the rules were assembled from
             scheme,
-            http_client,
+            upstream_client,
             &rules,
             &*state.cache,
             &proxy_ctx,
@@ -1253,7 +1244,9 @@ mod tests {
         });
 
         // Act: use the same client the gateway uses in production.
-        let client = build_http_client(false);
+        let client =
+            upstream::build_http_client(false, upstream::UpstreamTransportConfig::default())
+                .expect("build HTTP client");
         let resp = client
             .get(format!("http://{addr}/test"))
             .send()

--- a/apps/gateway/src/gateway/forward.rs
+++ b/apps/gateway/src/gateway/forward.rs
@@ -27,6 +27,7 @@ use crate::policy_engine;
 use super::hooks;
 use super::mitm::ResolvedRules;
 use super::response;
+use super::upstream::UpstreamClientLease;
 use super::ProxyContext;
 
 // ── Header filtering ────────────────────────────────────────────────────
@@ -106,6 +107,77 @@ const AUTH_CHECK_BODY_LIMIT: usize = 8192;
 /// OAuth refresh bodies are tiny; this only guards against pathological inputs.
 const MAX_DEFAULT_INTERCEPT_BODY: usize = 64 * 1024;
 
+enum UpstreamSendError {
+    ResponseHeaderTimeout,
+    Request(reqwest::Error),
+}
+
+enum ForwardUpstreamError {
+    TimeoutResponse(Box<Response<hooks::ForwardResponseBody>>),
+    Request(reqwest::Error),
+}
+
+fn observable_host(host: &str) -> &str {
+    let without_userinfo = host.rsplit('@').next().unwrap_or(host);
+    super::strip_port(without_userinfo)
+}
+
+/// Send an upstream request, bounding the wait for response headers.
+///
+/// The response body remains streamed after headers arrive, so long-lived SSE
+/// and large downloads are not capped by this timeout.
+async fn send_upstream_with_timeout(
+    request: reqwest::RequestBuilder,
+    timeout: Duration,
+) -> std::result::Result<reqwest::Response, UpstreamSendError> {
+    match tokio::time::timeout(timeout, request.send()).await {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(err)) => Err(UpstreamSendError::Request(err)),
+        Err(_) => Err(UpstreamSendError::ResponseHeaderTimeout),
+    }
+}
+
+async fn send_upstream_or_timeout_response(
+    request: reqwest::RequestBuilder,
+    client: &UpstreamClientLease,
+    method: &hyper::Method,
+    host: &str,
+) -> std::result::Result<reqwest::Response, ForwardUpstreamError> {
+    match send_upstream_with_timeout(request, client.response_header_timeout()).await {
+        Ok(response) => Ok(response),
+        Err(UpstreamSendError::ResponseHeaderTimeout) => {
+            let log_host = observable_host(host);
+            let rotated = match client.rotate_after_timeout() {
+                Ok(rotated) => rotated,
+                Err(err) => {
+                    warn!(
+                        method = %method,
+                        host = %log_host,
+                        tls_policy = ?client.policy(),
+                        generation = client.generation(),
+                        error = ?err,
+                        "upstream response-header timeout; failed to rotate client generation"
+                    );
+                    false
+                }
+            };
+            warn!(
+                method = %method,
+                host = %log_host,
+                tls_policy = ?client.policy(),
+                generation = client.generation(),
+                timeout_secs = client.response_header_timeout().as_secs(),
+                rotated,
+                "upstream response-header timeout"
+            );
+            Err(ForwardUpstreamError::TimeoutResponse(Box::new(
+                response::upstream_timeout(),
+            )))
+        }
+        Err(UpstreamSendError::Request(err)) => Err(ForwardUpstreamError::Request(err)),
+    }
+}
+
 /// Mint any deferred credentials and fold their rules into the request's
 /// injection set. Called once the request is allowed — see
 /// [`crate::connect::PendingInjection`].
@@ -180,7 +252,7 @@ pub(crate) async fn forward_request(
     // forward target (URL, `is_llm_host`, interception).
     policy_host: &str,
     scheme: &str,
-    http_client: reqwest::Client,
+    http_client: UpstreamClientLease,
     rules: &ResolvedRules,
     cache: &dyn CacheStore,
     proxy_ctx: &ProxyContext,
@@ -775,16 +847,20 @@ pub(crate) async fn forward_request(
     };
 
     // ── Forward to upstream ──────────────────────────────────────────
-    let mut upstream = http_client.request(method.clone(), &upstream_url);
+    let mut upstream = http_client.client().request(method.clone(), &upstream_url);
     for (name, value) in headers.iter() {
         upstream = upstream.header(name.clone(), value.clone());
     }
     upstream = upstream.body(forward_body);
 
-    let upstream_resp = upstream
-        .send()
-        .await
-        .with_context(|| format!("forwarding to {url}"))?;
+    let upstream_resp =
+        match send_upstream_or_timeout_response(upstream, &http_client, &method, host).await {
+            Ok(response) => response,
+            Err(ForwardUpstreamError::TimeoutResponse(resp)) => return Ok(*resp),
+            Err(ForwardUpstreamError::Request(err)) => {
+                return Err(err).with_context(|| format!("forwarding to {url}"));
+            }
+        };
 
     let status = upstream_resp.status();
     let resp_headers = upstream_resp.headers().clone();
@@ -1166,6 +1242,295 @@ fn body_indicates_auth_error(body: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use http_body_util::BodyExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::super::upstream::{UpstreamClients, UpstreamTlsPolicy, UpstreamTransportConfig};
+
+    fn upstream_clients(response_header_timeout: Duration) -> UpstreamClients {
+        UpstreamClients::new(
+            UpstreamTransportConfig {
+                connect_timeout: Duration::from_secs(10),
+                response_header_timeout,
+            },
+            false,
+        )
+        .expect("build upstream clients")
+    }
+
+    async fn read_request_headers(stream: &mut tokio::net::TcpStream) {
+        let mut buf = [0u8; 1024];
+        let mut seen = Vec::new();
+        loop {
+            match stream.read(&mut buf).await {
+                Ok(0) | Err(_) => return,
+                Ok(n) => {
+                    seen.extend_from_slice(&buf[..n]);
+                    if seen.windows(4).any(|w| w == b"\r\n\r\n") {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn silent_upstream() -> (SocketAddr, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind silent upstream");
+        let addr = listener.local_addr().expect("silent upstream address");
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let accepted_for_task = Arc::clone(&accepted);
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                accepted_for_task.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    read_request_headers(&mut stream).await;
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                });
+            }
+        });
+        (addr, accepted, server)
+    }
+
+    async fn wait_for_accepts(accepted: &AtomicUsize, expected: usize) {
+        let done = tokio::time::timeout(Duration::from_secs(1), async {
+            while accepted.load(Ordering::SeqCst) < expected {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            done.is_ok(),
+            "upstream accepted {} requests, expected {expected}",
+            accepted.load(Ordering::SeqCst)
+        );
+    }
+
+    async fn one_response_upstream(
+        response: &'static [u8],
+        body_delay: Duration,
+    ) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind response upstream");
+        let addr = listener.local_addr().expect("response upstream address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            read_request_headers(&mut stream).await;
+            if let Some(split) = response.windows(4).position(|w| w == b"\r\n\r\n") {
+                let header_end = split + 4;
+                stream
+                    .write_all(&response[..header_end])
+                    .await
+                    .expect("write response headers");
+                tokio::time::sleep(body_delay).await;
+                stream
+                    .write_all(&response[header_end..])
+                    .await
+                    .expect("write response body");
+            } else {
+                stream
+                    .write_all(response)
+                    .await
+                    .expect("write whole response");
+            }
+        });
+        (addr, server)
+    }
+
+    async fn timeout_response_body(resp: Response<hooks::ForwardResponseBody>) -> String {
+        let bytes = resp
+            .into_body()
+            .collect()
+            .await
+            .expect("collect timeout response body")
+            .to_bytes();
+        String::from_utf8(bytes.to_vec()).expect("timeout response is utf8")
+    }
+
+    #[tokio::test]
+    async fn upstream_response_header_wait_is_bounded() {
+        let (addr, accepted, server) = silent_upstream().await;
+        let request = reqwest::Client::new().get(format!("http://{addr}/silent"));
+        let guarded = tokio::time::timeout(
+            Duration::from_millis(250),
+            send_upstream_with_timeout(request, Duration::from_millis(50)),
+        )
+        .await;
+
+        wait_for_accepts(&accepted, 1).await;
+        server.abort();
+        assert!(
+            matches!(guarded, Ok(Err(UpstreamSendError::ResponseHeaderTimeout))),
+            "the helper did not enforce its own response-header timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn upstream_timeout_maps_to_sanitized_504() {
+        let (addr, _accepted, server) = silent_upstream().await;
+        let clients = upstream_clients(Duration::from_millis(50));
+        let lease = clients.lease(UpstreamTlsPolicy::Verify);
+        let request = lease.client().get(format!(
+            "http://{addr}/silent?marker=fixture-redaction-marker"
+        ));
+
+        let err = match send_upstream_or_timeout_response(
+            request,
+            &lease,
+            &hyper::Method::GET,
+            "127.0.0.1",
+        )
+        .await
+        {
+            Ok(_) => panic!("silent upstream should return timeout response"),
+            Err(err) => err,
+        };
+
+        server.abort();
+        let ForwardUpstreamError::TimeoutResponse(resp) = err else {
+            panic!("expected timeout response");
+        };
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(
+            resp.headers()
+                .get("x-should-retry")
+                .and_then(|v| v.to_str().ok()),
+            Some("false")
+        );
+        let body = timeout_response_body(*resp).await;
+        assert!(body.contains(r#""error":"upstream_timeout""#));
+        assert!(!body.contains("fixture-redaction-marker"));
+    }
+
+    #[tokio::test]
+    async fn timeout_rotates_generation_and_next_lease_succeeds() {
+        let (silent_addr, _accepted, silent_server) = silent_upstream().await;
+        let clients = upstream_clients(Duration::from_millis(50));
+        let stale = clients.lease(UpstreamTlsPolicy::Verify);
+        let request = stale.client().get(format!("http://{silent_addr}/silent"));
+
+        let result =
+            send_upstream_or_timeout_response(request, &stale, &hyper::Method::GET, "127.0.0.1")
+                .await;
+        assert!(matches!(
+            result,
+            Err(ForwardUpstreamError::TimeoutResponse(_))
+        ));
+        assert_eq!(clients.generation(UpstreamTlsPolicy::Verify), 1);
+        silent_server.abort();
+
+        let (ok_addr, ok_server) = one_response_upstream(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+            Duration::ZERO,
+        )
+        .await;
+        let fresh = clients.lease(UpstreamTlsPolicy::Verify);
+        assert_eq!(fresh.generation(), 1);
+        let request = fresh.client().get(format!("http://{ok_addr}/ok"));
+        let response_result =
+            send_upstream_or_timeout_response(request, &fresh, &hyper::Method::GET, "127.0.0.1")
+                .await;
+        let response = match response_result {
+            Ok(response) => response,
+            Err(_) => panic!("fresh generation should receive response headers"),
+        };
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.bytes().await.expect("read body"),
+            Bytes::from_static(b"ok")
+        );
+        ok_server.await.expect("response server finished");
+    }
+
+    #[tokio::test]
+    async fn concurrent_timeouts_rotate_one_generation_once() {
+        let (addr, _accepted, server) = silent_upstream().await;
+        let clients = upstream_clients(Duration::from_millis(50));
+        let leases = (0..5)
+            .map(|_| clients.lease(UpstreamTlsPolicy::Verify))
+            .collect::<Vec<_>>();
+
+        let results = futures_util::future::join_all(leases.into_iter().map(|lease| {
+            let request = lease.client().get(format!("http://{addr}/silent"));
+            async move {
+                send_upstream_or_timeout_response(request, &lease, &hyper::Method::GET, "127.0.0.1")
+                    .await
+            }
+        }))
+        .await;
+
+        server.abort();
+        assert!(results
+            .into_iter()
+            .all(|result| matches!(result, Err(ForwardUpstreamError::TimeoutResponse(_)))));
+        assert_eq!(clients.generation(UpstreamTlsPolicy::Verify), 1);
+    }
+
+    #[tokio::test]
+    async fn response_header_timeout_does_not_bound_streamed_body() {
+        let (addr, server) = one_response_upstream(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello world",
+            Duration::from_millis(150),
+        )
+        .await;
+        let clients = upstream_clients(Duration::from_millis(50));
+        let lease = clients.lease(UpstreamTlsPolicy::Verify);
+        let request = lease.client().get(format!("http://{addr}/stream"));
+
+        let response_result =
+            send_upstream_or_timeout_response(request, &lease, &hyper::Method::GET, "127.0.0.1")
+                .await;
+        let response = match response_result {
+            Ok(response) => response,
+            Err(_) => panic!("headers arrive before the response-header timeout"),
+        };
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = tokio::time::timeout(Duration::from_secs(1), response.bytes())
+            .await
+            .expect("body stream should not be capped by the header timeout")
+            .expect("read body");
+        assert_eq!(body, Bytes::from_static(b"hello world"));
+        server.await.expect("stream server finished");
+    }
+
+    #[tokio::test]
+    async fn response_header_timeout_does_not_replay_post() {
+        let (addr, accepted, server) = silent_upstream().await;
+        let clients = upstream_clients(Duration::from_millis(50));
+        let lease = clients.lease(UpstreamTlsPolicy::Verify);
+        let request = lease
+            .client()
+            .post(format!("http://{addr}/create"))
+            .body("payload");
+
+        let result =
+            send_upstream_or_timeout_response(request, &lease, &hyper::Method::POST, "127.0.0.1")
+                .await;
+
+        wait_for_accepts(&accepted, 1).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        server.abort();
+        assert!(matches!(
+            result,
+            Err(ForwardUpstreamError::TimeoutResponse(_))
+        ));
+        assert_eq!(accepted.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn observable_host_strips_userinfo_and_port() {
+        assert_eq!(observable_host("userinfo@example.test:443"), "example.test");
+        assert_eq!(observable_host("example.test:443"), "example.test");
+    }
 
     // ── is_forwarded_request_header ──────────────────────────────────────
 

--- a/apps/gateway/src/gateway/mitm.rs
+++ b/apps/gateway/src/gateway/mitm.rs
@@ -24,6 +24,7 @@ use crate::inject::InjectionRule;
 
 use super::forward;
 use super::response;
+use super::upstream::{UpstreamClients, UpstreamTlsPolicy};
 use super::ProxyContext;
 
 /// Cap on the client-side TLS handshake inside a tunnel.
@@ -48,7 +49,8 @@ pub(super) async fn mitm(
     upgraded: hyper::upgrade::Upgraded,
     host: &str,
     ca: &CertificateAuthority,
-    http_client: reqwest::Client,
+    upstream_clients: UpstreamClients,
+    upstream_tls_policy: UpstreamTlsPolicy,
     // Upstream TLS for the WebSocket leg, already resolved against the
     // operator's skip-verify configuration at CONNECT time.
     ws_connector: TlsConnector,
@@ -84,7 +86,7 @@ pub(super) async fn mitm(
             io,
             service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
                 let host = host_owned.clone();
-                let client = http_client.clone();
+                let clients = upstream_clients.clone();
                 let ws_tls = ws_connector.clone();
                 let cache = Arc::clone(&cache);
                 let ctx = Arc::clone(&proxy_ctx);
@@ -141,6 +143,7 @@ pub(super) async fn mitm(
                                     }
                                 }
                             } else {
+                                let client = clients.lease(upstream_tls_policy);
                                 match forward::forward_request(
                                     req,
                                     effective_host, // forward target (may be host-rewritten)

--- a/apps/gateway/src/gateway/response.rs
+++ b/apps/gateway/src/gateway/response.rs
@@ -364,6 +364,18 @@ pub(crate) fn resolution_failed<S>() -> Response<ForwardBody<S>> {
     )
 }
 
+/// 504 Gateway Timeout — upstream accepted the request path but did not return
+/// response headers before the configured gateway bound.
+pub(crate) fn upstream_timeout<S>() -> Response<ForwardBody<S>> {
+    with_no_retry(json_error(
+        StatusCode::GATEWAY_TIMEOUT,
+        serde_json::json!({
+            "error": "upstream_timeout",
+            "message": "Upstream did not return response headers before the gateway timeout.",
+        }),
+    ))
+}
+
 /// 403 Forbidden — manual approval denied or timed out.
 pub(crate) fn manual_approval_denied<S>(
     approval_id: &str,

--- a/apps/gateway/src/gateway/upstream.rs
+++ b/apps/gateway/src/gateway/upstream.rs
@@ -1,0 +1,270 @@
+//! Shared upstream HTTP clients and transport limits.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+
+/// Upstream TCP/TLS connect timeout in seconds; defaults to 10 seconds.
+pub(crate) const CONNECT_TIMEOUT_SECS_ENV: &str = "GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECS";
+/// Upstream `RequestBuilder::send()` timeout in seconds; defaults to 120
+/// seconds. Request upload time counts against this budget, and response bodies
+/// after headers are not bounded by it.
+pub(crate) const RESPONSE_HEADER_TIMEOUT_SECS_ENV: &str =
+    "GATEWAY_UPSTREAM_RESPONSE_HEADER_TIMEOUT_SECS";
+
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_RESPONSE_HEADER_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct UpstreamTransportConfig {
+    pub connect_timeout: Duration,
+    pub response_header_timeout: Duration,
+}
+
+impl UpstreamTransportConfig {
+    pub(crate) fn from_env() -> Result<Self> {
+        Self::from_env_values(
+            std::env::var(CONNECT_TIMEOUT_SECS_ENV).ok(),
+            std::env::var(RESPONSE_HEADER_TIMEOUT_SECS_ENV).ok(),
+        )
+    }
+
+    pub(crate) fn from_env_values(
+        connect_timeout_secs: Option<String>,
+        response_header_timeout_secs: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            connect_timeout: parse_positive_secs(
+                CONNECT_TIMEOUT_SECS_ENV,
+                connect_timeout_secs.as_deref(),
+                DEFAULT_CONNECT_TIMEOUT,
+            )?,
+            response_header_timeout: parse_positive_secs(
+                RESPONSE_HEADER_TIMEOUT_SECS_ENV,
+                response_header_timeout_secs.as_deref(),
+                DEFAULT_RESPONSE_HEADER_TIMEOUT,
+            )?,
+        })
+    }
+}
+
+impl Default for UpstreamTransportConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            response_header_timeout: DEFAULT_RESPONSE_HEADER_TIMEOUT,
+        }
+    }
+}
+
+fn parse_positive_secs(name: &str, raw: Option<&str>, default: Duration) -> Result<Duration> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+    let secs: u64 = raw
+        .trim()
+        .parse()
+        .with_context(|| format!("{name} must be a positive integer number of seconds"))?;
+    if secs == 0 {
+        bail!("{name} must be greater than zero");
+    }
+    Ok(Duration::from_secs(secs))
+}
+
+/// Whether an upstream client verifies server certificates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UpstreamTlsPolicy {
+    Verify,
+    NoVerify,
+}
+
+/// Pair of reqwest client slots. The slots are intentionally independent so a
+/// timeout in the no-verify pool cannot change the verified pool, or vice versa.
+#[derive(Clone)]
+pub(crate) struct UpstreamClients {
+    verify: Arc<UpstreamClientSlot>,
+    no_verify: Arc<UpstreamClientSlot>,
+}
+
+impl UpstreamClients {
+    pub(crate) fn new(
+        config: UpstreamTransportConfig,
+        verify_slot_accepts_invalid_certs: bool,
+    ) -> Result<Self> {
+        Ok(Self {
+            verify: Arc::new(UpstreamClientSlot::new(
+                verify_slot_accepts_invalid_certs,
+                config,
+            )?),
+            no_verify: Arc::new(UpstreamClientSlot::new(true, config)?),
+        })
+    }
+
+    pub(crate) fn lease(&self, policy: UpstreamTlsPolicy) -> UpstreamClientLease {
+        match policy {
+            UpstreamTlsPolicy::Verify => self.verify.lease(policy),
+            UpstreamTlsPolicy::NoVerify => self.no_verify.lease(policy),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn generation(&self, policy: UpstreamTlsPolicy) -> u64 {
+        match policy {
+            UpstreamTlsPolicy::Verify => self.verify.generation(),
+            UpstreamTlsPolicy::NoVerify => self.no_verify.generation(),
+        }
+    }
+}
+
+struct UpstreamClientSlot {
+    accept_invalid_certs: bool,
+    config: UpstreamTransportConfig,
+    inner: Mutex<ClientGeneration>,
+}
+
+impl UpstreamClientSlot {
+    fn new(accept_invalid_certs: bool, config: UpstreamTransportConfig) -> Result<Self> {
+        Ok(Self {
+            accept_invalid_certs,
+            config,
+            inner: Mutex::new(ClientGeneration {
+                generation: 0,
+                client: build_http_client(accept_invalid_certs, config)?,
+            }),
+        })
+    }
+
+    fn lease(self: &Arc<Self>, policy: UpstreamTlsPolicy) -> UpstreamClientLease {
+        let inner = self.inner.lock().expect("upstream client slot poisoned");
+        UpstreamClientLease {
+            policy,
+            generation: inner.generation,
+            client: inner.client.clone(),
+            response_header_timeout: self.config.response_header_timeout,
+            slot: Arc::clone(self),
+        }
+    }
+
+    #[cfg(test)]
+    fn generation(&self) -> u64 {
+        self.inner
+            .lock()
+            .expect("upstream client slot poisoned")
+            .generation
+    }
+
+    fn rotate_if_generation(&self, observed_generation: u64) -> Result<bool> {
+        let mut inner = self.inner.lock().expect("upstream client slot poisoned");
+        if inner.generation != observed_generation {
+            return Ok(false);
+        }
+        inner.client = build_http_client(self.accept_invalid_certs, self.config)?;
+        inner.generation = inner.generation.saturating_add(1);
+        Ok(true)
+    }
+}
+
+struct ClientGeneration {
+    generation: u64,
+    client: reqwest::Client,
+}
+
+#[derive(Clone)]
+pub(crate) struct UpstreamClientLease {
+    policy: UpstreamTlsPolicy,
+    generation: u64,
+    client: reqwest::Client,
+    response_header_timeout: Duration,
+    slot: Arc<UpstreamClientSlot>,
+}
+
+impl UpstreamClientLease {
+    pub(crate) fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    pub(crate) fn policy(&self) -> UpstreamTlsPolicy {
+        self.policy
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) fn response_header_timeout(&self) -> Duration {
+        self.response_header_timeout
+    }
+
+    pub(crate) fn rotate_after_timeout(&self) -> Result<bool> {
+        self.slot.rotate_if_generation(self.generation)
+    }
+}
+
+pub(super) fn build_http_client(
+    accept_invalid_certs: bool,
+    config: UpstreamTransportConfig,
+) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(config.connect_timeout)
+        .danger_accept_invalid_certs(accept_invalid_certs)
+        .build()
+        .context("building upstream HTTP client")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_config_uses_safe_defaults() {
+        let config = UpstreamTransportConfig::from_env_values(None, None).unwrap();
+        assert_eq!(config.connect_timeout, Duration::from_secs(10));
+        assert_eq!(config.response_header_timeout, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn transport_config_parses_positive_second_values() {
+        let config =
+            UpstreamTransportConfig::from_env_values(Some("3".into()), Some("7".into())).unwrap();
+        assert_eq!(config.connect_timeout, Duration::from_secs(3));
+        assert_eq!(config.response_header_timeout, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn transport_config_rejects_zero_values() {
+        let err = UpstreamTransportConfig::from_env_values(Some("0".into()), None).unwrap_err();
+        assert!(err.to_string().contains(CONNECT_TIMEOUT_SECS_ENV));
+
+        let err = UpstreamTransportConfig::from_env_values(None, Some("0".into())).unwrap_err();
+        assert!(err.to_string().contains(RESPONSE_HEADER_TIMEOUT_SECS_ENV));
+    }
+
+    #[test]
+    fn transport_config_rejects_invalid_values() {
+        let err = UpstreamTransportConfig::from_env_values(Some("ten".into()), None).unwrap_err();
+        assert!(err.to_string().contains(CONNECT_TIMEOUT_SECS_ENV));
+    }
+
+    #[test]
+    fn stale_generation_rotates_only_once() {
+        let clients = UpstreamClients::new(UpstreamTransportConfig::default(), false).unwrap();
+        let first = clients.lease(UpstreamTlsPolicy::Verify);
+        let second = clients.lease(UpstreamTlsPolicy::Verify);
+
+        assert!(first.rotate_after_timeout().unwrap());
+        assert!(!second.rotate_after_timeout().unwrap());
+        assert_eq!(clients.generation(UpstreamTlsPolicy::Verify), 1);
+    }
+
+    #[test]
+    fn verified_and_no_verify_generations_are_independent() {
+        let clients = UpstreamClients::new(UpstreamTransportConfig::default(), false).unwrap();
+        let no_verify = clients.lease(UpstreamTlsPolicy::NoVerify);
+
+        assert!(no_verify.rotate_after_timeout().unwrap());
+        assert_eq!(clients.generation(UpstreamTlsPolicy::NoVerify), 1);
+        assert_eq!(clients.generation(UpstreamTlsPolicy::Verify), 0);
+    }
+}

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -317,7 +317,7 @@ async fn main() -> Result<()> {
         vault_service,
         cache,
         approval_store,
-    );
+    )?;
     let result = server.run().await;
 
     // The drain, in the one order that does not lose data: connections first


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / reliability proposal for #493.

This PR is intentionally presented as one possible implementation of the behavior requested in #493. It is not intended to prescribe this exact architecture: if the maintainers prefer a different timeout, error-mapping, or client-pool recovery design, the issue can be addressed independently of this proposal.

## What is the current behavior?

Issue #493 documents an intermittent field failure in which the gateway's upstream forwarding path stopped completing requests to GitHub. The same OneCLI image had served the requests successfully before the incident. During the failure:

- the proxy accepted CONNECT;
- curl/OpenSSL completed the client-facing TLS handshake for both TLS 1.2 and TLS 1.3 but received no HTTP response before an external deadline;
- Git/libcurl-GnuTLS either remained pending or surfaced a secondary non-proper TLS termination;
- forcing HTTP/1.1 on the client-facing Git leg was not a reliable workaround;
- the gateway process/listener remained alive and did not show resource exhaustion;
- restarting OneCLI cleared the in-memory state;
- the same requests then succeeded with no Git HTTP/TLS overrides.

The initiating runtime fault could not be recovered after restart, so the report does not claim a proven cause. Cargo feature inspection also shows that this build's upstream reqwest client does **not** enable reqwest's HTTP/2 feature; the upstream pool is HTTP/1.1. A bad HTTP/1.1 keep-alive connection or other stuck outbound state remains plausible, but unproven.

The deterministic source-level defect is narrower: the gateway awaited upstream `RequestBuilder::send()` without an explicit connect timeout, response-header/request-send deadline, or recovery mechanism for the shared reqwest client pool. A local upstream that accepted a request and never sent response headers could therefore keep the forwarding task pending indefinitely.

Related but distinct work:

- #424 concerns DNS-family failure and IPv4 fallback;
- #251 concerned Git credential injection and was fixed separately;
- #259 concerned absolute-form HTTPS forwarding and a later wrong-port axios case.

## What is the new behavior?

This proposal adds two startup-parsed transport settings:

```text
GATEWAY_UPSTREAM_CONNECT_TIMEOUT_SECS=10
GATEWAY_UPSTREAM_RESPONSE_HEADER_TIMEOUT_SECS=120
```

Missing values use those defaults. Zero, negative, or non-integer values fail startup and name the offending setting.

For each upstream TLS policy, the gateway owns a shared generation-managed reqwest client:

- normal certificate verification;
- explicitly configured no-verification behavior.

A request leases the current generation for its TLS-policy slot. The gateway then:

1. applies the configured reqwest connect timeout;
2. bounds `RequestBuilder::send()` with the configured 120-second default;
3. leaves the response body unbounded after response headers arrive;
4. on expiry, returns a static sanitized HTTP 504 response:

   ```json
   {
     "error": "upstream_timeout",
     "message": "Upstream did not return response headers before the gateway timeout."
   }
   ```

5. adds `x-should-retry: false` to prevent unsafe automatic replay;
6. rotates the affected client generation if and only if the timing-out lease still references the current generation;
7. does not retry or replay the failed request.

Subsequent requests lease the fresh generation and cannot reuse the retired generation's pool. Concurrent requests timing out from one retired generation perform at most one rotation.

The MITM path now leases the current upstream client per inner request rather than freezing one reqwest client for the entire lifetime of a CONNECT tunnel. Long-lived tunnels can therefore observe a later generation after recovery.

## Additional context

### Why this design

#### Bound failure rather than changing protocols

The reproducible defect is the unbounded wait, not a proven TLS-version or HTTP/2 bug. This proposal therefore does not:

- disable TLS verification;
- force TLS 1.2;
- force client-facing HTTP/1.1;
- disable pooling;
- add a GitHub/Git-specific special case.

The OneCLI upstream reqwest client is already HTTP/1.1-only in this build. Pool rotation is still useful because it prevents future requests from leasing the same set of HTTP/1.1 keep-alive connections or other client-local state after a timeout.

#### Separate connection and send/header bounds

A connection timeout contains DNS/TCP/TLS establishment. The second bound contains a connection that accepts the request path but does not produce response headers.

The second setting is intentionally **not** a total response timeout. Once headers arrive, SSE, long downloads, and delayed/streamed response bodies continue without this deadline.

Important reqwest semantic: `RequestBuilder::send()` covers request transmission as well as waiting for response headers. A slow streaming request upload therefore counts against `GATEWAY_UPSTREAM_RESPONSE_HEADER_TIMEOUT_SECS`. This is disclosed in code and `.env.example`; it is the main compatibility trade-off in this proposal. reqwest does not expose a Go-style timer that begins strictly after the complete request body has been written, while reqwest's total timeout would incorrectly cap streamed response bodies.

#### Rotate after timeout

A timeout alone bounds one task but does not prove that a client pool has forgotten the state associated with that request. Rebuilding the affected client slot guarantees that later requests lease a new pool generation.

Generation comparison keeps concurrent recovery idempotent:

```text
five requests lease generation 7
first timeout rotates 7 -> 8
remaining generation-7 timeouts observe stale leases and do not rotate again
next request leases generation 8
```

The old client remains reference-counted for requests already using it; it is not destroyed underneath in-flight work.

#### Keep TLS policies independent

The existing standard and skip-verification clients had different security behavior. This patch keeps them in independent slots and records the certificate policy needed to rebuild each slot. A timeout in an explicitly no-verify destination does not alter or rotate the normal-verification slot, and vice versa.

`GATEWAY_DANGER_ACCEPT_INVALID_CERTS` retains its existing global behavior. WebSocket TLS connectors and raw tunnels are unchanged.

#### Do not replay

The gateway cannot safely infer that a timed-out request was not accepted upstream. Automatically replaying a POST, streamed upload, or other non-idempotent operation could duplicate a side effect. The proposal therefore returns a controlled error, marks it no-automatic-retry, and leaves any explicit retry decision to the caller/application.

This deliberately sacrifices automatic GET recovery in favor of replay safety across all methods.

### Known trade-offs and limitations

- **Per-slot rather than per-host rotation:** one stalled host rotates the shared client slot and discards healthy keep-alive connections for other hosts using that TLS policy. Requests continue to work, but may reconnect. Per-host pools could reduce this collateral at the cost of more state and eviction policy; it is not included here.
- **Slow request uploads count against the bound:** described above. Response bodies after headers do not.
- **Already-leased requests:** a request can lease a generation before a manual-approval hold. If another request rotates the slot during that hold, the approved request may still attempt once using its retired client. If it also times out, its stale generation check will not rotate the current pool again. Re-leasing immediately before send is a possible refinement.
- **Timeout scope:** this PR covers upstream reqwest connection/send behavior. It does not add deadlines to credential resolution, OAuth refresh, database access, WebSocket forwarding, or raw CONNECT tunnels.
- **No claim about the original trigger:** the patch guarantees bounded failure/recovery from the demonstrated state; it does not prove or eliminate every possible initiating network fault.

### Observability and sanitization

The new timeout response is static and never echoes:

- upstream URLs or query strings;
- authorization/proxy-authorization headers;
- credential values;
- request/response bodies;
- CA material.

The new timeout event adds only:

- HTTP method;
- host with userinfo and port removed;
- TLS-policy slot;
- leased generation;
- configured timeout;
- whether this event rotated the slot.

Existing surrounding request spans may carry the gateway's normal request metadata; raw field-test logs are therefore not copied into this PR or #493. The issue and PR contain no credentials, agent/project identifiers, private endpoints, authorization headers, private CA material, or raw sensitive traces.

### Regression tests added

Focused transport/config tests cover:

- safe 10-second/120-second defaults;
- positive environment-value parsing;
- startup rejection for zero and invalid values;
- one rotation for multiple stale leases;
- independence of verified and no-verify generations.

Focused forwarding tests use real local TCP listeners and cover:

- an upstream that accepts the request and sends no headers is bounded by the helper's own deadline;
- timeout maps to sanitized HTTP 504 `upstream_timeout`;
- a query marker is not echoed in the timeout body;
- the no-automatic-retry header is present;
- timeout rotates the current generation and the next lease completes against a healthy server;
- five concurrent timeouts rotate one generation once;
- headers arriving before the deadline followed by a body delayed beyond it still succeed;
- a timed-out POST reaches the upstream exactly once;
- observable host logging strips userinfo and port.

### Verification results

All commands below were run against the complete uncommitted proposal diff.

```text
cargo fmt --all -- --check
PASS

cargo clippy -- -D warnings
PASS

cargo test gateway::upstream::tests -- --nocapture
6 passed, 0 failed

cargo test gateway::forward::tests -- --nocapture
20 passed, 0 failed

cargo test -- --nocapture
531 passed, 0 failed

pnpm check
9/9 tasks successful
Prettier check passed
Prisma format check passed

pnpm build
Gateway release build passed
Next.js production build passed

git diff --check
PASS
```

The fresh clone required the repository's documented generation step before monorepo type checking/building:

```text
pnpm db:generate
```

No production configuration was copied into the source clone.

### Official-image build

The repository's official Dockerfile built successfully with the proposal:

```text
docker build -f docker/Dockerfile \
  --build-arg APP_VERSION=1.45.0-upstream-timeout-proposal \
  -t onecli:upstream-timeout-proposal .
```

### End-to-end fault injection

A custom gateway from that image ran as an isolated sidecar on an alternate port. Production remained on its existing port and binary.

A disposable local HTTP server provided deterministic endpoints:

1. first request accepts and withholds headers;
2. second request to the same host returns immediately;
3. response headers return immediately but the response body waits three seconds;
4. POST accepts once and withholds headers while a separate counter records deliveries.

The sidecar used one-second test-only settings. Sanitized results:

```text
first silent request:
  HTTP 504 in 1.021 s
  static sanitized body: yes
  x-should-retry: false
  generation 0 rotated: true

next request to the same host:
  HTTP 200 in 0.006 s

slow response body:
  HTTP 200 in 3.005 s
  complete body received despite one-second send/header bound

timed-out POST:
  HTTP 504 in 1.003 s
  upstream observed request count: exactly 1
  generation 1 rotated: true
```

The custom sidecar also exercised the existing GitHub connection paths without retaining response bodies or credentials:

```text
GitHub smart-HTTP path: MITM, one injection applied, response received
GitHub API identity path: MITM, one injection applied, HTTP 200
```

The sidecar, fault server, and temporary binary were then stopped/removed. Production health remained HTTP 200 on both web and gateway health endpoints.

### Post-test production controls

The proposal was **not deployed** to production. The currently released OneCLI process still passed:

```text
default Git fetch through OneCLI: success
GitHub API credential-injection path: HTTP 200
repository-local Git HTTP/TLS overrides: unset
global Git HTTP/TLS overrides: unset
```

These controls confirm the recovered production service remained healthy; they are not claimed as validation of deployed proposal behavior.

### Independent review

A fresh read-only Fable 5 review of the complete diff returned `APPROVE` with no critical or blocking findings. Its non-blocking trade-offs are disclosed above: request-upload timing, per-slot cross-host pool rotation, pre-approval stale leases, and conservative no-retry behavior.

### Maintainer choice

The requested behavior in #493 is:

- no indefinitely pending upstream forward;
- controlled sanitized failure;
- automatic escape from suspect pooled client state;
- no TLS weakening;
- no unsafe request replay;
- no response-body timeout after headers.

This PR is a tested proposal for those properties. The maintainers are explicitly invited to implement #493 differently, adjust the defaults/configuration surface, request a smaller first patch, or use this branch only as a reproducer/reference.
