### PR TITLE
fix: restore GitHub-detectable Apache-2.0 LICENSE

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -9,10 +9,10 @@ project, collectively referred to as the "Parties."
 OneCLI is an open-source project. Most of this repository is licensed under
 the Apache License, Version 2.0, as set out in the [LICENSE](LICENSE) file;
 a set of enterprise features is licensed under the OneCLI Enterprise License,
-as set out in the [LICENSE-ENTERPRISE](LICENSE-ENTERPRISE) file. The LICENSE
-file carries the authoritative description of which parts of the repository
-each license covers. This CLA governs the rights in the contributions made by
-the Contributor to the OneCLI project.
+as set out in the [LICENSE-ENTERPRISE](LICENSE-ENTERPRISE) file. The
+LICENSE-ENTERPRISE file carries the authoritative description of which parts
+of the repository each license covers. This CLA governs the rights in the
+contributions made by the Contributor to the OneCLI project.
 
 ## Agreement
 
@@ -28,7 +28,7 @@ right and license to:
   including any intellectual property rights therein.
 - Incorporate the Contributions into other works or products.
 - License and re-license the Contributions, in whole or in part, under any
-  license at ChartDB's sole discretion — including the Apache License,
+  license at ChartDB's sole discretion, including the Apache License,
   Version 2.0 (as included in the LICENSE file), the OneCLI Enterprise
   License (as included in the LICENSE-ENTERPRISE file), or any other license,
   whether open source or proprietary, at any time in the future.
@@ -81,8 +81,8 @@ understandings, agreements, representations, and warranties.
 The Contributor accepts this CLA in either of two ways, each of which is
 individually sufficient:
 
-1. By signing it through the CLA Assistant flow on a pull request — replying
-   to the CLA Assistant comment with the sign phrase it asks for. The
+1. By signing it through the CLA Assistant flow on a pull request (replying
+   to the CLA Assistant comment with the sign phrase it asks for). The
    signature is recorded once against the Contributor's GitHub account and
    applies to all past and future Contributions.
 2. By submitting Contributions to the OneCLI project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,8 @@ Running these before you create the PR will help reduce back and forth during re
 
 This project is licensed under the [Apache License 2.0](LICENSE), with one
 exception: the `ee/` directories hold enterprise features under the [OneCLI
-Enterprise License](LICENSE-ENTERPRISE). See [LICENSE](LICENSE) for the exact
-paths. By contributing, you agree that your contributions will be licensed
+Enterprise License](LICENSE-ENTERPRISE), which enumerates the exact paths it
+covers. By contributing, you agree that your contributions will be licensed
 under the Apache License 2.0 as well.
 
 ---

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,3 @@
-OneCLI is licensed under the Apache License, Version 2.0, reproduced in full
-below, WITH THE FOLLOWING EXCEPTION.
-
-THE LICENSED PATHS. The list below is authoritative. This file is the only
-place the paths are enumerated. Every other document in this repository refers
-back to this list rather than restating it.
-
-    apps/web/src/ee/
-    packages/api/src/ee/
-    apps/gateway/src/ee/
-    apps/gateway/src/ee.rs
-
-Those paths are NOT covered by the Apache License. They contain enterprise
-features licensed under the OneCLI Enterprise License, set out in the
-LICENSE-ENTERPRISE file at the root of this repository. A notice pointing at
-that license is also placed in each of the licensed directories above.
-
-No rights under the Apache License, including the rights to use, reproduce,
-modify, distribute or sublicense, are granted with respect to those paths.
-Everything else in this repository is Apache-2.0 and may be self-hosted in
-production with no commercial license.
-
-See the NOTICE file for the same summary in attribution form.
-
--------------------------------------------------------------------------------
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE-ENTERPRISE
+++ b/LICENSE-ENTERPRISE
@@ -3,12 +3,26 @@ OneCLI Enterprise License
 Copyright (c) 2025-present ChartDB, Inc.
 
 This license governs the enterprise components of OneCLI. It applies ONLY to
-the paths enumerated under "THE LICENSED PATHS" in the LICENSE file at the root
-of this repository. Each of those directories carries a notice pointing back
-at this file, so the license travels with the code it covers.
+the paths enumerated below.
+
+THE LICENSED PATHS. The list below is authoritative. This file is the only
+place the paths are enumerated. Every other document in this repository refers
+back to this list rather than restating it.
+
+    apps/web/src/ee/
+    packages/api/src/ee/
+    apps/gateway/src/ee/
+    apps/gateway/src/ee.rs
+
+Those paths are NOT covered by the Apache License. No rights under the Apache
+License, including the rights to use, reproduce, modify, distribute or
+sublicense, are granted with respect to those paths. Each of the licensed
+directories carries a notice pointing back at this file, so the license
+travels with the code it covers.
 
 All other files in this repository are licensed under the Apache License,
-Version 2.0. See the LICENSE and NOTICE files at the root of the repository.
+Version 2.0, and may be self-hosted in production with no commercial license.
+See the LICENSE and NOTICE files at the root of the repository.
 
 Those enterprise components and their associated documentation files (the
 "Software") are licensed under the following terms:

--- a/NOTICE
+++ b/NOTICE
@@ -13,9 +13,9 @@ the root of this repository.
 Certain paths are NOT licensed under the Apache License. They contain
 enterprise features governed by the OneCLI Enterprise License
 (LICENSE-ENTERPRISE). Those paths are enumerated under "THE LICENSED PATHS" in
-the LICENSE file at the root of this repository, which is the authoritative
-list; a notice pointing at the enterprise license is also placed in each of
-the licensed directories.
+the LICENSE-ENTERPRISE file itself, which is the authoritative list; a notice
+pointing at the enterprise license is also placed in each of the licensed
+directories.
 
 The OneCLI Enterprise License permits use for development, testing, evaluation
 and internal non-production purposes. Production use of those components

--- a/README.md
+++ b/README.md
@@ -122,5 +122,5 @@ enterprise features under the [OneCLI Enterprise License](LICENSE-ENTERPRISE),
 each carrying a notice that points at it. That license is free for development,
 testing and evaluation, and requires a subscription for production use.
 Everything else is Apache-2.0 and can be self-hosted in production with no
-commercial license. [LICENSE](LICENSE) carries the authoritative list of
-licensed paths.
+commercial license. [LICENSE-ENTERPRISE](LICENSE-ENTERPRISE) carries the
+authoritative list of licensed paths.

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -2,8 +2,8 @@
 name = "onecli-gateway"
 version = "0.1.0"
 edition = "2021"
-# The crate embeds the licensed src/ee/ modules in every build — see /LICENSE
-# ("THE LICENSED PATHS") and /LICENSE-ENTERPRISE at the repository root.
+# The crate embeds the licensed src/ee/ modules in every build — see
+# /LICENSE-ENTERPRISE ("THE LICENSED PATHS") at the repository root.
 license = "Apache-2.0 AND LicenseRef-OneCLI-Enterprise"
 publish = false
 

--- a/apps/gateway/src/ee/LICENSE
+++ b/apps/gateway/src/ee/LICENSE
@@ -5,7 +5,7 @@ this repository. It contains enterprise features licensed under the OneCLI
 Enterprise License.
 
   Terms:      /LICENSE-ENTERPRISE at the root of this repository
-  Path list:  /LICENSE, under "THE LICENSED PATHS"
+  Path list:  /LICENSE-ENTERPRISE, under "THE LICENSED PATHS"
 
 That license permits development, testing, evaluation and internal
 non-production use. Production use requires a valid OneCLI Enterprise

--- a/apps/web/src/ee/LICENSE
+++ b/apps/web/src/ee/LICENSE
@@ -5,7 +5,7 @@ this repository. It contains enterprise features licensed under the OneCLI
 Enterprise License.
 
   Terms:      /LICENSE-ENTERPRISE at the root of this repository
-  Path list:  /LICENSE, under "THE LICENSED PATHS"
+  Path list:  /LICENSE-ENTERPRISE, under "THE LICENSED PATHS"
 
 That license permits development, testing, evaluation and internal
 non-production use. Production use requires a valid OneCLI Enterprise

--- a/packages/api/src/ee/LICENSE
+++ b/packages/api/src/ee/LICENSE
@@ -5,7 +5,7 @@ this repository. It contains enterprise features licensed under the OneCLI
 Enterprise License.
 
   Terms:      /LICENSE-ENTERPRISE at the root of this repository
-  Path list:  /LICENSE, under "THE LICENSED PATHS"
+  Path list:  /LICENSE-ENTERPRISE, under "THE LICENSED PATHS"
 
 That license permits development, testing, evaluation and internal
 non-production use. Production use requires a valid OneCLI Enterprise

--- a/packages/api/src/licensing/ee-boundary.test.ts
+++ b/packages/api/src/licensing/ee-boundary.test.ts
@@ -278,20 +278,24 @@ describe("enterprise-license boundary", () => {
 
   // ── The paperwork says what the code says ──────────────────────────────
   //
-  // The path list is authored ONCE, in the root LICENSE under "THE LICENSED
-  // PATHS", and every other document points at it. That is what keeps a
-  // rename from needing seven edits — but it only works if the one remaining
-  // copy cannot drift from `LICENSED_ROOTS`/`LICENSED_FILES`, which is what
-  // the boundary is actually enforced against. Prose that disagrees with the
-  // enforced boundary is worse than no prose: it is a written claim we do not
-  // honour.
-  it("the LICENSE path list is exactly the boundary the code enforces", () => {
+  // The path list is authored ONCE, in LICENSE-ENTERPRISE under "THE LICENSED
+  // PATHS", and every other document points at it. It lives in the enterprise
+  // license rather than the root LICENSE so the grant document defines its
+  // own scope and the Apache file stays the pristine, tool-recognizable text
+  // (GitHub's licensee needs a near-verbatim match to name it Apache-2.0).
+  // That is what keeps a rename from needing seven edits — but it only works
+  // if the one remaining copy cannot drift from
+  // `LICENSED_ROOTS`/`LICENSED_FILES`, which is what the boundary is actually
+  // enforced against. Prose that disagrees with the enforced boundary is
+  // worse than no prose: it is a written claim we do not honour.
+  it("the LICENSE-ENTERPRISE path list is exactly the boundary the code enforces", () => {
     const section = /THE LICENSED PATHS\.[\s\S]*?\n\n([\s\S]*?)\n\n/.exec(
-      read("LICENSE"),
+      read("LICENSE-ENTERPRISE"),
     );
-    expect(section, "LICENSE must carry a THE LICENSED PATHS block").not.toBe(
-      null,
-    );
+    expect(
+      section,
+      "LICENSE-ENTERPRISE must carry a THE LICENSED PATHS block",
+    ).not.toBe(null);
 
     const listed = (section?.[1] ?? "")
       .split("\n")
@@ -342,15 +346,28 @@ describe("enterprise-license boundary", () => {
     );
   });
 
-  // The documents that defer to LICENSE must actually say so. Without this a
-  // well-meaning edit re-inlines the list somewhere and the duplication grows
-  // back, one file at a time.
-  it("the other documents defer to LICENSE rather than restating the paths", () => {
-    for (const doc of ["NOTICE", "README.md", "CONTRIBUTING.md", "CLA.md"]) {
+  // The documents that defer to LICENSE-ENTERPRISE must actually say so, and
+  // the root LICENSE must never restate the paths — a preamble there is both
+  // duplication and exactly what broke GitHub's Apache-2.0 detection. Without
+  // this a well-meaning edit re-inlines the list somewhere and the
+  // duplication grows back, one file at a time.
+  it("the other documents defer to LICENSE-ENTERPRISE rather than restating the paths", () => {
+    for (const doc of [
+      "LICENSE",
+      "NOTICE",
+      "README.md",
+      "CONTRIBUTING.md",
+      "CLA.md",
+    ]) {
       const text = read(doc);
-      expect(text, `${doc} must point at LICENSE for the paths`).toMatch(
-        /LICENSE/,
-      );
+      // The root LICENSE is the one document that must not point anywhere:
+      // it stays the verbatim Apache text and mentions no other file.
+      if (doc !== "LICENSE") {
+        expect(
+          text,
+          `${doc} must point at LICENSE-ENTERPRISE for the paths`,
+        ).toMatch(/LICENSE-ENTERPRISE/);
+      }
       for (const root of LICENSED_ROOTS) {
         expect(text, `${doc} restates the licensed path ${root}`).not.toContain(
           root,


### PR DESCRIPTION
## What

GitHub stopped recognizing this repo as Apache-2.0 after v2: the release prepended a "THE LICENSED PATHS" preamble to `LICENSE`, dropping the file below licensee's similarity bar, so the repo shows two generic "License" entries instead of naming Apache-2.0.

This PR moves the authoritative licensed-path list into `LICENSE-ENTERPRISE` (the grant document now defines its own scope) and restores `LICENSE` to the verbatim Apache-2.0 text, byte-identical to the pre-v2 file GitHub detected, except the copyright-year fill. Every pointer flips to `LICENSE-ENTERPRISE`: `NOTICE`, `README.md`, `CONTRIBUTING.md`, `CLA.md`, the three `ee/*/LICENSE` notices, and the gateway `Cargo.toml` comment. `ee-boundary.test.ts` now parses the list from `LICENSE-ENTERPRISE`, and `LICENSE` joins the no-restate guard so a preamble cannot grow back unnoticed.

After this merges, the sidebar should read "Apache-2.0, License licenses found": Apache named first, the enterprise license still visible as the second entry.

## Why this is safe

The carve-out is unchanged in substance. It is still stated in `NOTICE` (whose content travels downstream with every redistribution under Apache 2.0 section 4(d)), `README`, `CONTRIBUTING`, `CLA`, and the per-directory `ee/*/LICENSE` notices attached to the licensed code itself. Apache-2.0 scopes the "Work" by attached notices (section 1), and the notice nearest the code controls. Single-source governance is preserved: the path list exists in exactly one file, and `ee-boundary.test.ts` pins it to the enforced boundary.

## Verification

- New `LICENSE` diffs byte-identical to the pre-v2 file (5e2a869) except the copyright-year fill
- Both reworked guards mutation-tested: re-adding a path to `LICENSE` fails the defer test; dropping a path from `LICENSE-ENTERPRISE` fails the path-list test
- Full licensing suite green (90 tests), plus lint / types / format / scripts suites and the gateway and web suites
