### PR TITLE
fix: user-chosen Slack transport, removable org workspaces in every state, agent-image upgrades on self-host

### DIFF
--- a/apps/web/src/app/(dashboard)/org/[orgId]/(admin)/channels/_components/slack-integration-card.test.tsx
+++ b/apps/web/src/app/(dashboard)/org/[orgId]/(admin)/channels/_components/slack-integration-card.test.tsx
@@ -153,7 +153,7 @@ describe("the disconnect confirm", () => {
 });
 
 describe("needs credentials", () => {
-  it("says the token died and offers the re-paste", () => {
+  it("says the token died, offers the re-paste — and still offers removal", () => {
     state.view = view({
       integrations: [
         integration({ hasCredentials: false, needsCredentials: true }),
@@ -167,9 +167,87 @@ describe("needs credentials", () => {
     expect(
       screen.getByLabelText("App Configuration refresh token"),
     ).toBeInTheDocument();
+    // The dead-token state must not strand the row: Remove clears the expired
+    // credential (and deletes the row once nothing references it).
     expect(
       screen.queryByRole("button", { name: "Disconnect" }),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+  });
+});
+
+describe("removal in every state", () => {
+  it("removes an unreferenced credential-less workspace row from the dialog", async () => {
+    const user = userEvent.setup();
+    mocks.disconnect.mockImplementation(
+      (_provider: string, opts: { onSuccess: () => void }) => opts.onSuccess(),
+    );
+    state.view = view({
+      integrations: [
+        integration({
+          hasCredentials: false,
+          needsCredentials: false,
+          presenceCount: 0,
+        }),
+      ],
+    });
+    render(<SlackIntegrationCard />);
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    const dialog = screen.getByRole("alertdialog");
+    expect(
+      within(dialog).getByText(/removes the workspace connection/),
+    ).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+    expect(mocks.disconnect).toHaveBeenCalledWith("slack", expect.anything());
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("shows an explainer instead of a dead button when removal would change nothing", () => {
+    // No credential to clear, no dead-token notice, and the row survives while
+    // referenced — a Remove here would be a silent no-op.
+    state.view = view({
+      integrations: [
+        integration({
+          hasCredentials: false,
+          needsCredentials: false,
+          presenceCount: 2,
+        }),
+      ],
+    });
+    render(<SlackIntegrationCard />);
+
+    expect(
+      screen.queryByRole("button", { name: "Remove" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/stays listed while it's still in use: 2 agent apps/),
+    ).toBeInTheDocument();
+  });
+
+  it("tells a referenced disconnect what keeps the row listed, member links included", async () => {
+    const user = userEvent.setup();
+    state.view = view({
+      integrations: [integration({ presenceCount: 1 })],
+      userLinks: [
+        {
+          id: "l1",
+          externalUserId: "U1",
+          linkedVia: "manual",
+          createdAt: new Date().toISOString(),
+          user: { id: "u1", email: "a@b.c", name: null },
+          integration: { provider: "slack" },
+        },
+      ],
+    });
+    render(<SlackIntegrationCard />);
+
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+    const dialog = screen.getByRole("alertdialog");
+    expect(
+      within(dialog).getByText(/1 agent app and 1 member link/),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/app/(dashboard)/org/[orgId]/(admin)/channels/_components/slack-integration-card.tsx
+++ b/apps/web/src/app/(dashboard)/org/[orgId]/(admin)/channels/_components/slack-integration-card.tsx
@@ -39,7 +39,10 @@ import {
  * is automatic server-side; when it fails, `needsCredentials` surfaces the
  * amber re-paste state. A workspace connected only through hand-made apps
  * (the paste floor) appears here too, with the paste form as its upgrade
- * path.
+ * path. Removal exists in every state: Disconnect (live credential) or
+ * Remove (dead/absent credential) — the server deletes the row only when no
+ * agent apps or member links reference it, so the dialog says which outcome
+ * the click buys.
  */
 export const SlackIntegrationCard = () => {
   const { data, isPending } = useOrgChannels();
@@ -51,6 +54,52 @@ export const SlackIntegrationCard = () => {
   const slack = data?.integrations.find((i) => i.provider === "slack");
   const showAdapterOffline =
     data !== undefined && data.integrations.length > 0 && !data.adapter.online;
+
+  // What keeps the workspace row alive: the server deletes it only when no
+  // agent apps and no member links reference it — otherwise a disconnect
+  // clears the credential and the row stays listed.
+  const slackLinkCount =
+    data?.userLinks.filter((l) => l.integration.provider === "slack").length ??
+    0;
+  const referenced = (slack?.presenceCount ?? 0) > 0 || slackLinkCount > 0;
+  const willDelete = !referenced;
+  const usage = [
+    slack && slack.presenceCount > 0
+      ? `${slack.presenceCount} agent app${slack.presenceCount === 1 ? "" : "s"}`
+      : null,
+    slackLinkCount > 0
+      ? `${slackLinkCount} member link${slackLinkCount === 1 ? "" : "s"}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" and ");
+  // The one state where the DELETE would change nothing: no credential to
+  // clear, no dead-token notice to resolve, and the row survives regardless.
+  const removeIsNoop =
+    slack !== undefined &&
+    !slack.hasCredentials &&
+    !slack.needsCredentials &&
+    referenced;
+
+  const hasCredentials = slack?.hasCredentials ?? false;
+  const dialogDescription = [
+    hasCredentials
+      ? "One-click agent setup stops working. Agents already attached keep their own tokens and stay in Slack."
+      : null,
+    !hasCredentials && slack?.needsCredentials && !willDelete
+      ? "This clears the expired credential."
+      : null,
+    willDelete
+      ? "This removes the workspace connection from your organization."
+      : `The workspace stays listed while it's still in use: ${usage}. Detach those to remove it completely.`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const successToast = willDelete
+    ? "Slack workspace removed"
+    : hasCredentials
+      ? "Slack disconnected"
+      : "Expired credential cleared";
 
   const submitToken = (e: React.FormEvent) => {
     e.preventDefault();
@@ -178,8 +227,26 @@ export const SlackIntegrationCard = () => {
                 </Button>
               ) : (
                 // Connected via hand-made apps only, or the credential died —
-                // either way the paste form is the way (back) to one-click.
-                pasteForm
+                // either way the paste form is the way (back) to one-click,
+                // and removal must not depend on holding a live credential.
+                <>
+                  {pasteForm}
+                  {removeIsNoop ? (
+                    <p className="text-muted-foreground text-sm">
+                      This workspace stays listed while it&apos;s still in use:{" "}
+                      {usage}. Detach those to remove it.
+                    </p>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => setConfirmOpen(true)}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </>
               )}
             </>
           )}
@@ -195,11 +262,10 @@ export const SlackIntegrationCard = () => {
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Disconnect Slack?</AlertDialogTitle>
-            <AlertDialogDescription>
-              One-click agent setup stops working. Agents already attached keep
-              their own tokens and stay in Slack.
-            </AlertDialogDescription>
+            <AlertDialogTitle>
+              {hasCredentials ? "Disconnect Slack?" : "Remove Slack workspace?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>{dialogDescription}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={disconnect.isPending}>
@@ -213,7 +279,7 @@ export const SlackIntegrationCard = () => {
                 e.preventDefault();
                 disconnect.mutate("slack", {
                   onSuccess: () => {
-                    toast.success("Slack disconnected");
+                    toast.success(successToast);
                     setConfirmOpen(false);
                   },
                   onError: (err) => toast.error(err.message),
@@ -223,7 +289,13 @@ export const SlackIntegrationCard = () => {
               {disconnect.isPending && (
                 <Loader2 className="animate-spin" aria-hidden />
               )}
-              {disconnect.isPending ? "Disconnecting…" : "Disconnect"}
+              {disconnect.isPending
+                ? hasCredentials
+                  ? "Disconnecting…"
+                  : "Removing…"
+                : hasCredentials
+                  ? "Disconnect"
+                  : "Remove"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/channels-section.test.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/channels-section.test.tsx
@@ -68,7 +68,7 @@ const view = (
   overrides: Partial<AgentChannelsView> = {},
 ): AgentChannelsView => ({
   presences: [],
-  posture: { transport: "events" },
+  posture: { transport: "events", available: ["events"] },
   orgIntegrations: [
     { provider: "slack", connected: true, hasCredentials: true },
   ],
@@ -114,10 +114,30 @@ describe("the guided events arm", () => {
   });
 });
 
+describe("the mode picker", () => {
+  it("appears when the deployment offers both transports", () => {
+    state.view = view({
+      posture: { transport: "events", available: ["events", "socket"] },
+    });
+    renderSection();
+
+    expect(
+      screen.getByRole("radiogroup", { name: "Connection mode" }),
+    ).toBeInTheDocument();
+  });
+
+  it("stays hidden when only one transport is available", () => {
+    renderSection();
+    expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+  });
+});
+
 describe("the guided socket arm", () => {
   it("walks the two-step token list once the app exists, and completes with both tokens", async () => {
     const user = userEvent.setup();
-    state.view = view({ posture: { transport: "socket" } });
+    state.view = view({
+      posture: { transport: "socket", available: ["socket"] },
+    });
     state.attachData = {
       presenceId: "pr1",
       transport: "socket",
@@ -166,7 +186,7 @@ describe("the paste floor (no org credential)", () => {
   it("swaps the signing secret for the app-level token on the SOCKET floor", () => {
     state.view = view({
       orgIntegrations: [],
-      posture: { transport: "socket" },
+      posture: { transport: "socket", available: ["socket"] },
     });
     renderSection();
 
@@ -187,7 +207,14 @@ describe("the paste floor (no org credential)", () => {
     await user.click(screen.getByRole("button", { name: "Finish setup" }));
 
     expect(mocks.complete).toHaveBeenCalledWith(
-      { botToken: "xoxb-bot", appId: "A999", signingSecret: "sig" },
+      {
+        botToken: "xoxb-bot",
+        appId: "A999",
+        signingSecret: "sig",
+        // The server advertised `available`, so the wire names the effective
+        // transport explicitly (here the deployment default).
+        transport: "events",
+      },
       expect.anything(),
     );
   });

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/channels-section.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/channels-section.tsx
@@ -134,9 +134,10 @@ export const ChannelsSection = () => {
       ) : (
         <SlackAttachCard
           agentId={agent.id}
+          posture={data.posture}
           // A pending presence resumes on ITS transport (the provider-side app
-          // baked one in); a fresh attach uses the deployment's posture.
-          transport={slack?.transport ?? data.posture.transport}
+          // baked one in); a fresh attach starts from the deployment's posture.
+          pendingTransport={slack?.transport}
           hasOrgCredentials={hasOrgCredentials}
           resuming={slack?.status === "pending_setup"}
         />

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-attach-card.test.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-attach-card.test.tsx
@@ -2,7 +2,7 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { CreatePresenceResult } from "@/lib/api";
+import type { ChannelTransport, CreatePresenceResult } from "@/lib/api";
 
 /**
  * The events-arm popup dance: the install popup must open *synchronously* inside
@@ -10,6 +10,12 @@ import type { CreatePresenceResult } from "@/lib/api";
  * survives a popup blocker — then be pointed at the URL on success. When the
  * browser blocks it even so, a plain install link takes over (a fresh gesture).
  * The socket "Create app" arm opens nothing.
+ *
+ * The mode picker: shown only when the server offers a real choice
+ * (`posture.available` has both) and nothing is pinned by a pending row; its
+ * choice rides the attach body — and is NEVER sent to a server that offered
+ * no choice (an old server reads no attach body and would silently stamp its
+ * own default).
  */
 
 const state = vi.hoisted(() => ({
@@ -19,21 +25,27 @@ const state = vi.hoisted(() => ({
 
 const mocks = vi.hoisted(() => ({
   attach: vi.fn(),
+  attachReset: vi.fn(),
   detach: vi.fn(),
+  complete: vi.fn(),
+  manifestHook: vi.fn(),
   toastError: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-channels", () => ({
   useAttachChannel: () => ({
     mutate: mocks.attach,
+    reset: mocks.attachReset,
     isPending: state.isPending,
     data: state.attachData,
   }),
   useDetachChannel: () => ({ mutate: mocks.detach, isPending: false }),
-  // Stubs for the child arms — never rendered in these branches, but the tree
-  // imports them.
-  useCompleteChannel: () => ({ mutate: vi.fn(), isPending: false }),
-  useChannelManifest: () => ({ data: undefined, isPending: false }),
+  // The floor's hooks — arg-recording so the picker→floor wire is provable.
+  useCompleteChannel: () => ({ mutate: mocks.complete, isPending: false }),
+  useChannelManifest: (...args: unknown[]) => {
+    mocks.manifestHook(...args);
+    return { data: undefined, isPending: false };
+  },
 }));
 
 vi.mock("sonner", () => ({
@@ -52,6 +64,11 @@ const result = (
   ...overrides,
 });
 
+const posture = (
+  transport: ChannelTransport,
+  available?: ChannelTransport[],
+) => ({ transport, ...(available && { available }) });
+
 // The mutate mock hands back the `onSuccess` it was called with, so a test can
 // drive the create's resolution by hand and prove the popup opened first.
 let onSuccess: ((r: CreatePresenceResult) => void) | undefined;
@@ -63,12 +80,16 @@ beforeEach(() => {
   mocks.attach.mockReset();
   mocks.attach.mockImplementation(
     (
-      _input: undefined,
+      _input: { transport?: ChannelTransport } | undefined,
       opts: { onSuccess: (r: CreatePresenceResult) => void },
     ) => {
       onSuccess = opts.onSuccess;
     },
   );
+  mocks.attachReset.mockClear();
+  mocks.detach.mockReset();
+  mocks.complete.mockClear();
+  mocks.manifestHook.mockClear();
   mocks.toastError.mockClear();
 });
 
@@ -86,7 +107,7 @@ describe("the events arm popup", () => {
     render(
       <SlackAttachCard
         agentId="ag-1"
-        transport="events"
+        posture={posture("events", ["events"])}
         hasOrgCredentials
         resuming={false}
       />,
@@ -115,7 +136,7 @@ describe("the events arm popup", () => {
     render(
       <SlackAttachCard
         agentId="ag-1"
-        transport="events"
+        posture={posture("events", ["events"])}
         hasOrgCredentials
         resuming={false}
       />,
@@ -140,7 +161,7 @@ describe("the events arm popup", () => {
     render(
       <SlackAttachCard
         agentId="ag-1"
-        transport="socket"
+        posture={posture("socket", ["socket"])}
         hasOrgCredentials
         resuming={false}
       />,
@@ -149,6 +170,171 @@ describe("the events arm popup", () => {
     await user.click(screen.getByRole("button", { name: "Create app" }));
     expect(open).not.toHaveBeenCalled();
     expect(mocks.attach).toHaveBeenCalledOnce();
+  });
+});
+
+describe("the mode picker", () => {
+  it("renders only when the server offers both transports", () => {
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events", ["events", "socket"])}
+        hasOrgCredentials
+        resuming={false}
+      />,
+    );
+    expect(
+      screen.getByRole("radiogroup", { name: "Connection mode" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Webhooks/ })).toBeChecked();
+  });
+
+  it.each([
+    ["a single available transport", posture("events", ["events"])],
+    ["an old server that sends no availability", posture("events")],
+  ])("hides the picker for %s", (_name, p) => {
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={p}
+        hasOrgCredentials
+        resuming={false}
+      />,
+    );
+    expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+  });
+
+  it("hides the picker while resuming — the pending row pinned the mode", () => {
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events", ["events", "socket"])}
+        pendingTransport="socket"
+        hasOrgCredentials
+        resuming
+      />,
+    );
+    expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+    // And the arm follows the row's stamp, not the deployment default.
+    expect(
+      screen.getByRole("button", { name: "Resume setup" }),
+    ).toBeInTheDocument();
+  });
+
+  it("sends the picked transport on attach — and resets a stale create on flip", async () => {
+    vi.stubGlobal(
+      "open",
+      vi.fn(() => null),
+    );
+    const user = userEvent.setup();
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events", ["events", "socket"])}
+        hasOrgCredentials
+        resuming={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: /Socket Mode/ }));
+    // A create result belongs to the mode it was made for.
+    expect(mocks.attachReset).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Create app" }));
+    expect(mocks.attach.mock.calls[0]?.[0]).toEqual({ transport: "socket" });
+  });
+
+  it("sends NO transport when the server offered no choice (old-server skew)", async () => {
+    const popup = { location: { href: "" }, close: vi.fn() };
+    vi.stubGlobal(
+      "open",
+      vi.fn(() => popup as unknown as Window),
+    );
+    const user = userEvent.setup();
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events")}
+        hasOrgCredentials
+        resuming={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add to Slack" }));
+    expect(mocks.attach.mock.calls[0]?.[0]).toBeUndefined();
+  });
+
+  it("threads the picked transport into the floor's manifest fetch and complete body", async () => {
+    const user = userEvent.setup();
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events", ["events", "socket"])}
+        hasOrgCredentials={false}
+        resuming={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: /Socket Mode/ }));
+    // The manifest is refetched for the picked mode — the server bakes the
+    // transport into the document, so a stale one is a wrong one.
+    expect(mocks.manifestHook).toHaveBeenLastCalledWith(
+      "ag-1",
+      "slack",
+      true,
+      "socket",
+    );
+
+    await user.type(screen.getByLabelText("Bot token"), "xoxb-bot");
+    await user.type(screen.getByLabelText("App-level token"), "xapp-1");
+    await user.type(screen.getByLabelText("App ID"), "A999");
+    await user.click(screen.getByRole("button", { name: "Finish setup" }));
+    // MUTATION-TESTED wire: drop the floor's transport spread and this fails —
+    // the server would stamp the deployment default, not the user's pick.
+    expect(mocks.complete.mock.calls[0]?.[0]).toEqual({
+      botToken: "xoxb-bot",
+      appToken: "xapp-1",
+      appId: "A999",
+      transport: "socket",
+    });
+  });
+
+  it("fetches the floor's manifest for the pending row's stamp on resume", () => {
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events", ["events", "socket"])}
+        pendingTransport="socket"
+        hasOrgCredentials={false}
+        resuming
+      />,
+    );
+    // The picker is hidden, but the wire still carries the ROW's transport —
+    // otherwise the floor shows the drifted deployment default's manifest
+    // beside the stamped mode's paste fields.
+    expect(mocks.manifestHook).toHaveBeenLastCalledWith(
+      "ag-1",
+      "slack",
+      true,
+      "socket",
+    );
+  });
+
+  it("gates the socket steps on the CREATE's transport, not the picker", () => {
+    // A stale events create must not satisfy the socket arm after a flip.
+    state.attachData = result({ transport: "events" });
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("socket", ["events", "socket"])}
+        hasOrgCredentials
+        resuming={false}
+      />,
+    );
+    expect(screen.queryByText(/app-level token/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create app" }),
+    ).toBeInTheDocument();
   });
 });
 
@@ -162,7 +348,8 @@ describe("the resume escape hatch", () => {
     render(
       <SlackAttachCard
         agentId="ag-1"
-        transport="socket"
+        posture={posture("socket", ["socket"])}
+        pendingTransport="socket"
         hasOrgCredentials
         resuming
       />,
@@ -173,11 +360,71 @@ describe("the resume escape hatch", () => {
     expect(mocks.detach.mock.calls[0]?.[0]).toEqual({ deleteRemote: true });
   });
 
+  it("clears the stale create result when Start over succeeds", async () => {
+    mocks.detach.mockImplementation(
+      (_input: unknown, opts: { onSuccess: () => void }) => opts.onSuccess(),
+    );
+    const user = userEvent.setup();
+    render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("socket", ["socket"])}
+        pendingTransport="socket"
+        hasOrgCredentials
+        resuming
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Start over" }));
+    // The dead app's URLs must not survive into the next attempt.
+    expect(mocks.attachReset).toHaveBeenCalled();
+  });
+
+  it("clears the blocked-install fallback link when Start over succeeds", async () => {
+    vi.stubGlobal(
+      "open",
+      vi.fn(() => null),
+    );
+    mocks.detach.mockImplementation(
+      (_input: unknown, opts: { onSuccess: () => void }) => opts.onSuccess(),
+    );
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events", ["events"])}
+        hasOrgCredentials
+        resuming={false}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Add to Slack" }));
+    act(() => onSuccess?.(result({ installUrl: "https://slack.com/install" })));
+    expect(
+      screen.getByRole("link", { name: /Slack install page/i }),
+    ).toBeInTheDocument();
+
+    // The create left a pending row — the section re-renders us as resuming.
+    rerender(
+      <SlackAttachCard
+        agentId="ag-1"
+        posture={posture("events", ["events"])}
+        pendingTransport="events"
+        hasOrgCredentials
+        resuming
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Start over" }));
+    // The DELETED app's install URL must not survive as a clickable link.
+    expect(
+      screen.queryByRole("link", { name: /Slack install page/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows no Start over on a fresh (non-resuming) card", () => {
     render(
       <SlackAttachCard
         agentId="ag-1"
-        transport="socket"
+        posture={posture("socket", ["socket"])}
         hasOrgCredentials
         resuming={false}
       />,

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-attach-card.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-attach-card.tsx
@@ -15,12 +15,15 @@ import type { ChannelTransport } from "@/lib/api";
 import { useAttachChannel, useDetachChannel } from "@/hooks/use-channels";
 import { SlackGuidedSocketSteps } from "./slack-guided-socket-steps";
 import { SlackManifestFloor } from "./slack-manifest-floor";
+import { SlackTransportPicker } from "./slack-transport-picker";
 
 interface SlackAttachCardProps {
   agentId: string;
-  /** The transport an attach would use — the pending presence's own when
-   * resuming, else the deployment posture. */
-  transport: ChannelTransport;
+  /** The deployment's transport posture: the default and (on servers that
+   * offer a choice) the alternatives. */
+  posture: { transport: ChannelTransport; available?: ChannelTransport[] };
+  /** A pending presence resumes on ITS stamped transport. */
+  pendingTransport?: ChannelTransport;
   hasOrgCredentials: boolean;
   /** A `pending_setup` presence exists: re-running create returns fresh URLs. */
   resuming: boolean;
@@ -51,16 +54,22 @@ const openInstallPopup = (): Window | null => {
  * The unattached (and resume) face of the Slack card. Three arms, decided by
  * what the org holds and how events can reach us: one-click install (events +
  * org credential), guided create + token paste (socket + org credential), or
- * the manifest paste floor (no org credential at all).
+ * the manifest paste floor (no org credential at all). When the deployment
+ * can serve both transports, a mode picker sits above the arms — the mode is
+ * baked into the Slack app at create time, so it is chosen up front.
  */
 export const SlackAttachCard = ({
   agentId,
-  transport,
+  posture,
+  pendingTransport,
   hasOrgCredentials,
   resuming,
 }: SlackAttachCardProps) => {
   const attach = useAttachChannel(agentId, "slack");
   const detach = useDetachChannel(agentId, "slack");
+  const [picked, setPicked] = useState<ChannelTransport>(
+    pendingTransport ?? posture.transport,
+  );
   // Set only when the events-arm popup was blocked despite opening inside the
   // click: the install URL is then offered as a plain link, whose click is a
   // fresh user gesture the blocker won't eat.
@@ -68,11 +77,37 @@ export const SlackAttachCard = ({
     null,
   );
 
+  // The picker renders only when the server offers a real choice (older
+  // servers send no `available`) and nothing is pinned by a pending row.
+  const showPicker = (posture.available?.length ?? 1) > 1 && !resuming;
+  // A resume is pinned to the row's stamp; a fresh attach follows the picker.
+  const transport = resuming && pendingTransport ? pendingTransport : picked;
+  // The wire carries the EFFECTIVE transport whenever the server understands
+  // it (`available` present) — including a resume, so the floor's manifest is
+  // fetched for the row's stamp, not the drifted deployment default. Older
+  // servers get nothing: the old attach route reads no body (the choice would
+  // be silently ignored) and the old strict complete schema rejects the key.
+  const requestedTransport = posture.available ? transport : undefined;
+
+  const pickTransport = (next: ChannelTransport) => {
+    setPicked(next);
+    // A create result belongs to the mode it was made for — a stale one must
+    // not drop the user into the other mode's steps.
+    attach.reset();
+    setBlockedInstallUrl(null);
+  };
+
   const startOver = () => {
     detach.mutate(
       { deleteRemote: true },
       {
-        onSuccess: () => toast.success("Setup cleared."),
+        onSuccess: () => {
+          // The dead app's URLs must not survive into the next attempt —
+          // neither the create result nor the blocked-popup fallback link.
+          attach.reset();
+          setBlockedInstallUrl(null);
+          toast.success("Setup cleared.");
+        },
         onError: (err) => toast.error(err.message),
       },
     );
@@ -87,28 +122,31 @@ export const SlackAttachCard = ({
     // The socket "Create app" has no install URL and opens nothing.
     const popup = transport === "events" ? openInstallPopup() : null;
 
-    attach.mutate(undefined, {
-      onSuccess: (result) => {
-        if (!result.installUrl) {
+    attach.mutate(
+      requestedTransport ? { transport: requestedTransport } : undefined,
+      {
+        onSuccess: (result) => {
+          if (!result.installUrl) {
+            popup?.close();
+            return;
+          }
+          if (popup) {
+            popup.location.href = result.installUrl;
+          } else if (transport === "events") {
+            // Blocked despite the in-gesture open — fall back to a link.
+            setBlockedInstallUrl(result.installUrl);
+            toast.error(
+              "Your browser blocked the Slack popup. Use the link below to continue.",
+            );
+          }
+        },
+        // The 422 ("no automation token") and friends carry a server sentence.
+        onError: (err) => {
           popup?.close();
-          return;
-        }
-        if (popup) {
-          popup.location.href = result.installUrl;
-        } else if (transport === "events") {
-          // Blocked despite the in-gesture open — fall back to a link.
-          setBlockedInstallUrl(result.installUrl);
-          toast.error(
-            "Your browser blocked the Slack popup. Use the link below to continue.",
-          );
-        }
+          toast.error(err.message);
+        },
       },
-      // The 422 ("no automation token") and friends carry a server sentence.
-      onError: (err) => {
-        popup?.close();
-        toast.error(err.message);
-      },
-    });
+    );
   };
 
   return (
@@ -140,9 +178,17 @@ export const SlackAttachCard = ({
           </div>
         )}
 
+        {showPicker && (
+          <SlackTransportPicker value={picked} onValueChange={pickTransport} />
+        )}
+
         {!hasOrgCredentials ? (
-          <SlackManifestFloor agentId={agentId} transport={transport} />
-        ) : transport === "socket" && attach.data ? (
+          <SlackManifestFloor
+            agentId={agentId}
+            transport={transport}
+            requestedTransport={requestedTransport}
+          />
+        ) : attach.data?.transport === "socket" ? (
           <SlackGuidedSocketSteps
             agentId={agentId}
             settingsUrl={attach.data.settingsUrl}

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-manifest-floor.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-manifest-floor.tsx
@@ -16,6 +16,9 @@ import { InstallStep } from "@/app/(dashboard)/w/[workspaceId]/settings/install/
 interface SlackManifestFloorProps {
   agentId: string;
   transport: ChannelTransport;
+  /** The picker's choice, sent on the wire only when the server offers one
+   * (undefined on older servers, whose strict schemas reject unknown keys). */
+  requestedTransport?: ChannelTransport;
 }
 
 /**
@@ -27,8 +30,14 @@ interface SlackManifestFloorProps {
 export const SlackManifestFloor = ({
   agentId,
   transport,
+  requestedTransport,
 }: SlackManifestFloorProps) => {
-  const manifestQuery = useChannelManifest(agentId, "slack", true);
+  const manifestQuery = useChannelManifest(
+    agentId,
+    "slack",
+    true,
+    requestedTransport,
+  );
   const complete = useCompleteChannel(agentId, "slack");
   const { copied, copy } = useCopyToClipboard();
 
@@ -55,6 +64,7 @@ export const SlackManifestFloor = ({
         ...(socket
           ? { appToken: appToken.trim() }
           : { signingSecret: signingSecret.trim() }),
+        ...(requestedTransport && { transport: requestedTransport }),
       },
       {
         onSuccess: () => toast.success("Slack connected"),

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-transport-picker.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/channels/_components/slack-transport-picker.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { cn } from "@onecli/ui/lib/utils";
+import type { ChannelTransport } from "@/lib/api";
+import { selectableCard } from "@/lib/onboarding/_components/selectable";
+
+interface SlackTransportPickerProps {
+  value: ChannelTransport;
+  onValueChange: (transport: ChannelTransport) => void;
+}
+
+const OPTIONS: {
+  transport: ChannelTransport;
+  title: string;
+  description: string;
+}[] = [
+  {
+    transport: "events",
+    title: "Webhooks",
+    description:
+      "Slack calls your deployment over public HTTPS. One-click install.",
+  },
+  {
+    transport: "socket",
+    title: "Socket Mode",
+    description:
+      "Your deployment connects out to Slack. Works without a public URL.",
+  },
+];
+
+/**
+ * The connection-mode choice, shown only when the deployment can serve more
+ * than one transport (a TLS'd self-host). The mode is baked into the Slack
+ * app at create time, so this is decided before the attach starts.
+ *
+ * Full WAI-ARIA radio contract (the secret-dialog "Inject as" precedent):
+ * roving tabindex + arrow-key movement — announcing `radio` without them
+ * promises an interaction that never comes.
+ */
+export const SlackTransportPicker = ({
+  value,
+  onValueChange,
+}: SlackTransportPickerProps) => (
+  <div
+    role="radiogroup"
+    aria-label="Connection mode"
+    className="grid gap-2 sm:grid-cols-2"
+    onKeyDown={(e) => {
+      if (!["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp"].includes(e.key))
+        return;
+      e.preventDefault();
+      const delta = e.key === "ArrowRight" || e.key === "ArrowDown" ? 1 : -1;
+      const current = OPTIONS.findIndex((o) => o.transport === value);
+      const nextIdx = (current + delta + OPTIONS.length) % OPTIONS.length;
+      const next = OPTIONS[nextIdx];
+      if (!next) return;
+      onValueChange(next.transport);
+      e.currentTarget
+        .querySelectorAll<HTMLButtonElement>('[role="radio"]')
+        [nextIdx]?.focus();
+    }}
+  >
+    {OPTIONS.map((option) => (
+      <button
+        key={option.transport}
+        type="button"
+        role="radio"
+        aria-checked={value === option.transport}
+        tabIndex={value === option.transport ? 0 : -1}
+        onClick={() => onValueChange(option.transport)}
+        className={cn(
+          "rounded-lg p-3 text-left",
+          selectableCard(value === option.transport),
+        )}
+      >
+        <span className="block text-sm font-medium">{option.title}</span>
+        <span className="text-muted-foreground mt-0.5 block text-xs">
+          {option.description}
+        </span>
+      </button>
+    ))}
+  </div>
+);

--- a/apps/web/src/hooks/use-channels.test.tsx
+++ b/apps/web/src/hooks/use-channels.test.tsx
@@ -40,7 +40,7 @@ describe("channel mutations sweep the agents ROOT (not the scoped all())", () =>
     const { result } = renderHook(() => useAttachChannel("ag-1", "slack"), {
       wrapper,
     });
-    await result.current.mutateAsync();
+    await result.current.mutateAsync(undefined);
     expect(sweptKeys()).toContainEqual(queryKeys.agents.root());
     expect(sweptKeys()).toContainEqual(queryKeys.channels.all());
   });

--- a/apps/web/src/hooks/use-channels.ts
+++ b/apps/web/src/hooks/use-channels.ts
@@ -2,7 +2,11 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { channels } from "@/lib/api";
-import type { ChannelProvider, CompletePresenceInput } from "@/lib/api";
+import type {
+  ChannelProvider,
+  ChannelTransport,
+  CompletePresenceInput,
+} from "@/lib/api";
 import { queryKeys } from "@/lib/api/keys";
 
 // Channel mutations are headless (the use-app-config convention): the callers
@@ -19,15 +23,17 @@ export const useAgentChannels = (agentId: string) =>
     queryFn: () => channels.agentView(agentId),
   });
 
-/** The paste floor's step 0 — fetched only while the floor is on screen. */
+/** The paste floor's step 0 — fetched only while the floor is on screen.
+ * Keyed by the chosen transport: the manifest bakes it in. */
 export const useChannelManifest = (
   agentId: string,
   provider: ChannelProvider,
   enabled: boolean,
+  transport?: ChannelTransport,
 ) =>
   useQuery({
-    queryKey: queryKeys.channels.manifest(agentId, provider),
-    queryFn: () => channels.manifest(agentId, provider),
+    queryKey: queryKeys.channels.manifest(agentId, provider, transport),
+    queryFn: () => channels.manifest(agentId, provider, transport),
     enabled,
   });
 
@@ -39,7 +45,8 @@ export const useAttachChannel = (
 ) => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => channels.attach(agentId, provider),
+    mutationFn: (input: { transport?: ChannelTransport } | undefined) =>
+      channels.attach(agentId, provider, input),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.channels.all() });
       // The agent lists carry the attached channels (the connected marks,

--- a/apps/web/src/lib/api/channels.ts
+++ b/apps/web/src/lib/api/channels.ts
@@ -35,8 +35,9 @@ export interface AgentChannelPresence {
 
 export interface AgentChannelsView {
   presences: AgentChannelPresence[];
-  /** What an attach would use right now. */
-  posture: { transport: ChannelTransport };
+  /** What an attach would use right now — and, on servers that offer a
+   * choice, what it could use instead (absent on older servers). */
+  posture: { transport: ChannelTransport; available?: ChannelTransport[] };
   orgIntegrations: {
     provider: ChannelProvider;
     connected: boolean;
@@ -66,6 +67,9 @@ export interface CompletePresenceInput {
   appToken?: string;
   signingSecret?: string;
   appId?: string;
+  /** The floor's chosen mode — sent only when the server offers a choice
+   * (`posture.available` present); older strict servers reject unknown keys. */
+  transport?: ChannelTransport;
 }
 
 /** The completion door's echo of the activated presence row. */
@@ -115,12 +119,30 @@ const agentBase = (agentId: string, sub = "") =>
 export const agentView = (agentId: string) =>
   apiGet<AgentChannelsView>(agentBase(agentId));
 
-export const manifest = (agentId: string, provider: ChannelProvider) =>
-  apiGet<ChannelSetupMaterial>(agentBase(agentId, `/${provider}/manifest`));
+export const manifest = (
+  agentId: string,
+  provider: ChannelProvider,
+  transport?: ChannelTransport,
+) =>
+  apiGet<ChannelSetupMaterial>(
+    agentBase(
+      agentId,
+      `/${provider}/manifest${transport ? `?transport=${transport}` : ""}`,
+    ),
+  );
 
-/** The guided arm: create the provider app from the org credential. */
-export const attach = (agentId: string, provider: ChannelProvider) =>
-  apiPost<CreatePresenceResult>(agentBase(agentId, `/${provider}`), {});
+/** The guided arm: create the provider app from the org credential. The
+ * transport rides along only when the server offers a choice (older servers
+ * read no body and would silently stamp their own default). */
+export const attach = (
+  agentId: string,
+  provider: ChannelProvider,
+  input?: { transport?: ChannelTransport },
+) =>
+  apiPost<CreatePresenceResult>(
+    agentBase(agentId, `/${provider}`),
+    input ?? {},
+  );
 
 /** The pasted-tokens completion door (socket arm + the whole paste floor). */
 export const complete = (

--- a/apps/web/src/lib/api/keys.ts
+++ b/apps/web/src/lib/api/keys.ts
@@ -217,8 +217,16 @@ export const queryKeys = {
     all: () => ["channels", ...scope()] as const,
     agent: (agentId: string) =>
       [...queryKeys.channels.all(), "agent", agentId] as const,
-    manifest: (agentId: string, provider: string) =>
-      [...queryKeys.channels.all(), "manifest", agentId, provider] as const,
+    manifest: (agentId: string, provider: string, transport?: string) =>
+      [
+        ...queryKeys.channels.all(),
+        "manifest",
+        agentId,
+        provider,
+        // Part of the key: flipping the mode picker must refetch, never serve
+        // the other transport's cached manifest.
+        transport ?? "default",
+      ] as const,
     org: () => [...queryKeys.channels.all(), "org"] as const,
   },
   appBlocklist: {

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -35,24 +35,83 @@ Open **http://localhost:10254**, create your account, then create an agent,
 store a model key, grant it to the agent, and start talking. (Keep
 `SECRET_ENCRYPTION_KEY` safe — it encrypts your stored secrets.)
 
+## Upgrading
+
+Re-run the front door you installed with. Both refresh every image and then
+restart your running agent sandboxes so they come back on the new one:
+
+```bash
+# Installed with the one-liner:
+curl -fsSL https://onecli.sh/install | sh
+
+# Installed from a checkout (the wizard runs what your working tree contains,
+# so update it first):
+git pull && pnpm install && pnpm run setup --upgrade
+```
+
+**Do not upgrade with a bare `docker compose pull && docker compose up -d`.**
+It will leave you on a stale agent sandbox image, silently. That image is not
+a compose service — it is one environment value on the `runner` service
+(`RUNNER_AGENT_IMAGE`) — so `docker compose pull` cannot see it, and the runner
+only fetches it when it is missing from the host entirely. The result is a
+stack whose dashboard, API and gateway have moved forward while every hosted
+agent still boots the old sandbox image, with nothing reporting the mismatch.
+The two commands above pull it explicitly; nothing else does.
+
+Restarting a sandbox interrupts whatever that agent was doing: the in-flight
+turn reports that the agent restarted, and you send it again. Nothing else is
+lost — each agent's `/workspace` lives on its own durable volume, which is
+never touched. To upgrade the images but leave running agents alone, set
+`ONECLI_KEEP_SANDBOXES=1`; they keep the old image until they next restart.
+Put it in your `.env`, or export it — note that in the piped form a variable
+written in front of `curl` binds to `curl`, not to the script:
+
+```bash
+export ONECLI_KEEP_SANDBOXES=1
+curl -fsSL https://onecli.sh/install | sh
+
+ONECLI_KEEP_SANDBOXES=1 pnpm run setup --upgrade   # prefix is fine here
+```
+
 ## Pinning versions
 
-Every service image defaults to `:latest`. For anything you intend to keep
-running, pin one release in the same `.env` — `ONECLI_VERSION=v2.0.0` pins
-all services at once, and the agent sandbox image follows it
+Every service image defaults to `:latest`, and re-running either front door
+moves an unpinned install to the newest published images. For anything you
+intend to keep running, pin one release in the same `.env` —
+`ONECLI_VERSION=2.0.0` pins all services at once (bare semver, no `v` prefix:
+that is how the images are tagged), and the agent sandbox image ref follows it
 (`ghcr.io/onecli/onecli-agent:$ONECLI_VERSION`) unless you point
-`RUNNER_AGENT_IMAGE` somewhere else. Upgrades are then a deliberate edit +
-`docker compose up -d`, never a surprise pull. On every `up`, a one-shot
+`RUNNER_AGENT_IMAGE` somewhere else. Neither front door ever writes or changes
+`ONECLI_VERSION` for you.
+
+Where the two doors differ, and it matters: `pnpm run setup` reads the pin from
+`docker/.env` and honors it. The install script instead exports
+`ONECLI_VERSION=latest` for its own run, and an exported value beats the `.env`
+file in Compose interpolation — so an `.env`-only pin does **not** survive
+`curl … | sh`, and re-running it would move a pinned install (including the
+`migrations` image, which rolls the schema forward irreversibly). A pinned
+install has two safe upgrade routes:
+
+```bash
+# Move the pin deliberately, through the installer:
+export ONECLI_VERSION=2.1.0
+curl -fsSL https://onecli.sh/install | sh
+
+# Or stay on the pin and just restart, editing ~/.onecli/.env by hand:
+docker compose -p onecli -f ~/.onecli/docker-compose.yml up -d
+docker pull ghcr.io/onecli/onecli-agent:2.0.0   # the agent image, by hand
+```
+
+On every `up`, a one-shot
 `migrations` service (its own small image, `onecli-migrations`, pinned by the
 same `ONECLI_VERSION` so schema and code always move together) applies any
 pending database migrations before the api starts (view its output with
 `docker compose logs migrations`; re-run it with
 `docker compose up -d` or explicitly `docker compose run --rm migrations`). If
 a migration fails, the stack refuses to start rather than serving against a
-half-migrated schema — fix the cause, then `up -d` again. When upgrading an
-install created by `install.sh`, re-run the installer rather than a bare
-`docker compose pull`, so the compose file itself stays current alongside the
-images. Sizing a host for hosted
+half-migrated schema — fix the cause, then `up -d` again. Re-running the
+installer also refreshes the compose file itself, so the stack topology stays
+current alongside the images. Sizing a host for hosted
 agents (memory per sandbox, the held-awake ceiling) is covered in
 [`apps/runner/README.md`](../apps/runner/README.md).
 
@@ -79,7 +138,7 @@ one — the agent answers in the thread telling you so.
 You can change your password any time from **Account → Preferences**, which
 also signs out every other session.
 
-## Upgrading from a release without login
+## Upgrading from a pre-login release
 
 Your existing organization, workspaces, agents and API keys move to the
 account you create — nothing to migrate by hand. **Register immediately

--- a/packages/api/src/routes/agent-channels.ts
+++ b/packages/api/src/routes/agent-channels.ts
@@ -12,6 +12,8 @@ import {
 import { isChannelProviderId } from "../services/channels/registry";
 import type { ChannelProviderId } from "../services/channels/types";
 import {
+  attachPresenceSchema,
+  channelTransportSchema,
   completePresenceSchema,
   detachPresenceSchema,
 } from "../validations/channels";
@@ -57,12 +59,29 @@ export const agentChannelRoutes = () => {
   });
 
   // GET /agents/:agentId/channels/:provider/manifest — the paste floor's
-  // step 0 (Slack: the app manifest for the current posture).
+  // step 0 (Slack: the app manifest for the chosen transport, else the
+  // current posture).
   app.get("/:agentId/channels/:provider/manifest", async (c) => {
     const workspaceId = requireWorkspaceId(c.get("auth"));
     const provider = parseProvider(c.req.param("provider"));
+    const transport = channelTransportSchema
+      .optional()
+      .safeParse(c.req.query("transport"));
+    if (!transport.success) {
+      // Zod's own message names the accepted values ('events' | 'socket') —
+      // the same vocabulary the body parsers surface.
+      throw new ServiceError(
+        "UNPROCESSABLE",
+        transport.error.issues[0]?.message ?? "Unknown transport",
+      );
+    }
     return c.json(
-      await getSetupMaterial(workspaceId, c.req.param("agentId"), provider),
+      await getSetupMaterial(
+        workspaceId,
+        c.req.param("agentId"),
+        provider,
+        transport.data,
+      ),
     );
   });
 
@@ -73,11 +92,21 @@ export const agentChannelRoutes = () => {
     const a = c.get("auth");
     const workspaceId = requireWorkspaceId(a);
     const provider = parseProvider(c.req.param("provider"));
+    const body = attachPresenceSchema.safeParse(
+      (await parseBody(c.req.raw)) ?? {},
+    );
+    if (!body.success) {
+      throw new ServiceError(
+        "UNPROCESSABLE",
+        body.error.issues[0]?.message ?? "Invalid body",
+      );
+    }
     const result = await createPresence(
       workspaceId,
       c.req.param("agentId"),
       provider,
       a.userId,
+      body.data.transport,
     );
     await recordAuditEvent({
       workspaceId,
@@ -127,6 +156,7 @@ export const agentChannelRoutes = () => {
         provider,
         agentId: c.req.param("agentId"),
         presenceId: presence.id,
+        transport: presence.transport,
         completed: true,
       },
     });

--- a/packages/api/src/routes/channel-routes.test.ts
+++ b/packages/api/src/routes/channel-routes.test.ts
@@ -289,7 +289,7 @@ beforeEach(() => {
   services.addUserLink.mockResolvedValue({ id: "lnk-1" });
   services.getAgentChannels.mockResolvedValue({
     presences: [],
-    posture: { transport: "socket" },
+    posture: { transport: "socket", available: ["socket"] },
     orgIntegrations: [],
     adapter: { online: false, lastSeenAt: null },
   });
@@ -1030,8 +1030,120 @@ describe("/v1/agents/:agentId/channels", () => {
       "ag-1",
       "slack",
       "user-1",
+      undefined,
     );
     expect(dbSpies.auditCreate).toHaveBeenCalled();
+  });
+
+  it("passes an explicit transport choice through to the create", async () => {
+    const res = await appRbacOff.request("/v1/agents/ag-1/channels/slack", {
+      method: "POST",
+      headers: { ...WORKSPACE_HEADERS, "content-type": "application/json" },
+      body: JSON.stringify({ transport: "socket" }),
+    });
+    expect(res.status).toBe(201);
+    expect(services.createPresence).toHaveBeenCalledWith(
+      "p1",
+      "ag-1",
+      "slack",
+      "user-1",
+      "socket",
+    );
+  });
+
+  it("rejects an unknown transport at the schema shell with 422", async () => {
+    const res = await appRbacOff.request("/v1/agents/ag-1/channels/slack", {
+      method: "POST",
+      headers: { ...WORKSPACE_HEADERS, "content-type": "application/json" },
+      body: JSON.stringify({ transport: "carrier-pigeon" }),
+    });
+    expect(res.status).toBe(422);
+    expect(services.createPresence).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the service's transport refusals over HTTP: unavailable → 422, mismatch → 409", async () => {
+    // The pg suite proves the ServiceError codes; this crosses the HTTP
+    // boundary so the errorHandler's STATUS_MAP is exercised for both.
+    services.createPresence.mockRejectedValueOnce(
+      new ServiceError("UNPROCESSABLE", "Socket Mode isn't available"),
+    );
+    const unavailable = await appRbacOff.request(
+      "/v1/agents/ag-1/channels/slack",
+      {
+        method: "POST",
+        headers: { ...WORKSPACE_HEADERS, "content-type": "application/json" },
+        body: JSON.stringify({ transport: "socket" }),
+      },
+    );
+    expect(unavailable.status).toBe(422);
+
+    services.createPresence.mockRejectedValueOnce(
+      new ServiceError("CONFLICT", "Setup already started"),
+    );
+    const mismatch = await appRbacOff.request(
+      "/v1/agents/ag-1/channels/slack",
+      {
+        method: "POST",
+        headers: { ...WORKSPACE_HEADERS, "content-type": "application/json" },
+        body: JSON.stringify({ transport: "events" }),
+      },
+    );
+    expect(mismatch.status).toBe(409);
+  });
+
+  it("serves the manifest for a requested transport, and 422s an unknown one", async () => {
+    services.getSetupMaterial.mockResolvedValue({
+      transport: "socket",
+      material: {},
+    });
+    const res = await appRbacOff.request(
+      "/v1/agents/ag-1/channels/slack/manifest?transport=socket",
+      { headers: WORKSPACE_HEADERS },
+    );
+    expect(res.status).toBe(200);
+    expect(services.getSetupMaterial).toHaveBeenCalledWith(
+      "p1",
+      "ag-1",
+      "slack",
+      "socket",
+    );
+
+    const bad = await appRbacOff.request(
+      "/v1/agents/ag-1/channels/slack/manifest?transport=carrier-pigeon",
+      { headers: WORKSPACE_HEADERS },
+    );
+    expect(bad.status).toBe(422);
+  });
+
+  it("passes the floor's transport choice through to complete", async () => {
+    services.completePresence.mockResolvedValue({
+      id: "pr-1",
+      provider: "slack",
+      externalId: "A100",
+      status: "active",
+      transport: "socket",
+    });
+    const res = await appRbacOff.request(
+      "/v1/agents/ag-1/channels/slack/complete",
+      {
+        method: "POST",
+        headers: { ...WORKSPACE_HEADERS, "content-type": "application/json" },
+        body: JSON.stringify({
+          botToken: "xoxb-1",
+          appToken: "xapp-1",
+          appId: "A100",
+          transport: "socket",
+        }),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(services.completePresence).toHaveBeenCalledWith(
+      "p1",
+      "ag-1",
+      "slack",
+      expect.objectContaining({ transport: "socket" }),
+      "user-1",
+    );
   });
 
   it("rejects an unknown provider with 404", async () => {

--- a/packages/api/src/services/channels/agent-channel-service.ts
+++ b/packages/api/src/services/channels/agent-channel-service.ts
@@ -5,7 +5,12 @@ import { signOAuthState, verifyOAuthState } from "../../lib/oauth-state";
 import { ServiceError } from "../errors";
 import { createServiceApiKey, revokeServiceApiKey } from "../api-key-service";
 import { channelProvider } from "./registry";
-import { defaultTransport, publicApiUrl } from "./posture";
+import {
+  availableTransports,
+  defaultTransport,
+  publicApiUrl,
+  resolveTransport,
+} from "./posture";
 import { withFreshIntegrationCredentials } from "./channel-integration-service";
 import type {
   ChannelProviderId,
@@ -85,8 +90,8 @@ export interface AgentChannelStatus {
 
 export interface AgentChannelsView {
   presences: AgentChannelStatus[];
-  /** What an attach would use right now. */
-  posture: { transport: ChannelTransport };
+  /** What an attach would use right now, and what it could choose instead. */
+  posture: { transport: ChannelTransport; available: ChannelTransport[] };
   /** Per provider: does the org hold an automation credential? */
   orgIntegrations: {
     provider: ChannelProviderId;
@@ -180,7 +185,10 @@ export const getAgentChannels = async (
       },
       groupThreads: p.threadLinks,
     })),
-    posture: { transport: defaultTransport() },
+    posture: {
+      transport: defaultTransport(),
+      available: availableTransports(),
+    },
     orgIntegrations: integrations.map((i) => ({
       provider: i.provider as ChannelProviderId,
       connected: true,
@@ -202,9 +210,10 @@ export const getSetupMaterial = async (
   workspaceId: string,
   agentId: string,
   provider: ChannelProviderId,
+  requestedTransport?: ChannelTransport,
 ) => {
   const agent = await requireHostedAgent(workspaceId, agentId);
-  const transport = defaultTransport();
+  const transport = resolveTransport(requestedTransport);
   return {
     transport,
     material: channelProvider(provider).buildSetupMaterial({
@@ -235,13 +244,20 @@ export const createPresence = async (
   agentId: string,
   provider: ChannelProviderId,
   actorUserId: string,
+  requestedTransport?: ChannelTransport,
 ): Promise<CreatePresenceResult> => {
   const agent = await requireHostedAgent(workspaceId, agentId);
   const organizationId = agent.workspace.organizationId;
 
   const existing = await db.agentChannel.findUnique({
     where: { agentId_provider: { agentId: agent.id, provider } },
-    select: { id: true, status: true, externalId: true, credentials: true },
+    select: {
+      id: true,
+      status: true,
+      externalId: true,
+      transport: true,
+      credentials: true,
+    },
   });
   if (existing && existing.status !== "pending_setup") {
     throw new ServiceError(
@@ -249,8 +265,25 @@ export const createPresence = async (
       "This agent already has a Slack app. Detach it first.",
     );
   }
+  if (
+    existing &&
+    requestedTransport &&
+    requestedTransport !== existing.transport
+  ) {
+    throw new ServiceError(
+      "CONFLICT",
+      "Setup already started with a different connection mode. Start over to switch.",
+    );
+  }
 
-  const transport = defaultTransport();
+  // A resumed attach stays on the row's stamp (the provider-side app config
+  // baked it in); only a fresh create consults the request and the posture.
+  // The OAuth state is minted per that transport — mint it off the current
+  // default and a socket resume would carry a useless state while an events
+  // resume under a changed posture would lose its install URL.
+  const transport = existing
+    ? (existing.transport as ChannelTransport)
+    : resolveTransport(requestedTransport);
   const oauthState =
     transport === "events"
       ? signOAuthState({
@@ -459,6 +492,7 @@ export const completePresence = async (
     appToken?: string;
     signingSecret?: string;
     appId?: string;
+    transport?: ChannelTransport;
   },
   actorUserId: string,
 ) => {
@@ -480,10 +514,18 @@ export const completePresence = async (
       "This agent already has a Slack app. Detach it first.",
     );
   }
+  if (existing && input.transport && input.transport !== existing.transport) {
+    throw new ServiceError(
+      "CONFLICT",
+      "Setup already started with a different connection mode. Start over to switch.",
+    );
+  }
 
+  // A pending row keeps its stamp (the provider-side app config baked it in);
+  // only the floor's no-row paste consults the request and the posture.
   const transport = existing
     ? (existing.transport as ChannelTransport)
-    : defaultTransport();
+    : resolveTransport(input.transport);
 
   const externalId = existing?.externalId ?? input.appId?.trim();
   if (!externalId) {

--- a/packages/api/src/services/channels/channels.pg.test.ts
+++ b/packages/api/src/services/channels/channels.pg.test.ts
@@ -1672,6 +1672,116 @@ describe.skipIf(!PROOF_URL)("createPresence (the guided arm)", () => {
     ).rejects.toMatchObject({ code: "CONFLICT" });
     expect(slackCalls).toHaveLength(0);
   });
+
+  it("an explicit socket request on events posture stamps socket", async () => {
+    initSelfUrl(EVENTS_SELF_URL);
+    await seedIntegration({
+      credentials: await integrationCredentials(12 * 3600),
+    });
+    const agentId = await seedAgent("guided-choice-socket");
+    scriptManifestCreate();
+
+    const result = await agentChannels.createPresence(
+      WORKSPACE,
+      agentId,
+      "slack",
+      ADMIN,
+      "socket",
+    );
+
+    expect(result.transport).toBe("socket");
+    expect(result.installUrl).toBeNull();
+    const manifest = JSON.parse(
+      slackCallsFor("apps.manifest.create")[0]!.form.get("manifest")!,
+    ) as { settings: { socket_mode_enabled: boolean } };
+    expect(manifest.settings.socket_mode_enabled).toBe(true);
+    const row = await db.agentChannel.findUniqueOrThrow({
+      where: { agentId_provider: { agentId, provider: "slack" } },
+    });
+    expect(row.transport).toBe("socket");
+  });
+
+  it("refuses an events request without a public https origin", async () => {
+    // Default posture: socket self-url — events physically can't reach us.
+    await seedIntegration({
+      credentials: await integrationCredentials(12 * 3600),
+    });
+    const agentId = await seedAgent("guided-choice-events-refused");
+    await expect(
+      agentChannels.createPresence(
+        WORKSPACE,
+        agentId,
+        "slack",
+        ADMIN,
+        "events",
+      ),
+    ).rejects.toMatchObject({ code: "UNPROCESSABLE" });
+    expect(slackCalls).toHaveLength(0);
+  });
+
+  it("refuses a socket request on the cloud edition — the product clamp, not the URL scheme", async () => {
+    initSelfUrl(EVENTS_SELF_URL);
+    await seedIntegration({
+      credentials: await integrationCredentials(12 * 3600),
+    });
+    const agentId = await seedAgent("guided-choice-cloud-clamp");
+    // `isOnpremEdition()` reads env call-time, so this flip is visible without
+    // a re-import — and MUST be restored (the suite's semantics are onprem;
+    // see the beforeAll pin's worker-leak warning).
+    process.env.EDITION = "cloud";
+    process.env.NEXT_PUBLIC_EDITION = "cloud";
+    try {
+      await expect(
+        agentChannels.createPresence(
+          WORKSPACE,
+          agentId,
+          "slack",
+          ADMIN,
+          "socket",
+        ),
+      ).rejects.toMatchObject({ code: "UNPROCESSABLE" });
+    } finally {
+      process.env.EDITION = "onprem";
+      process.env.NEXT_PUBLIC_EDITION = "onprem";
+    }
+    expect(slackCalls).toHaveLength(0);
+  });
+
+  it("a resume keeps the row's stamp through posture drift, and refuses a conflicting request", async () => {
+    // Stamp events, then flip the deployment posture to socket-only.
+    initSelfUrl(EVENTS_SELF_URL);
+    await seedIntegration({
+      credentials: await integrationCredentials(12 * 3600),
+    });
+    const agentId = await seedAgent("guided-resume-stamp");
+    scriptManifestCreate();
+    await agentChannels.createPresence(WORKSPACE, agentId, "slack", ADMIN);
+
+    initSelfUrl(SOCKET_SELF_URL);
+    const resumed = await agentChannels.createPresence(
+      WORKSPACE,
+      agentId,
+      "slack",
+      ADMIN,
+    );
+    // The row's stamp wins — and the events resume still carries a usable
+    // install URL: the OAuth state is minted for the ROW's transport, not the
+    // drifted default (mint it off the default and this URL loses its state).
+    expect(resumed.transport).toBe("events");
+    expect(resumed.installUrl).toContain("&state=");
+
+    await expect(
+      agentChannels.createPresence(
+        WORKSPACE,
+        agentId,
+        "slack",
+        ADMIN,
+        "socket",
+      ),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    // Neither the resume nor the refusal minted a second Slack app.
+    expect(slackCallsFor("apps.manifest.create")).toHaveLength(1);
+  });
 });
 
 describe.skipIf(!PROOF_URL)("completePresence (the paste floor)", () => {
@@ -1722,6 +1832,49 @@ describe.skipIf(!PROOF_URL)("completePresence (the paste floor)", () => {
       botToken: "xoxb-floor-token",
       appToken: "xapp-floor-token",
     });
+  });
+
+  it("stamps the floor's explicit socket choice on an events-posture deployment", async () => {
+    initSelfUrl(EVENTS_SELF_URL);
+    const agentId = await seedAgent("floor-choice-socket");
+    scriptAuthTest();
+
+    const presence = await agentChannels.completePresence(
+      WORKSPACE,
+      agentId,
+      "slack",
+      {
+        botToken: "xoxb-floor-token",
+        appToken: "xapp-floor-token",
+        appId: "A210",
+        transport: "socket",
+      },
+      ADMIN,
+    );
+
+    expect(presence.transport).toBe("socket");
+  });
+
+  it("refuses a transport that contradicts a pending row's stamp", async () => {
+    initSelfUrl(EVENTS_SELF_URL);
+    await seedIntegration({
+      credentials: await integrationCredentials(12 * 3600),
+    });
+    const agentId = await seedAgent("floor-choice-conflict");
+    scriptManifestCreate();
+    // The guided create stamps events; a socket-flavored paste must not
+    // silently complete onto it.
+    await agentChannels.createPresence(WORKSPACE, agentId, "slack", ADMIN);
+
+    await expect(
+      agentChannels.completePresence(
+        WORKSPACE,
+        agentId,
+        "slack",
+        { botToken: "xoxb-x", appToken: "xapp-x", transport: "socket" },
+        ADMIN,
+      ),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
   });
 
   it("requires the App ID when no guided create ran", async () => {

--- a/packages/api/src/services/channels/posture.test.ts
+++ b/packages/api/src/services/channels/posture.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { initSelfUrl } from "../../providers/self-url";
+import { ServiceError } from "../errors";
+import {
+  availableTransports,
+  defaultTransport,
+  resolveTransport,
+} from "./posture";
+
+/**
+ * The transport posture table: edition × API-origin scheme. Edition is read
+ * call-time (`isOnpremEdition`), so mutating process.env per test is safe —
+ * as long as every mutation is restored (worker processes are reused).
+ */
+
+const ORIGINAL_EDITION = process.env.EDITION;
+const ORIGINAL_PUBLIC_EDITION = process.env.NEXT_PUBLIC_EDITION;
+
+const setEdition = (edition: "cloud" | "onprem") => {
+  process.env.EDITION = edition;
+  process.env.NEXT_PUBLIC_EDITION = edition;
+};
+
+afterEach(() => {
+  if (ORIGINAL_EDITION === undefined) delete process.env.EDITION;
+  else process.env.EDITION = ORIGINAL_EDITION;
+  if (ORIGINAL_PUBLIC_EDITION === undefined)
+    delete process.env.NEXT_PUBLIC_EDITION;
+  else process.env.NEXT_PUBLIC_EDITION = ORIGINAL_PUBLIC_EDITION;
+});
+
+describe("availableTransports / defaultTransport", () => {
+  it("cloud with a public https origin offers events only", () => {
+    setEdition("cloud");
+    initSelfUrl("https://api.example.test");
+    expect(availableTransports()).toEqual(["events"]);
+    expect(defaultTransport()).toBe("events");
+  });
+
+  it("onprem with a public https origin offers both, events first", () => {
+    setEdition("onprem");
+    initSelfUrl("https://api.example.test");
+    expect(availableTransports()).toEqual(["events", "socket"]);
+    expect(defaultTransport()).toBe("events");
+  });
+
+  it("onprem on localhost offers socket only", () => {
+    setEdition("onprem");
+    initSelfUrl("http://localhost:10256");
+    expect(availableTransports()).toEqual(["socket"]);
+    expect(defaultTransport()).toBe("socket");
+  });
+
+  it("cloud without https offers nothing — misconfiguration, not socket", () => {
+    setEdition("cloud");
+    initSelfUrl("http://localhost:10256");
+    expect(availableTransports()).toEqual([]);
+  });
+});
+
+describe("resolveTransport", () => {
+  it("an omitted request keeps the deployment default", () => {
+    setEdition("onprem");
+    initSelfUrl("https://api.example.test");
+    expect(resolveTransport(undefined)).toBe("events");
+  });
+
+  it("an explicit available request is honored", () => {
+    setEdition("onprem");
+    initSelfUrl("https://api.example.test");
+    expect(resolveTransport("socket")).toBe("socket");
+    expect(resolveTransport("events")).toBe("events");
+  });
+
+  it("refuses socket on cloud — the product clamp, not the URL scheme", () => {
+    setEdition("cloud");
+    initSelfUrl("https://api.example.test");
+    expect(() => resolveTransport("socket")).toThrowError(ServiceError);
+    expect(() => resolveTransport("socket")).toThrowError(/Socket Mode/);
+  });
+
+  it("refuses events without a public https origin", () => {
+    setEdition("onprem");
+    initSelfUrl("http://localhost:10256");
+    expect(() => resolveTransport("events")).toThrowError(ServiceError);
+    expect(() => resolveTransport("events")).toThrowError(/HTTPS/);
+  });
+
+  it("fails loudly on the degenerate cloud+http config instead of stamping socket", () => {
+    setEdition("cloud");
+    initSelfUrl("http://localhost:10256");
+    expect(() => resolveTransport(undefined)).toThrowError(ServiceError);
+  });
+});

--- a/packages/api/src/services/channels/posture.ts
+++ b/packages/api/src/services/channels/posture.ts
@@ -1,12 +1,19 @@
+import { isOnpremEdition } from "../../lib/policy-flags";
 import { getSelfUrl } from "../../providers/self-url";
+import { ServiceError } from "../errors";
 import type { ChannelTransport } from "./types";
 
 /**
- * The deployment's transport posture (§step-6 decision 7): a presence can use
- * the provider's HTTP events arm — the one-click install — only when the
- * provider can reach this API over public HTTPS. A config-presence signal
- * (the house rule: config beats edition where honest), never an edition read:
- * cloud and a TLS'd self-host both qualify; a laptop on localhost does not.
+ * The deployment's transport posture (§step-6 decision 7). Two independent
+ * questions decide what a NEW presence may use:
+ *
+ * - "events" (webhooks) needs the provider to reach this API over public
+ *   HTTPS — a config-presence signal (the house rule: config beats edition
+ *   where honest): cloud and a TLS'd self-host both qualify; a laptop on
+ *   localhost does not.
+ * - "socket" is self-host only — a product decision with no natural config
+ *   signal (the hosted platform's adapter fleet could hold the sockets, we
+ *   just don't offer it), so this one IS a deliberate edition read.
  *
  * `getSelfUrl()` is the API's own configured origin (`apps/api-server`
  * initializes it from `API_URL`), which is exactly the URL the provider would
@@ -22,7 +29,35 @@ export const publicApiUrl = (): string | null => {
   }
 };
 
-/** Which transport a NEW presence gets. Existing presences keep their stamp —
- * the provider-side app config baked one, so switching is detach/re-attach. */
+/** The transports a NEW presence may be stamped with, events first. */
+export const availableTransports = (): ChannelTransport[] => [
+  ...(publicApiUrl() !== null ? (["events"] as const) : []),
+  ...(isOnpremEdition() ? (["socket"] as const) : []),
+];
+
+/** Which transport a NEW presence gets by default. Existing presences keep
+ * their stamp — the provider-side app config baked one, so switching is
+ * detach/re-attach. */
 export const defaultTransport = (): ChannelTransport =>
   publicApiUrl() ? "events" : "socket";
+
+/**
+ * The one gate every stamping path goes through: an omitted request keeps
+ * today's default; an explicit request must be available here. A misconfigured
+ * deployment (cloud without a public HTTPS URL) fails loudly rather than
+ * silently stamping a transport it cannot serve.
+ */
+export const resolveTransport = (
+  requested?: ChannelTransport,
+): ChannelTransport => {
+  const transport = requested ?? defaultTransport();
+  if (!availableTransports().includes(transport)) {
+    throw new ServiceError(
+      "UNPROCESSABLE",
+      transport === "socket"
+        ? "Socket Mode isn't available on OneCLI Cloud — hosted workspaces connect over the Events API."
+        : "Webhooks need a public HTTPS API URL. Set ONECLI_EXTERNAL_URL (or API_URL) to an https origin, or use Socket Mode.",
+    );
+  }
+  return transport;
+};

--- a/packages/api/src/validations/channels.ts
+++ b/packages/api/src/validations/channels.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { CHANNEL_PROVIDER_IDS } from "../services/channels/types";
+import {
+  CHANNEL_PROVIDER_IDS,
+  CHANNEL_TRANSPORTS,
+} from "../services/channels/types";
 
 /**
  * Zod surfaces for the channel routes (step 6). One definition per union —
@@ -8,6 +11,18 @@ import { CHANNEL_PROVIDER_IDS } from "../services/channels/types";
  */
 
 export const channelProviderSchema = z.enum(CHANNEL_PROVIDER_IDS);
+
+/** The connection-mode vocabulary — the manifest GET validates its
+ * `?transport=` with this directly (query params are bare strings). */
+export const channelTransportSchema = z.enum(CHANNEL_TRANSPORTS);
+
+/** POST /v1/agents/:agentId/channels/:provider: the caller's connection-mode
+ * choice — optional, the deployment posture decides when omitted. */
+export const attachPresenceSchema = z
+  .object({
+    transport: channelTransportSchema.optional(),
+  })
+  .strict();
 
 /** PUT /v1/org/channels/:provider/credentials */
 export const connectIntegrationSchema = z
@@ -31,6 +46,7 @@ export const completePresenceSchema = z
     appToken: z.string().trim().min(1).max(500).optional(),
     signingSecret: z.string().trim().min(1).max(500).optional(),
     appId: z.string().trim().min(1).max(100).optional(),
+    transport: channelTransportSchema.optional(),
   })
   .strict();
 

--- a/scripts/install-sh.test.mjs
+++ b/scripts/install-sh.test.mjs
@@ -205,3 +205,289 @@ test("--print-resolved never displays a wildcard bind as the address", () => {
   assert.match(r.stdout, /^external=http:\/\/localhost:10254$/m);
   rmSync(r.home, { recursive: true, force: true });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// The upgrade path: pulling the agent sandbox image, and restarting this
+// installation's sandboxes onto it.
+//
+// A stand-in for the docker CLI, in the style of scripts/migrate-sh.test.mjs:
+// it appends every invocation to STUB_LOG and answers `ps` from STUB_IDS, so
+// the tests can assert exactly which calls the script makes and, critically,
+// which it never makes.
+// ─────────────────────────────────────────────────────────────────────────
+
+const DOCKER_STUB = `
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.STUB_LOG, args.join(" ") + "\\n");
+if (args[0] === "ps") process.stdout.write(process.env.STUB_IDS ?? "");
+process.exit(0);
+`;
+
+/** Run a hook with a stubbed docker; returns the result plus its call log. */
+const runStubbed = (args, { env = {}, envFile = "", ids = "" } = {}) => {
+  const home = mkdtempSync(join(tmpdir(), "onecli-install-test-"));
+  mkdirSync(join(home, ".onecli"), { recursive: true });
+  if (envFile) writeFileSync(join(home, ".onecli", ".env"), envFile);
+  const stub = join(home, "stub-docker.mjs");
+  const log = join(home, "docker-calls.log");
+  writeFileSync(stub, DOCKER_STUB);
+  writeFileSync(log, "");
+  const result = { home };
+  try {
+    result.stdout = execFileSync("sh", [SCRIPT, ...args], {
+      env: {
+        PATH: process.env.PATH,
+        HOME: home,
+        ONECLI_DOCKER_CMD: `node ${stub}`,
+        STUB_LOG: log,
+        STUB_IDS: ids,
+        ...env,
+      },
+      encoding: "utf8",
+    });
+    result.status = 0;
+  } catch (err) {
+    result.status = err.status;
+    result.stdout = err.stdout ?? "";
+    result.stderr = err.stderr ?? "";
+  }
+  result.calls = readFileSync(log, "utf8").trim().split("\n").filter(Boolean);
+  return result;
+};
+
+const RUNNER_ENV = "COMPOSE_PROFILES=runner\nRUNNER_TOKEN=rnr_testtoken\n";
+
+test("--print-agent-image returns the compose default when nothing is set", () => {
+  const r = runStubbed(["--print-agent-image"]);
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout.trim(), "ghcr.io/onecli/onecli-agent:latest");
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("--print-agent-image honors RUNNER_AGENT_IMAGE from the env file and the shell", () => {
+  const fromFile = runStubbed(["--print-agent-image"], {
+    envFile: "RUNNER_AGENT_IMAGE=ghcr.io/acme/agent:9.9.9\n",
+  });
+  assert.equal(fromFile.stdout.trim(), "ghcr.io/acme/agent:9.9.9");
+  rmSync(fromFile.home, { recursive: true, force: true });
+
+  // The shell export is what compose interpolation would use, so it wins.
+  const fromShell = runStubbed(["--print-agent-image"], {
+    envFile: "RUNNER_AGENT_IMAGE=ghcr.io/acme/agent:9.9.9\n",
+    env: { RUNNER_AGENT_IMAGE: "ghcr.io/acme/agent:1.0.0" },
+  });
+  assert.equal(fromShell.stdout.trim(), "ghcr.io/acme/agent:1.0.0");
+  rmSync(fromShell.home, { recursive: true, force: true });
+});
+
+test("--print-agent-image tracks a pinned ONECLI_VERSION", () => {
+  const r = runStubbed(["--print-agent-image"], {
+    env: { ONECLI_VERSION: "2.1.0" },
+  });
+  assert.equal(r.stdout.trim(), "ghcr.io/onecli/onecli-agent:2.1.0");
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("the installation fingerprint is sha256(token) and uses printf, not echo", async () => {
+  const { createHash } = await import("node:crypto");
+  const token = "rnr_testtoken";
+  const r = runStubbed(["--print-installation-id"], { envFile: RUNNER_ENV });
+  assert.equal(r.status, 0);
+
+  const expected = createHash("sha256")
+    .update(token)
+    .digest("hex")
+    .slice(0, 32);
+  assert.equal(r.stdout.trim(), expected);
+
+  // The mutation test for `printf` vs `echo`: echo appends a newline, which
+  // hashes to something else entirely. The sweep would then match no
+  // containers while still reporting success, which is the worst possible
+  // failure mode here. This assertion is what makes that regression loud.
+  const withNewline = createHash("sha256")
+    .update(`${token}\n`)
+    .digest("hex")
+    .slice(0, 32);
+  assert.notEqual(r.stdout.trim(), withNewline);
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("--print-installation-id fails when no runner token exists", () => {
+  const r = runStubbed(["--print-installation-id"]);
+  assert.notEqual(r.status, 0);
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("the reap stops this installation's sandboxes, fenced on BOTH labels", async () => {
+  const { createHash } = await import("node:crypto");
+  const fp = createHash("sha256")
+    .update("rnr_testtoken")
+    .digest("hex")
+    .slice(0, 32);
+  const r = runStubbed(["--reap-sandboxes"], {
+    envFile: RUNNER_ENV,
+    ids: "abc123\ndef456\n",
+  });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /^reaped=2$/m);
+
+  const ps = r.calls.find((c) => c.startsWith("ps "));
+  assert.ok(ps, "expected a docker ps call");
+  assert.ok(
+    ps.includes("label=sh.onecli.managed=1"),
+    `managed label missing: ${ps}`,
+  );
+  assert.ok(
+    ps.includes(`label=sh.onecli.installation=${fp}`),
+    `installation fence missing: ${ps}`,
+  );
+
+  assert.deepEqual(
+    r.calls.filter((c) => c.startsWith("stop ")),
+    ["stop -t 30 abc123", "stop -t 30 def456"],
+  );
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("the reap NEVER touches volumes, removes, or prunes", () => {
+  // The durable agent homes (onecli-home-*) carry the IDENTICAL label pair as
+  // the containers, so this exact filter aimed at `docker volume rm` would
+  // erase every agent's /workspace. This is the guard against that.
+  const r = runStubbed(["--reap-sandboxes"], {
+    envFile: RUNNER_ENV,
+    ids: "abc123\n",
+  });
+  for (const forbidden of ["volume", "rm", "prune", "-v", "down"]) {
+    assert.deepEqual(
+      r.calls.filter((c) => c.split(" ").includes(forbidden)),
+      [],
+      `docker was called with "${forbidden}": ${r.calls.join(" | ")}`,
+    );
+  }
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("ONECLI_KEEP_SANDBOXES leaves every sandbox alone", () => {
+  const r = runStubbed(["--reap-sandboxes"], {
+    envFile: RUNNER_ENV,
+    ids: "abc123\n",
+    env: { ONECLI_KEEP_SANDBOXES: "1" },
+  });
+  assert.match(r.stdout, /^reaped=0$/m);
+  assert.match(r.stdout, /^kept=yes$/m);
+  assert.deepEqual(r.calls, [], "docker must not be called at all");
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("no runner token means no sweep: the fence is never widened", () => {
+  // An unknown installation must NOT fall back to a managed-only filter --
+  // that would reap a co-located install's live agents.
+  const r = runStubbed(["--reap-sandboxes"], {
+    envFile: "COMPOSE_PROFILES=runner\n",
+    ids: "abc123\n",
+  });
+  assert.match(r.stdout, /^reaped=0$/m);
+  assert.deepEqual(r.calls, [], "docker must not be called without a fence");
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("an install without hosted agents skips the sweep entirely", () => {
+  const r = runStubbed(["--reap-sandboxes"], {
+    envFile: "COMPOSE_PROFILES=\nRUNNER_TOKEN=rnr_testtoken\n",
+    ids: "abc123\n",
+  });
+  assert.match(r.stdout, /^reaped=0$/m);
+  assert.deepEqual(r.calls, []);
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("a quoted RUNNER_TOKEN hashes to the same fingerprint as a bare one", async () => {
+  const { createHash } = await import("node:crypto");
+  const expected = createHash("sha256")
+    .update("rnr_testtoken")
+    .digest("hex")
+    .slice(0, 32);
+  const r = runStubbed(["--print-installation-id"], {
+    envFile: 'RUNNER_TOKEN="rnr_testtoken"\n',
+  });
+  assert.equal(r.stdout.trim(), expected);
+  rmSync(r.home, { recursive: true, force: true });
+});
+
+test("--print-compose-url routes pre-2.0 to legacy and everything else to split", () => {
+  const legacy = ["1", "1.45", "1.45.0", "v1.44.2"];
+  const split = ["2", "2.1.0", "v2.1.0", "latest", ""];
+  for (const v of legacy) {
+    const r = run(["--print-compose-url"], { ONECLI_VERSION: v });
+    assert.match(r.stdout, /docker-compose\.legacy\.yml/, `version ${v}`);
+    rmSync(r.home, { recursive: true, force: true });
+  }
+  for (const v of split) {
+    const r = run(["--print-compose-url"], { ONECLI_VERSION: v });
+    assert.doesNotMatch(r.stdout, /legacy/, `version ${v}`);
+    rmSync(r.home, { recursive: true, force: true });
+  }
+});
+
+test("the supply-chain guard only pulls references that name a registry", () => {
+  // A reference whose first segment has no "." or ":" is not a registry: Docker
+  // would resolve `onecli-agent:dev` to docker.io/library/onecli-agent and pull
+  // whatever a squatter published there, over the top of a locally built image.
+  // Being conservative costs a skipped pull and a printed line; being wrong
+  // runs a stranger's code as the agent sandbox.
+  const cases = [
+    ["ghcr.io/onecli/onecli-agent:2.1.0", "pullable"],
+    ["ghcr.io/o/a@sha256:abc", "pullable"],
+    ["localhost:5000/foo:1", "pullable"],
+    ["myreg:5000/team/img:1", "pullable"],
+    ["docker.io/library/onecli-agent:dev", "pullable"],
+    // The source-mode tag the wizard builds, and the shapes that would
+    // silently become docker.io/library/*.
+    ["onecli-agent:dev", "local"],
+    ["onecli-agent", "local"],
+    ["onecli/onecli-agent:dev", "local"],
+    ["localhost/foo:1", "local"],
+    ["/foo:1", "local"],
+    ["", "local"],
+  ];
+  for (const [ref, expected] of cases) {
+    const r = runStubbed(["--print-ref-pullable", ref]);
+    assert.equal(r.stdout.trim(), expected, `ref ${JSON.stringify(ref)}`);
+    rmSync(r.home, { recursive: true, force: true });
+  }
+});
+
+test("a CRLF .env still produces the fingerprint the runner labelled", async () => {
+  // WSL is a first-class target and writes CRLF. Compose strips the carriage
+  // return; `cut -d= -f2-` does not. Without the trailing-whitespace strip the
+  // token hashes as "rnr_x\r", the label filter matches zero containers, and
+  // the sweep reports success having done nothing at all. That silent no-op is
+  // exactly the failure mode this code's own comment calls the worst one.
+  const { createHash } = await import("node:crypto");
+  const expected = createHash("sha256")
+    .update("rnr_testtoken")
+    .digest("hex")
+    .slice(0, 32);
+  for (const envFile of [
+    "RUNNER_TOKEN=rnr_testtoken\r\n",
+    'RUNNER_TOKEN="rnr_testtoken"\r\n',
+    "RUNNER_TOKEN=rnr_testtoken   \n",
+  ]) {
+    const r = runStubbed(["--print-installation-id"], { envFile });
+    assert.equal(r.stdout.trim(), expected, JSON.stringify(envFile));
+    rmSync(r.home, { recursive: true, force: true });
+  }
+});
+
+test("ONECLI_KEEP_SANDBOXES works from the env file, not just an export", () => {
+  // In the documented `curl … | sh` form a variable written in front of curl
+  // binds to curl, never to the script, so the .env route has to work.
+  const r = runStubbed(["--reap-sandboxes"], {
+    envFile: `${RUNNER_ENV}ONECLI_KEEP_SANDBOXES=1\n`,
+    ids: "abc123\n",
+  });
+  assert.match(r.stdout, /^kept=yes$/m);
+  assert.deepEqual(r.calls, [], "docker must not be called at all");
+  rmSync(r.home, { recursive: true, force: true });
+});

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,6 +34,14 @@
 #   curl -fsSL https://onecli.sh/install | sh
 # (or edit the COMPOSE_PROFILES line in ~/.onecli/.env later — empty disables.)
 #
+# Re-running this script IS the update path: it refreshes every image — the
+# agent sandbox image included, which `docker compose pull` cannot reach — and
+# then restarts this installation's agent sandboxes so they come back on the
+# new image. Keep them running instead (they stay on the old agent image until
+# they next restart on their own):
+#   export ONECLI_KEEP_SANDBOXES=1
+#   curl -fsSL https://onecli.sh/install | sh
+#
 # This script checks for Docker, downloads the docker-compose.yml matching the
 # requested version, and starts OneCLI (dashboard + API + gateway + PostgreSQL
 # + the hosted-agents runner) on ports 10254/10255/10256 by default.
@@ -47,6 +55,12 @@ ENV_FILE="$INSTALL_DIR/.env"
 COMPOSE_URL_NEW="https://raw.githubusercontent.com/onecli/onecli/main/docker/docker-compose.yml"
 COMPOSE_URL_LEGACY="https://raw.githubusercontent.com/onecli/onecli/main/docker/docker-compose.legacy.yml"
 PROJECT_NAME="onecli"
+# Docker command indirection, so the tests can substitute a stub and assert
+# exactly which calls the upgrade steps make — and, critically, which they
+# never make (see reap_sandboxes). docker/migrate.sh carries PRISMA_CMD for
+# the same reason. Only the upgrade helpers below read it; the prerequisite
+# checks deliberately probe the real binary.
+DOCKER="${ONECLI_DOCKER_CMD:-docker}"
 
 # Which compose file serves this version: a numeric major below 2 gets the
 # legacy all-in-one stack; everything else (2+, "latest", unset, non-numeric)
@@ -202,8 +216,139 @@ env_or_file() {
     return
   fi
   if [ -f "$ENV_FILE" ]; then
-    grep "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2-
+    # Trailing whitespace and a CRLF carriage return are stripped, exactly as
+    # compose does when it reads the same file. Without this a .env saved on
+    # Windows/WSL hands back "rnr_x\r", which hashes to a fingerprint matching
+    # no container: the sandbox sweep then finds nothing and reports success.
+    # The EXPORT branch above is deliberately left verbatim, since that is the
+    # value compose itself interpolates.
+    grep "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | sed 's/[[:space:]]*$//'
   fi
+}
+
+# One layer of surrounding quotes off an .env value. `env_or_file` hands back
+# the raw right-hand side, and compose accepts either style, so a quoted
+# RUNNER_TOKEN would otherwise hash to the wrong fingerprint.
+unquote() {
+  _u="$1"
+  case "$_u" in
+    '"'*'"')
+      _u="${_u#\"}"
+      _u="${_u%\"}"
+      ;;
+    "'"*"'")
+      _u="${_u#\'}"
+      _u="${_u%\'}"
+      ;;
+  esac
+  printf '%s' "$_u"
+}
+
+# Whether hosted agents are enabled for this install. The runner profile is
+# what creates sandboxes and what makes the agent image worth pulling, so both
+# upgrade steps below hang off it.
+runner_profile_on() {
+  case "$(env_or_file COMPOSE_PROFILES)" in
+    *runner*) return 0 ;;
+  esac
+  return 1
+}
+
+# The agent sandbox image this install starts agents from. It is deliberately
+# NOT a compose service — it is one env value on the runner service — so
+# `docker compose pull` cannot see it and this script has to pull it by name.
+agent_image_ref() {
+  _ref=$(unquote "$(env_or_file RUNNER_AGENT_IMAGE)")
+  if [ -n "$_ref" ]; then
+    printf '%s' "$_ref"
+    return
+  fi
+  printf 'ghcr.io/onecli/onecli-agent:%s' "${ONECLI_VERSION:-latest}"
+}
+
+# Whether a reference names a registry we may pull from. Docker treats the
+# first path segment as a registry only when it contains a "." or a ":", so a
+# locally built tag like `onecli-agent:dev` (what the wizard's source mode
+# builds) would silently resolve to docker.io/library/onecli-agent and pull a
+# stranger's image. Refusing is a supply-chain guard, not tidiness.
+ref_is_pullable() {
+  case "$1" in
+    */*) ;;
+    *) return 1 ;;
+  esac
+  case "${1%%/*}" in
+    *.* | *:*) return 0 ;;
+  esac
+  return 1
+}
+
+# A stable, non-secret fingerprint of THIS installation: sha256 of the runner
+# token, first 32 hex. Byte-equal with apps/runner/src/installation.ts, which
+# stamps the same value onto every sandbox container as sh.onecli.installation
+# — that label is what fences the restart below to our own containers.
+#
+# `printf`, never `echo`: echo appends a newline, which hashes to an entirely
+# different value, and the label filter would then match nothing while still
+# reporting success. A silent no-op that looks like it ran is the worst
+# possible failure here, so a test pins the exact digest.
+installation_fingerprint() {
+  _token=$(unquote "$(env_or_file RUNNER_TOKEN)")
+  [ -n "$_token" ] || return 1
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$_token" | sha256sum | cut -c1-32
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$_token" | shasum -a 256 | cut -c1-32
+  else
+    return 1
+  fi
+}
+
+# Restart this installation's agent sandboxes so they come back on the image we
+# just pulled. Sandbox containers are created by the runner through the Docker
+# API rather than by compose, so they carry no compose labels and `compose
+# down` never touches them: without this they keep running the OLD agent image
+# indefinitely, which is the whole bug this step exists to close.
+#
+# BOTH labels are required. `managed=1` alone would also match a co-located
+# install's containers — precisely the failure apps/runner/src/installation.ts
+# was written to prevent. No fingerprint means no sweep: never widen the fence.
+#
+# CONTAINERS ONLY. The durable home volumes carry the IDENTICAL label pair, so
+# this filter must never reach `docker volume`, `docker rm -v`, or a prune:
+# that would erase every agent's /workspace. A test asserts those calls are
+# never made.
+#
+# Sets REAPED to the number of sandboxes actually stopped, and REAP_KEPT when
+# the operator opted out. The success block does the reporting, so every
+# "Agents:" line the run prints stays together.
+reap_sandboxes() {
+  REAPED=0
+  REAP_KEPT=""
+  [ "$STACK" = "split" ] || return 0
+  runner_profile_on || return 0
+  # Through env_or_file, like every other knob, so it works as a shell export
+  # AND as a line in the install's .env. A bare `$ONECLI_KEEP_SANDBOXES` would
+  # only ever see the export, and in the documented `curl | sh` form a variable
+  # prefix binds to curl, not to the script.
+  if [ -n "$(env_or_file ONECLI_KEEP_SANDBOXES)" ]; then
+    REAP_KEPT="yes"
+    return 0
+  fi
+  _fp=$(installation_fingerprint) || return 0
+  [ -n "$_fp" ] || return 0
+  _ids=$($DOCKER ps -q \
+    --filter "label=sh.onecli.managed=1" \
+    --filter "label=sh.onecli.installation=$_fp" 2>/dev/null)
+  [ -n "$_ids" ] || return 0
+  # -t 30 matches the runner's own graceful stop. The runner recreates the
+  # container from the current image on the agent's next message, so stopping
+  # is enough; removing it would only make the control plane wait longer.
+  for _id in $_ids; do
+    if $DOCKER stop -t 30 "$_id" >/dev/null 2>&1; then
+      REAPED=$((REAPED + 1))
+    fi
+  done
+  return 0
 }
 
 # Strict validation for the canonical var only (legacy APP_URL stays lenient):
@@ -491,6 +636,34 @@ main() {
     exit 1
   fi
 
+  # The agent sandbox image is not a compose service, so the pull above did not
+  # fetch it. Skipping this is how an upgraded install ends up serving 2.x
+  # services from a stale agent image: the runner only pulls that image when it
+  # is missing entirely, which never happens once a moving tag is cached.
+  #
+  # Non-fatal on purpose. It is the largest image by far, and a flaky network
+  # must not abort an upgrade whose services are already pulled; the warning
+  # names the exact consequence instead.
+  AGENT_PULL_FAILED=""
+  if [ "$STACK" = "split" ] && runner_profile_on; then
+    AGENT_IMAGE=$(agent_image_ref)
+    if ref_is_pullable "$AGENT_IMAGE"; then
+      echo "  Pulling the agent sandbox image ($AGENT_IMAGE)..."
+      if ! $DOCKER pull "$AGENT_IMAGE"; then
+        AGENT_PULL_FAILED="yes"
+        echo "Warning: Failed to pull $AGENT_IMAGE." >&2
+        echo "  OneCLI will still start, but hosted agents keep using the agent image already on this host." >&2
+      fi
+    else
+      # Not "built locally": a two-segment ref like myorg/agent:1 is a real
+      # Docker Hub reference we refuse on purpose, because pulling it could
+      # replace a locally built image from a namespace we do not control.
+      # Name the reason and the way out instead of guessing at intent.
+      echo "  Agent image $AGENT_IMAGE names no registry host, so it is not pulled."
+      echo "  Prefix it with ghcr.io/ or docker.io/ in $ENV_FILE to have it pulled."
+    fi
+  fi
+
   echo "  Starting OneCLI..."
   if ! docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d --wait; then
     echo "" >&2
@@ -503,6 +676,12 @@ main() {
     exit 1
   fi
 
+  # ── Move running agents onto the new image ──
+  # After `up`, so the runner is already reconciling and reports the stopped
+  # sandbox on its first pass rather than waiting out an interval.
+
+  reap_sandboxes
+
   # ── Success ──
 
   echo ""
@@ -513,9 +692,22 @@ main() {
     echo "  Dashboard:  $RESOLVED_EXTERNAL"
     echo "  Gateway:    $RESOLVED_GATEWAY"
     echo "  API:        $RESOLVED_API"
-    if grep "^COMPOSE_PROFILES=" "$ENV_FILE" | tail -1 | grep -q runner; then
+    if runner_profile_on; then
       echo "  Agents:     hosted agents are ON (the runner mounts the Docker socket to start sandboxes;"
       echo "              disable with COMPOSE_PROFILES= in $ENV_FILE)"
+      if [ -n "$REAP_KEPT" ]; then
+        echo "              running sandboxes left alone (ONECLI_KEEP_SANDBOXES is set); they keep the"
+        echo "              old agent image until they next restart"
+      elif [ "$REAPED" -gt 0 ]; then
+        # "current", not "new": the pull above is non-fatal, so this may well
+        # be the same image they were already on. Claiming otherwise would
+        # send an operator hunting for a version bump that never happened.
+        echo "              restarted $REAPED running sandbox(es) onto the current agent image; any turn"
+        echo "              in flight reports that the agent restarted, and every /workspace is intact"
+        if [ -n "$AGENT_PULL_FAILED" ]; then
+          echo "              (the agent image pull failed above, so that is the image already on this host)"
+        fi
+      fi
     else
       echo "  Agents:     off (set COMPOSE_PROFILES=runner in $ENV_FILE to enable hosted agents)"
     fi
@@ -563,6 +755,44 @@ if [ "$1" = "--print-resolved" ]; then
   echo "external=$RESOLVED_EXTERNAL"
   echo "api=$RESOLVED_API"
   echo "gateway=$RESOLVED_GATEWAY"
+  exit 0
+fi
+
+# Hidden verification hook: print the agent sandbox image this install pulls,
+# resolved exactly as the pull step resolves it.
+if [ "$1" = "--print-agent-image" ]; then
+  ONECLI_VERSION="${ONECLI_VERSION:-latest}"
+  printf '%s\n' "$(agent_image_ref)"
+  exit 0
+fi
+
+# Hidden verification hook: whether a reference would be pulled from a
+# registry or treated as locally built. This is the supply-chain guard, so its
+# edge cases are pinned by tests rather than trusted.
+if [ "$1" = "--print-ref-pullable" ]; then
+  if ref_is_pullable "$2"; then
+    echo "pullable"
+  else
+    echo "local"
+  fi
+  exit 0
+fi
+
+# Hidden verification hook: print this installation's sandbox-label
+# fingerprint, so a test can pin it against apps/runner/src/installation.ts.
+if [ "$1" = "--print-installation-id" ]; then
+  installation_fingerprint || exit 1
+  exit 0
+fi
+
+# Hidden verification hook: run ONLY the sandbox restart, through
+# $ONECLI_DOCKER_CMD, so tests can assert every docker call it makes and every
+# destructive one it must never make.
+if [ "$1" = "--reap-sandboxes" ]; then
+  STACK="split"
+  reap_sandboxes
+  echo "reaped=$REAPED"
+  echo "kept=$REAP_KEPT"
   exit 0
 fi
 

--- a/scripts/lib/sandbox-reap.mjs
+++ b/scripts/lib/sandbox-reap.mjs
@@ -1,0 +1,106 @@
+// Restarting an installation's agent sandboxes so they pick up a new image.
+//
+// Agent sandboxes are containers the runner creates through the Docker API,
+// not compose services. They therefore carry none of the `com.docker.compose.*`
+// labels, and `docker compose down`/`up` never touches them: after an upgrade
+// they keep running the OLD agent image until something stops them. Both
+// self-host front doors (scripts/install.sh and `pnpm run setup`) call the
+// same logic, which is why it lives here rather than in scripts/setup/ -- this
+// module must stay dependency-free so its tests run without @clack/prompts.
+//
+// Two invariants govern everything below.
+//
+// FENCE ON BOTH LABELS. `sh.onecli.managed=1` alone also matches a co-located
+// installation's containers; pairing it with `sh.onecli.installation` is what
+// keeps one stack from reaping another's live agents. This mirrors the
+// runner's own orphan sweep, and apps/runner/src/installation.ts explains why
+// the identity exists at all. No fingerprint means no sweep: an unknown
+// installation is never a reason to widen the filter.
+//
+// CONTAINERS ONLY. The durable home volumes (onecli-home-<sandboxId>) carry
+// the IDENTICAL label pair, so this exact filter aimed at `docker volume rm`
+// would erase every agent's /workspace. Nothing here may ever use `volume`,
+// `rm -v`, or a prune, and a test asserts those calls are never made.
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+
+export const MANAGED_LABEL = "sh.onecli.managed=1";
+export const INSTALLATION_LABEL = "sh.onecli.installation";
+
+/**
+ * A stable, non-secret fingerprint of THIS installation, derived from the
+ * runner's registration token.
+ *
+ * Byte-equal with `installationFingerprint` in apps/runner/src/installation.ts
+ * and with `installation_fingerprint` in scripts/install.sh. The runner stamps
+ * this value onto every sandbox container it creates, so all three must agree
+ * exactly or the filter silently matches nothing.
+ */
+export const installationFingerprint = (token) =>
+  createHash("sha256").update(token).digest("hex").slice(0, 32);
+
+/**
+ * The `docker ps` filter that selects exactly this installation's sandbox
+ * containers. Exported so a test can assert both doors use the same pair.
+ */
+export const sandboxFilterArgs = (fingerprint) => [
+  "--filter",
+  `label=${MANAGED_LABEL}`,
+  "--filter",
+  `label=${INSTALLATION_LABEL}=${fingerprint}`,
+];
+
+/**
+ * Stop this installation's running sandboxes.
+ *
+ * Returns `{ stopped, kept }`: how many containers were stopped, and whether
+ * the operator opted out. Best effort throughout -- a failed stop leaves an
+ * agent on the old image until it next restarts, which is not worth failing an
+ * otherwise successful upgrade over.
+ *
+ * `stop`, not `rm`: the runner recreates a sandbox container from the current
+ * image on the agent's next message either way, and a stopped container is
+ * reported to the control plane on the very next reconcile pass, where a
+ * removed one has to be noticed as vanished across two.
+ */
+export const reapSandboxes = ({
+  token,
+  keep = false,
+  docker = "docker",
+} = {}) => {
+  if (keep) return { stopped: 0, kept: true };
+  if (!token) return { stopped: 0, kept: false };
+
+  const run = (args) => {
+    try {
+      return execFileSync(docker, args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return "";
+    }
+  };
+
+  const ids = run([
+    "ps",
+    "-q",
+    ...sandboxFilterArgs(installationFingerprint(token)),
+  ])
+    .split("\n")
+    .filter(Boolean);
+  if (!ids.length) return { stopped: 0, kept: false };
+
+  let stopped = 0;
+  for (const id of ids) {
+    try {
+      // -t 30 matches the runner's own graceful stop timeout.
+      execFileSync(docker, ["stop", "-t", "30", id], { stdio: "ignore" });
+      stopped += 1;
+    } catch {
+      // Already gone, or held by something else. Best effort.
+    }
+  }
+  return { stopped, kept: false };
+};

--- a/scripts/lib/sandbox-reap.test.mjs
+++ b/scripts/lib/sandbox-reap.test.mjs
@@ -1,0 +1,148 @@
+// The Node half of the sandbox restart, used by `pnpm run setup`. The shell
+// half lives in scripts/install.sh and is covered by
+// scripts/install-sh.test.mjs; scripts/upgrade-parity.test.mjs pins that the
+// two halves agree.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  INSTALLATION_LABEL,
+  MANAGED_LABEL,
+  installationFingerprint,
+  reapSandboxes,
+  sandboxFilterArgs,
+} from "./sandbox-reap.mjs";
+
+// Same idiom as scripts/migrate-sh.test.mjs: a stub binary that logs every
+// invocation, so a test can assert both what ran and what did not. It is a
+// real executable (shebang + 0755) because execFileSync takes a binary, not
+// a command line.
+const DOCKER_STUB = `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.STUB_LOG, args.join(" ") + "\\n");
+if (args[0] === "ps") process.stdout.write(process.env.STUB_IDS ?? "");
+process.exit(0);
+`;
+
+const withStub = (fn, ids = "") => {
+  const dir = mkdtempSync(join(tmpdir(), "sandbox-reap-test-"));
+  const stub = join(dir, "stub-docker.mjs");
+  const log = join(dir, "calls.log");
+  writeFileSync(stub, DOCKER_STUB);
+  chmodSync(stub, 0o755);
+  writeFileSync(log, "");
+  const previous = { log: process.env.STUB_LOG, ids: process.env.STUB_IDS };
+  process.env.STUB_LOG = log;
+  process.env.STUB_IDS = ids;
+  try {
+    const result = fn(stub);
+    const calls = readFileSync(log, "utf8").trim().split("\n").filter(Boolean);
+    return { result, calls };
+  } finally {
+    if (previous.log === undefined) delete process.env.STUB_LOG;
+    else process.env.STUB_LOG = previous.log;
+    if (previous.ids === undefined) delete process.env.STUB_IDS;
+    else process.env.STUB_IDS = previous.ids;
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+test("the fingerprint matches apps/runner/src/installation.ts", () => {
+  const token = "rnr_abc123";
+  assert.equal(
+    installationFingerprint(token),
+    createHash("sha256").update(token).digest("hex").slice(0, 32),
+  );
+  assert.equal(installationFingerprint(token).length, 32);
+});
+
+test("the filter always carries BOTH labels", () => {
+  const args = sandboxFilterArgs("deadbeef");
+  assert.deepEqual(args, [
+    "--filter",
+    `label=${MANAGED_LABEL}`,
+    "--filter",
+    `label=${INSTALLATION_LABEL}=deadbeef`,
+  ]);
+  // A managed-only filter would also match a co-located install's live
+  // agents, which is the failure apps/runner/src/installation.ts exists to
+  // prevent.
+  assert.equal(args.filter((a) => a === "--filter").length, 2);
+});
+
+test("keep short-circuits before docker is ever invoked", () => {
+  const { result, calls } = withStub(
+    (docker) => reapSandboxes({ token: "rnr_x", keep: true, docker }),
+    "abc\n",
+  );
+  assert.deepEqual(result, { stopped: 0, kept: true });
+  assert.deepEqual(calls, []);
+});
+
+test("a missing token means no sweep: the fence is never widened", () => {
+  const { result, calls } = withStub(
+    (docker) => reapSandboxes({ token: "", docker }),
+    "abc\n",
+  );
+  assert.deepEqual(result, { stopped: 0, kept: false });
+  assert.deepEqual(calls, []);
+});
+
+test("nothing running is a clean no-op", () => {
+  const { result, calls } = withStub(
+    (docker) => reapSandboxes({ token: "rnr_x", docker }),
+    "",
+  );
+  assert.deepEqual(result, { stopped: 0, kept: false });
+  assert.deepEqual(
+    calls.filter((c) => c.startsWith("stop")),
+    [],
+  );
+});
+
+test("the ps call is fenced on this installation's fingerprint", () => {
+  const { calls } = withStub(
+    (docker) => reapSandboxes({ token: "rnr_x", docker }),
+    "abc123\n",
+  );
+  const ps = calls.find((c) => c.startsWith("ps "));
+  assert.ok(ps, "expected a docker ps call");
+  assert.ok(ps.includes(`label=${MANAGED_LABEL}`));
+  assert.ok(
+    ps.includes(
+      `label=${INSTALLATION_LABEL}=${installationFingerprint("rnr_x")}`,
+    ),
+  );
+});
+
+test("stops each matching sandbox gracefully and never touches volumes", () => {
+  const { result, calls } = withStub(
+    (docker) => reapSandboxes({ token: "rnr_x", docker }),
+    "abc123\ndef456\n",
+  );
+  assert.deepEqual(result, { stopped: 2, kept: false });
+  assert.deepEqual(
+    calls.filter((c) => c.startsWith("stop")),
+    ["stop -t 30 abc123", "stop -t 30 def456"],
+  );
+  // The durable homes carry the identical label pair, so a destructive verb
+  // here would erase every agent's /workspace.
+  for (const forbidden of ["volume", "rm", "prune", "-v"])
+    assert.deepEqual(
+      calls.filter((c) => c.split(" ").includes(forbidden)),
+      [],
+      `docker was called with "${forbidden}"`,
+    );
+});

--- a/scripts/lib/upgrade.mjs
+++ b/scripts/lib/upgrade.mjs
@@ -1,0 +1,108 @@
+// The Node half of the self-host upgrade decisions, kept pure and
+// dependency-free so it is testable without @clack/prompts (which
+// scripts/setup/ui.mjs pulls in transitively) and so scripts/install.sh's
+// shell half can be compared against it byte for byte.
+//
+// The shell half lives in scripts/install.sh (`ref_is_pullable`,
+// `agent_image_ref`); scripts/upgrade-parity.test.mjs runs both over the same
+// inputs and asserts they agree.
+
+import { realpathSync } from "node:fs";
+
+/**
+ * Whether a reference names a registry we may pull from.
+ *
+ * Docker treats the first path segment as a registry only when it contains a
+ * "." or a ":". Everything else is a Docker Hub shorthand: `onecli-agent:dev`
+ * becomes docker.io/library/onecli-agent, and `myorg/agent:1` becomes
+ * docker.io/myorg/agent. Pulling either would fetch whoever owns that name
+ * upstream, over the top of a locally built image. Refusing costs a skipped
+ * pull and a printed line; accepting runs a stranger's code as the agent
+ * sandbox.
+ *
+ * `localhost/foo` is refused too. That is a real (if unusual) local-registry
+ * reference, so this is a false negative, but it fails in the safe direction
+ * and the caller says so out loud.
+ */
+export const isPullableRef = (ref) => {
+  if (typeof ref !== "string" || !ref.includes("/")) return false;
+  const host = ref.slice(0, ref.indexOf("/"));
+  return host.includes(".") || host.includes(":");
+};
+
+/**
+ * The agent sandbox image this install starts agents from.
+ *
+ * Precedence matches docker compose interpolation exactly: a shell value beats
+ * the env file, for both keys. Getting this wrong is not cosmetic -- the
+ * runner reads RUNNER_AGENT_IMAGE through compose, so resolving it differently
+ * here would pull one image and then start agents from another.
+ *
+ * `env` is anything with a `.get(key)` (an EnvFile, or a plain stub in tests).
+ */
+export const agentImageRef = (env, procEnv = {}) => {
+  const fromEnv = (key) => procEnv[key] || env.get(key) || "";
+  return (
+    fromEnv("RUNNER_AGENT_IMAGE") ||
+    `ghcr.io/onecli/onecli-agent:${fromEnv("ONECLI_VERSION") || "latest"}`
+  );
+};
+
+const realOrSelf = (p) => {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+};
+
+/**
+ * Who owns the compose project that is currently running.
+ *
+ * Both front doors drive the project name `onecli`, from different files with
+ * different SECRET_ENCRYPTION_KEYs, so "whose install is this?" has to be
+ * answered before an upgrade recreates anything. Getting it wrong in either
+ * direction is expensive: a false "not ours" blocks the documented upgrade
+ * command, and a false "ours" makes every stored credential undecryptable.
+ *
+ * `configFiles` is the com.docker.compose.project.config_files label, split
+ * into paths -- or `null` when the probe could not run, which is NOT the same
+ * as an empty list and must never be read as permission.
+ *
+ * Returns one of:
+ *   { ours: true }
+ *   { ours: false, kind: "probe-failed" }
+ *   { ours: false, kind: "nothing-running" }
+ *   { ours: false, kind: "installer" | "checkout", owner }
+ */
+export const composeProjectOwner = (configFiles, { composeDir, homeDir }) => {
+  if (configFiles === null) return { ours: false, kind: "probe-failed" };
+  if (!configFiles.length) return { ours: false, kind: "nothing-running" };
+
+  // Every compose file this checkout can legitimately drive the project with.
+  // docker-compose.dev.yml deliberately shares `name: onecli` so `pnpm dev`
+  // reuses the same postgres volume, so a developer with the dev database up
+  // is still the owner -- treating them as a stranger would refuse the upgrade
+  // command on every development machine.
+  const ours = new Set(
+    ["docker-compose.yml", "docker-compose.dev.yml", "docker-compose.build.yml"]
+      .map((f) => `${composeDir}/${f}`)
+      .map(realOrSelf),
+  );
+  // Realpath both sides: compose records the path as invoked, while Node
+  // resolves symlinks, so a checkout reached through a symlinked path (or
+  // macOS /tmp -> /private/tmp) would otherwise fail to recognize itself.
+  const resolved = configFiles.map(realOrSelf);
+  if (resolved.some((p) => ours.has(p))) return { ours: true };
+
+  const owner = resolved[0];
+  // Only an install.sh install can be repaired by re-running install.sh. For
+  // any OTHER checkout, that advice is destructive: ~/.onecli/.env would not
+  // exist, the installer would mint a fresh SECRET_ENCRYPTION_KEY, and every
+  // stored credential would stop decrypting.
+  const installerHome = realOrSelf(`${homeDir}/.onecli`);
+  const kind = resolved.some((p) => p.startsWith(`${installerHome}/`))
+    ? "installer"
+    : "checkout";
+  return { ours: false, kind, owner };
+};

--- a/scripts/lib/upgrade.test.mjs
+++ b/scripts/lib/upgrade.test.mjs
@@ -1,0 +1,188 @@
+// The Node half of the upgrade decisions. Both guards here were previously
+// mutation-invisible: rewriting isPullableRef to `return true`, or deleting the
+// whole ownership check, left the suite green because nothing imported them.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  agentImageRef,
+  composeProjectOwner,
+  isPullableRef,
+} from "./upgrade.mjs";
+
+const envStub = (values) => ({ get: (k) => values[k] });
+
+test("only references naming a registry host are pulled", () => {
+  // Everything else is a Docker Hub shorthand: `onecli-agent:dev` becomes
+  // docker.io/library/onecli-agent, so pulling it would fetch whatever a
+  // squatter published there over a locally built image.
+  for (const ref of [
+    "ghcr.io/onecli/onecli-agent:2.1.0",
+    "ghcr.io/o/a@sha256:abc",
+    "localhost:5000/foo:1",
+    "myreg:5000/team/img:1",
+    "docker.io/library/onecli-agent:dev",
+  ])
+    assert.equal(isPullableRef(ref), true, ref);
+
+  for (const ref of [
+    "onecli-agent:dev",
+    "onecli-agent",
+    "onecli/onecli-agent:dev",
+    "localhost/foo:1",
+    "/foo:1",
+    "",
+  ])
+    assert.equal(isPullableRef(ref), false, JSON.stringify(ref));
+});
+
+test("the agent image defaults to the compose default", () => {
+  assert.equal(
+    agentImageRef(envStub({}), {}),
+    "ghcr.io/onecli/onecli-agent:latest",
+  );
+  assert.equal(
+    agentImageRef(envStub({ ONECLI_VERSION: "2.1.0" }), {}),
+    "ghcr.io/onecli/onecli-agent:2.1.0",
+  );
+  assert.equal(
+    agentImageRef(envStub({ RUNNER_AGENT_IMAGE: "onecli-agent:dev" }), {}),
+    "onecli-agent:dev",
+  );
+});
+
+test("a shell value beats the env file, exactly as compose interpolates", () => {
+  // The runner reads RUNNER_AGENT_IMAGE through compose, so resolving it by a
+  // different precedence here would pull one image and start agents on
+  // another. This is the mismatch the parity test now also checks live.
+  assert.equal(
+    agentImageRef(envStub({ RUNNER_AGENT_IMAGE: "ghcr.io/acme/file:1" }), {
+      RUNNER_AGENT_IMAGE: "ghcr.io/acme/shell:2",
+    }),
+    "ghcr.io/acme/shell:2",
+  );
+  assert.equal(
+    agentImageRef(envStub({ ONECLI_VERSION: "2.0.0" }), {
+      ONECLI_VERSION: "2.1.0",
+    }),
+    "ghcr.io/onecli/onecli-agent:2.1.0",
+  );
+});
+
+const withCheckout = (fn) => {
+  const root = mkdtempSync(join(tmpdir(), "onecli-owner-"));
+  const composeDir = join(root, "docker");
+  mkdirSync(composeDir, { recursive: true });
+  for (const f of [
+    "docker-compose.yml",
+    "docker-compose.dev.yml",
+    "docker-compose.build.yml",
+  ])
+    writeFileSync(join(composeDir, f), "");
+  const homeDir = join(root, "home");
+  mkdirSync(join(homeDir, ".onecli"), { recursive: true });
+  writeFileSync(join(homeDir, ".onecli", "docker-compose.yml"), "");
+  try {
+    return fn({ root, composeDir, homeDir });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test("our own compose files are recognized as ours", () => {
+  withCheckout(({ composeDir, homeDir }) => {
+    for (const f of ["docker-compose.yml", "docker-compose.build.yml"])
+      assert.deepEqual(
+        composeProjectOwner([join(composeDir, f)], { composeDir, homeDir }),
+        { ours: true },
+        f,
+      );
+  });
+});
+
+test("the dev database counts as ours, not as a stranger", () => {
+  // docker-compose.dev.yml deliberately sets `name: onecli` so `pnpm dev`
+  // reuses the same postgres volume. Treating it as a foreign project would
+  // refuse `pnpm run setup --upgrade` on every machine running the dev stack,
+  // and tell the developer to run an installer that would mint a new
+  // encryption key over their data.
+  withCheckout(({ composeDir, homeDir }) => {
+    assert.deepEqual(
+      composeProjectOwner([join(composeDir, "docker-compose.dev.yml")], {
+        composeDir,
+        homeDir,
+      }),
+      { ours: true },
+    );
+  });
+});
+
+test("a checkout reached through a symlink still recognizes itself", () => {
+  // Compose records the path as invoked; Node resolves symlinks. Without
+  // realpath on both sides a symlinked checkout (or macOS /tmp) fails to
+  // recognize its own project.
+  withCheckout(({ root, composeDir, homeDir }) => {
+    const link = join(root, "linked");
+    symlinkSync(join(root, "docker"), link);
+    assert.deepEqual(
+      composeProjectOwner([join(link, "docker-compose.yml")], {
+        composeDir,
+        homeDir,
+      }),
+      { ours: true },
+    );
+  });
+});
+
+test("an install.sh-owned project is named as the installer's", () => {
+  withCheckout(({ composeDir, homeDir }) => {
+    const r = composeProjectOwner(
+      [join(homeDir, ".onecli", "docker-compose.yml")],
+      { composeDir, homeDir },
+    );
+    assert.equal(r.ours, false);
+    // Only this kind may be told to re-run the installer. For any other
+    // checkout that advice mints a fresh SECRET_ENCRYPTION_KEY over their data.
+    assert.equal(r.kind, "installer");
+  });
+});
+
+test("another checkout is NOT told to run the installer", () => {
+  withCheckout(({ composeDir, homeDir }) => {
+    const r = composeProjectOwner(
+      ["/somewhere/else/docker/docker-compose.yml"],
+      {
+        composeDir,
+        homeDir,
+      },
+    );
+    assert.equal(r.ours, false);
+    assert.equal(r.kind, "checkout");
+    assert.equal(r.owner, "/somewhere/else/docker/docker-compose.yml");
+  });
+});
+
+test("a failed probe is never read as permission", () => {
+  // null (the probe could not run) must stay distinct from [] (it ran and
+  // found nothing); collapsing them turns a docker hiccup into consent.
+  withCheckout(({ composeDir, homeDir }) => {
+    assert.deepEqual(composeProjectOwner(null, { composeDir, homeDir }), {
+      ours: false,
+      kind: "probe-failed",
+    });
+    assert.deepEqual(composeProjectOwner([], { composeDir, homeDir }), {
+      ours: false,
+      kind: "nothing-running",
+    });
+  });
+});

--- a/scripts/setup/compose.mjs
+++ b/scripts/setup/compose.mjs
@@ -13,6 +13,11 @@ import { fileURLToPath } from "node:url";
 import { SetupError } from "./errors.mjs";
 import { log, spinner } from "./ui.mjs";
 
+// Re-exported so callers have one import site for the image decisions; the
+// logic itself lives in scripts/lib/ so it stays testable without this
+// module's @clack/prompts dependency (via ui.mjs).
+export { agentImageRef, isPullableRef } from "../lib/upgrade.mjs";
+
 const ROOT = fileURLToPath(new URL("../..", import.meta.url));
 
 export const composeArgs = (mode) => [
@@ -28,6 +33,16 @@ const run = (args) =>
 export const pullImages = (mode) => {
   log.step("Pulling images (docker compose pull)");
   return run([...composeArgs(mode), "pull"]).status === 0;
+};
+
+/**
+ * Pull the agent sandbox image. Non-throwing like `pullImages`: the caller
+ * warns and carries on, because this is the largest image by far and a flaky
+ * network must not fail an upgrade whose services are already pulled.
+ */
+export const pullAgentImage = (ref) => {
+  log.step(`Pulling the agent sandbox image (${ref})`);
+  return run(["pull", ref]).status === 0;
 };
 
 export const buildImages = (mode, { includeAgent = true } = {}) => {

--- a/scripts/setup/detect.mjs
+++ b/scripts/setup/detect.mjs
@@ -47,6 +47,44 @@ export const projectContainers = async () => {
   });
 };
 
+/**
+ * The compose file(s) the RUNNING `onecli` project was started from.
+ *
+ * Both front doors drive the same project name from different files:
+ * scripts/install.sh from ~/.onecli/docker-compose.yml with ~/.onecli/.env,
+ * this wizard from the checkout with docker/.env. Those .env files hold
+ * DIFFERENT SECRET_ENCRYPTION_KEYs, so recreating an install.sh project from
+ * the checkout would leave every stored credential undecryptable. This label
+ * is how the wizard tells whose install it is looking at before touching it.
+ *
+ * Returns `null` when the probe itself could not run, and `[]` when it ran and
+ * found nothing. The distinction is load-bearing: a caller that collapses them
+ * treats a docker hiccup as permission to proceed, which is exactly the case
+ * this probe exists to block.
+ */
+export const projectConfigFiles = async () => {
+  try {
+    const { stdout } = await execFile("docker", [
+      "ps",
+      "--filter",
+      "label=com.docker.compose.project=onecli",
+      // `.Label "key"`, not `index .Labels "key"`: in `docker ps --format`,
+      // .Labels is a comma-joined STRING, so indexing it errors out and the
+      // probe would silently report "cannot tell" for every install.
+      "--format",
+      '{{.Label "com.docker.compose.project.config_files"}}',
+    ]);
+    return stdout
+      .trim()
+      .split("\n")
+      .flatMap((line) => line.split(","))
+      .map((p) => p.trim())
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+};
+
 const dockerOut = (args) => {
   try {
     return execFileSync("docker", args, {

--- a/scripts/setup/index.mjs
+++ b/scripts/setup/index.mjs
@@ -12,6 +12,9 @@ const HELP = `pnpm run setup: install and start OneCLI on this machine
 
 Interactive by default. Flags for scripted runs:
   --yes               accept every default, ask nothing (required off-TTY)
+  --upgrade           pull the newest images (agent sandbox image included) and
+                      restart running agents onto them; keep them with
+                      ONECLI_KEEP_SANDBOXES=1
   --mode=<m>          compose (published images) | source (build from this checkout)
   --no-runner         leave hosted agents off (no COMPOSE_PROFILES=runner)
   --channel-adapter   also enable the Slack channel adapter profile
@@ -33,6 +36,7 @@ try {
   parsed = parseArgs({
     options: {
       yes: { type: "boolean", default: false },
+      upgrade: { type: "boolean", default: false },
       mode: { type: "string" },
       "no-runner": { type: "boolean", default: false },
       "channel-adapter": { type: "boolean", default: false },
@@ -80,6 +84,7 @@ try {
   setAssumeYes(values.yes);
   await runWizard({
     yes: values.yes,
+    upgrade: values.upgrade,
     mode: values.mode,
     noRunner: values["no-runner"],
     channelAdapter: values["channel-adapter"],

--- a/scripts/setup/wizard.mjs
+++ b/scripts/setup/wizard.mjs
@@ -5,21 +5,27 @@
 // generate-or-reuse, so a second run keeps a working install working.
 
 import { renameSync } from "node:fs";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { EnvFile, resolveEnv } from "../lib/env-file.mjs";
 import { portBusy, portOwner } from "../lib/ports.mjs";
+import { reapSandboxes } from "../lib/sandbox-reap.mjs";
+import { composeProjectOwner } from "../lib/upgrade.mjs";
 import { showBanner } from "./banner.mjs";
 import {
+  agentImageRef,
   buildImages,
   composeArgs,
   healthWait,
+  isPullableRef,
   openBrowser,
+  pullAgentImage,
   pullImages,
   upStack,
 } from "./compose.mjs";
-import { dockerUp, projectContainers } from "./detect.mjs";
+import { dockerUp, projectConfigFiles, projectContainers } from "./detect.mjs";
 import { SetupError } from "./errors.mjs";
 import {
   externalUrlProblem,
@@ -108,49 +114,96 @@ export const runWizard = async (opts) => {
     const running = (docker ? await projectContainers() : []).filter(
       (c) => c.state === "running",
     );
-    return { docker, running };
+    const configFiles = running.length ? await projectConfigFiles() : [];
+    return { docker, running, configFiles };
   })();
   await showBanner({ animate: !opts.yes });
 
   const s = spinner();
   s.start("Looking at what you already have…");
-  const { docker, running } = await detecting;
+  const { docker, running, configFiles } = await detecting;
   let env = new EnvFile(ENV_PATH, { label: "pnpm run setup" });
   s.stop(
     `Detected: docker ${docker ? "✓" : "✗"} · ${env.existed ? "existing install config" : "no existing install"}${running.length ? ` · ${running.length} service(s) running` : ""}`,
   );
 
-  // ── existing config: keep / review / reset ──
+  // ── existing config: keep / upgrade / review / reset ──
   let reviewing = false;
+  let upgrading = Boolean(opts.upgrade);
   if (env.existed) {
-    const action = await askSelect({
-      message: "Found an existing docker/.env. What should we do?",
-      options: [
-        {
-          value: "keep",
-          label: "Keep it",
-          hint: "reuse every value and just (re)start the stack",
-        },
-        {
-          value: "review",
-          label: "Review and update",
-          hint: "walk setup again; current values are kept",
-        },
-        {
-          value: "reset",
-          label: "Reset",
-          hint: "archive docker/.env and start fresh",
-        },
-      ],
-      initialValue: "keep",
-    });
+    // --upgrade is not just a shortcut: off-TTY runs are rejected outright and
+    // --yes makes askSelect return its initialValue silently, so a flag is the
+    // only way a scripted run can reach the upgrade path at all.
+    const action = upgrading
+      ? "upgrade"
+      : await askSelect({
+          message: "Found an existing docker/.env. What should we do?",
+          options: [
+            {
+              value: "keep",
+              label: "Keep it",
+              hint: "reuse every value and just (re)start the stack",
+            },
+            {
+              value: "upgrade",
+              label: "Upgrade",
+              hint: "pull the newest images and restart running agents onto them",
+            },
+            {
+              value: "review",
+              label: "Review and update",
+              hint: "walk setup again; current values are kept",
+            },
+            {
+              value: "reset",
+              label: "Reset",
+              hint: "archive docker/.env and start fresh",
+            },
+          ],
+          initialValue: "keep",
+        });
     if (action === "reset") {
       const backup = `${ENV_PATH}.bak-${new Date().toISOString().replace(/[:.]/g, "-")}`;
       renameSync(ENV_PATH, backup);
       log.step(`Archived the old config to ${backup}`);
       env = new EnvFile(ENV_PATH, { label: "pnpm run setup" });
     }
-    reviewing = action !== "keep";
+    // Upgrading is deliberately NOT reviewing: it must not reopen the URL and
+    // bind questions, which is all "review" means here.
+    reviewing = action === "review" || action === "reset";
+    upgrading = action === "upgrade";
+  }
+
+  // The running project may belong to a DIFFERENT install. Every front door
+  // drives the compose project `onecli`, but from different files with
+  // different SECRET_ENCRYPTION_KEYs, so recreating someone else's project
+  // from here would leave every stored credential undecryptable. Refuse, and
+  // name a remedy that is actually safe for whoever owns it.
+  if (upgrading) {
+    const owner = composeProjectOwner(configFiles, {
+      composeDir: join(ROOT, "docker"),
+      homeDir: homedir(),
+    });
+    if (owner.kind === "probe-failed")
+      throw new SetupError(
+        "Could not determine which install owns the running OneCLI stack.",
+        [
+          "The docker probe for the com.docker.compose.project.config_files label failed",
+          "Upgrading without that answer could recreate another install's stack with this checkout's docker/.env, and every credential it stored would stop decrypting",
+          "Check that `docker ps` works, then re-run",
+        ],
+      );
+    if (!owner.ours && owner.kind !== "nothing-running")
+      throw new SetupError(
+        "The OneCLI stack running on this machine was not started from this checkout.",
+        [
+          `It runs from: ${owner.owner}`,
+          "That install's own env file holds the SECRET_ENCRYPTION_KEY its data is encrypted with; upgrading from here would recreate the stack with this checkout's key instead, and every stored credential would stop decrypting",
+          owner.kind === "installer"
+            ? "Upgrade it with the installer that owns it: curl -fsSL https://onecli.sh/install | sh"
+            : `Upgrade it from the checkout that owns it: cd ${dirname(dirname(owner.owner))} && pnpm run setup --upgrade`,
+        ],
+      );
   }
 
   // ── run mode ──
@@ -264,6 +317,26 @@ export const runWizard = async (opts) => {
       ]);
     mode = "source";
   }
+  // The agent sandbox image is not a compose service, so the pull above could
+  // not have fetched it. This runs on EVERY compose-mode setup, not only an
+  // upgrade: `pullImages` already moves the six services forward, and leaving
+  // the agent image behind is exactly the drift being fixed here. Source mode
+  // skips it, because buildImages below rebuilds it from this checkout.
+  if (mode === "compose" && profiles.includes("runner")) {
+    const ref = agentImageRef(env, process.env);
+    if (!isPullableRef(ref)) {
+      // Not necessarily "built locally": a two-segment ref like myorg/agent:1
+      // is a real Docker Hub reference we refuse on purpose, since pulling it
+      // could replace a locally built image from a namespace we do not own.
+      log.step(
+        `Agent sandbox image ${ref} names no registry host, so it is not pulled`,
+      );
+    } else if (!pullAgentImage(ref)) {
+      log.warn(
+        `Could not pull ${ref}. OneCLI will still start, but hosted agents keep using the agent image already on this host.`,
+      );
+    }
+  }
   if (mode === "source") {
     // However source mode was reached — chosen up front or as the
     // pull-failure fallback — the runner must use the locally built agent
@@ -283,6 +356,29 @@ export const runWizard = async (opts) => {
   upStack(mode);
   const { bind, appPort, gatewayPort, apiPort } = resolvedPorts(env);
   await healthWait({ bind, apiPort, appPort, mode });
+
+  // Move running agents onto the image we just pulled. Sandboxes are runner
+  // created containers with no compose labels, so `up` never replaces them:
+  // without this they keep running the old agent image indefinitely. Only on
+  // an explicit upgrade, because it interrupts whatever an agent is doing.
+  let reaped = { stopped: 0, kept: false };
+  if (upgrading && profiles.includes("runner")) {
+    const resolved = resolveEnv(env, process.env);
+    reaped = reapSandboxes({
+      token: resolved.RUNNER_TOKEN,
+      // Shell value or docker/.env line, same as install.sh reads it, so the
+      // documented escape hatch behaves identically at both doors.
+      keep: Boolean(resolved.ONECLI_KEEP_SANDBOXES),
+    });
+    if (reaped.kept)
+      log.step(
+        "Left running agent sandboxes alone (ONECLI_KEEP_SANDBOXES is set)",
+      );
+    else if (reaped.stopped)
+      log.step(
+        `Restarted ${reaped.stopped} agent sandbox(es) onto the new image`,
+      );
+  }
 
   // Display the ADVERTISED addresses (what the resolver serves the browser),
   // not the publish plane — the two are decoupled now. The browser open
@@ -305,7 +401,7 @@ export const runWizard = async (opts) => {
       "Create your account right away. The first account owns the instance.",
       "",
       `Stop:    docker ${composeArgs(mode).join(" ")} down`,
-      "Update:  re-run pnpm run setup",
+      "Update:  git pull && pnpm install && pnpm run setup --upgrade",
     ].join("\n"),
     "OneCLI is running",
   );

--- a/scripts/upgrade-parity.test.mjs
+++ b/scripts/upgrade-parity.test.mjs
@@ -1,0 +1,283 @@
+// The upgrade contract, shared by the two self-host front doors.
+//
+// scripts/install.sh (POSIX sh, no toolchain) and `pnpm run setup` (Node ESM)
+// cannot share an implementation, and scripts/setup/detect.mjs states the rule
+// they must both satisfy: "the two front doors must provision identically or
+// an install's behavior would depend on which door it came through." This file
+// is where that identity is enforced. If you change one door, this fails until
+// you change the other.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  INSTALLATION_LABEL,
+  MANAGED_LABEL,
+  installationFingerprint,
+} from "./lib/sandbox-reap.mjs";
+import { agentImageRef, isPullableRef } from "./lib/upgrade.mjs";
+
+const REPO = fileURLToPath(new URL("..", import.meta.url));
+const read = (rel) => readFileSync(join(REPO, rel), "utf8");
+
+const INSTALL_SH = read("scripts/install.sh");
+const REAP_MJS = read("scripts/lib/sandbox-reap.mjs");
+const RUNNER_INSTALLATION_TS = read("apps/runner/src/installation.ts");
+const DOCKER_BACKEND_TS = read(
+  "apps/runner/src/backend/docker/docker-backend.ts",
+);
+const COMPOSE_YML = read("docker/docker-compose.yml");
+
+test("the sources this contract reads are not empty", () => {
+  // Canary: every assertion below is a substring search, so a renamed or
+  // moved file would make this whole suite vacuously green.
+  for (const [name, body] of [
+    ["install.sh", INSTALL_SH],
+    ["sandbox-reap.mjs", REAP_MJS],
+    ["installation.ts", RUNNER_INSTALLATION_TS],
+    ["docker-backend.ts", DOCKER_BACKEND_TS],
+    ["docker-compose.yml", COMPOSE_YML],
+  ])
+    assert.ok(body.length > 200, `${name} looks empty or moved`);
+});
+
+test("both doors compute the same installation fingerprint", () => {
+  const token = "rnr_paritytoken";
+  const home = mkdtempSync(join(tmpdir(), "onecli-parity-"));
+  mkdirSync(join(home, ".onecli"), { recursive: true });
+  writeFileSync(join(home, ".onecli", ".env"), `RUNNER_TOKEN=${token}\n`);
+  const fromShell = execFileSync(
+    "sh",
+    [join(REPO, "scripts/install.sh"), "--print-installation-id"],
+    { env: { PATH: process.env.PATH, HOME: home }, encoding: "utf8" },
+  ).trim();
+  rmSync(home, { recursive: true, force: true });
+
+  assert.equal(fromShell, installationFingerprint(token));
+  assert.equal(
+    fromShell,
+    createHash("sha256").update(token).digest("hex").slice(0, 32),
+  );
+});
+
+test("the runner stamps the label both doors filter on", () => {
+  // The value side: the runner's own fingerprint must be the same formula.
+  assert.match(RUNNER_INSTALLATION_TS, /createHash\("sha256"\)/);
+  assert.match(RUNNER_INSTALLATION_TS, /\.slice\(0,\s*32\)/);
+  // The key side: the label names are a cross-process contract.
+  assert.ok(DOCKER_BACKEND_TS.includes("sh.onecli.installation"));
+  assert.ok(DOCKER_BACKEND_TS.includes("sh.onecli.managed"));
+});
+
+test("both doors fence the sweep on BOTH labels", () => {
+  for (const [name, body] of [
+    ["install.sh", INSTALL_SH],
+    ["sandbox-reap.mjs", REAP_MJS],
+  ]) {
+    assert.ok(
+      body.includes(MANAGED_LABEL),
+      `${name} is missing the managed label`,
+    );
+    assert.ok(
+      body.includes(INSTALLATION_LABEL),
+      `${name} is missing the installation fence`,
+    );
+  }
+});
+
+/**
+ * Executable lines only. These files DOCUMENT the destructive commands they
+ * must never run, so scanning raw source would match the warnings rather than
+ * the code they warn about.
+ */
+const codeOf = (body, comment) =>
+  body
+    .split("\n")
+    .filter((line) => !new RegExp(`^\\s*${comment}`).test(line))
+    .join("\n");
+
+test("neither door can destroy a durable home", () => {
+  // The onecli-home-* volumes carry the IDENTICAL label pair as the sandbox
+  // containers, so the sweep's filter is one careless verb away from erasing
+  // every agent's /workspace. No door may RUN a volume-destroying command.
+  // `(?<!-)` keeps `docker run --rm -v <read-only mount>` (which this script
+  // legitimately uses to read the docker GID and the legacy key) from reading
+  // as `docker rm -v <container>`, which destroys the container's volumes.
+  const forbidden = [
+    /\bvolume\s+rm\b/,
+    /\bvolume\s+prune\b/,
+    /\bsystem\s+prune\b/,
+    /"volume"/,
+    /(?<!-)\brm\s+-v\b/,
+    /\bdown\s+-v\b/,
+  ];
+  const doors = [
+    ["install.sh", codeOf(INSTALL_SH, "#")],
+    ["sandbox-reap.mjs", codeOf(REAP_MJS, "//")],
+  ];
+  // Canary: if the stripper ever swallowed a file, every assertion below
+  // would pass on an empty string.
+  for (const [name, code] of doors)
+    assert.ok(code.length > 400, `${name}: comment stripping left nothing`);
+  for (const [name, code] of doors)
+    for (const pattern of forbidden)
+      assert.doesNotMatch(code, pattern, `${name} may never run ${pattern}`);
+});
+
+test("both doors honor ONECLI_KEEP_SANDBOXES", () => {
+  assert.ok(INSTALL_SH.includes("ONECLI_KEEP_SANDBOXES"));
+  assert.ok(read("scripts/setup/wizard.mjs").includes("ONECLI_KEEP_SANDBOXES"));
+  // And it is documented where an operator would look.
+  assert.ok(read("docs/self-hosting.md").includes("ONECLI_KEEP_SANDBOXES"));
+});
+
+/** Run one of install.sh's hidden hooks against a scratch HOME and .env. */
+const shellHook = (args, envFile = "", env = {}) => {
+  const home = mkdtempSync(join(tmpdir(), "onecli-parity-"));
+  mkdirSync(join(home, ".onecli"), { recursive: true });
+  if (envFile) writeFileSync(join(home, ".onecli", ".env"), envFile);
+  try {
+    return execFileSync("sh", [join(REPO, "scripts/install.sh"), ...args], {
+      env: { PATH: process.env.PATH, HOME: home, ...env },
+      encoding: "utf8",
+    }).trim();
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+};
+
+test("both doors resolve the SAME agent image, by the same precedence", () => {
+  // Behavioral, not a substring search: the doors previously agreed in
+  // spelling while disagreeing in PRECEDENCE (the shell honored an export,
+  // the wizard read the file only), which would pull one image and start
+  // agents on another. Compare real outputs over the same shell+file pairs.
+  assert.ok(
+    COMPOSE_YML.includes("ghcr.io/onecli/onecli-agent:"),
+    "the compose default moved; publish-workflow.test.mjs pins it too",
+  );
+  // ONECLI_VERSION read from the FILE is deliberately absent here: the two
+  // doors legitimately differ on it, and the test below pins that asymmetry
+  // rather than papering over it.
+  const cases = [
+    { file: {}, shell: {} },
+    { file: { RUNNER_AGENT_IMAGE: "ghcr.io/acme/a:1" }, shell: {} },
+    { file: {}, shell: { ONECLI_VERSION: "2.1.0" } },
+    {
+      file: { RUNNER_AGENT_IMAGE: "ghcr.io/acme/file:1" },
+      shell: { RUNNER_AGENT_IMAGE: "ghcr.io/acme/shell:2" },
+    },
+  ];
+  for (const { file, shell } of cases) {
+    const envFile = Object.entries(file)
+      .map(([k, v]) => `${k}=${v}\n`)
+      .join("");
+    const fromShell = shellHook(["--print-agent-image"], envFile, shell);
+    const fromNode = agentImageRef({ get: (k) => file[k] }, shell);
+    assert.equal(
+      fromShell,
+      fromNode,
+      `doors disagree for file=${JSON.stringify(file)} shell=${JSON.stringify(shell)}`,
+    );
+  }
+});
+
+test("install.sh ignores an .env ONECLI_VERSION pin, and that is correct", () => {
+  // The ONE place the doors diverge, pinned so it cannot drift unnoticed.
+  // install.sh does `ONECLI_VERSION="${ONECLI_VERSION:-latest}"; export` before
+  // every compose call, and a shell value beats the project .env in compose
+  // interpolation, so an .env-only pin does not survive that door. Resolving
+  // the agent image to `:latest` there is therefore RIGHT: it is exactly what
+  // compose interpolates into RUNNER_AGENT_IMAGE for the same run. Making
+  // agent_image_ref read the file alone would pull one image and start the
+  // runner on another.
+  //
+  // The wizard exports nothing, so its compose does read docker/.env, and the
+  // Node side honors the file. docs/self-hosting.md states both behaviors.
+  // Teaching install.sh to honor the pin is a recorded follow-up: it also
+  // changes which compose flavor a pinned pre-2.0 install downloads.
+  assert.match(INSTALL_SH, /ONECLI_VERSION="\$\{ONECLI_VERSION:-latest\}"/);
+  assert.equal(
+    shellHook(["--print-agent-image"], "ONECLI_VERSION=2.1.0\n"),
+    "ghcr.io/onecli/onecli-agent:latest",
+  );
+  assert.equal(
+    agentImageRef({ get: (k) => ({ ONECLI_VERSION: "2.1.0" })[k] }, {}),
+    "ghcr.io/onecli/onecli-agent:2.1.0",
+  );
+});
+
+test("the wizard actually consults the ownership guard before upgrading", () => {
+  // composeProjectOwner is unit-tested in scripts/lib/upgrade.test.mjs, but a
+  // tested predicate nobody calls protects nothing: deleting this call site
+  // left every other test green. The failure it guards against is silent and
+  // unrecoverable (recreating another install's project with this checkout's
+  // SECRET_ENCRYPTION_KEY), so the wiring gets pinned too.
+  const wizard = codeOf(read("scripts/setup/wizard.mjs"), "//");
+  assert.match(
+    wizard,
+    /composeProjectOwner\(\s*configFiles/,
+    "the upgrade path must resolve project ownership from the live probe",
+  );
+  assert.match(
+    wizard,
+    /kind === "probe-failed"/,
+    "a probe that could not run must be refused, not treated as permission",
+  );
+});
+
+test("the door-mismatch probe uses a docker ps template that actually works", () => {
+  // Caught live, not by review: `docker ps --format` exposes .Labels as a
+  // comma-joined STRING, so `index .Labels "k"` fails with "cannot index
+  // slice/array with type string". Docker prints the error to stderr and the
+  // probe's catch turns it into [], which callers read as "cannot tell" and
+  // therefore "do not block". The credential-destroying door mismatch would
+  // then sail straight through. `.Label "k"` is the verb that works.
+  const detect = codeOf(read("scripts/setup/detect.mjs"), "//");
+  assert.ok(
+    detect.includes('{{.Label "com.docker.compose.project.config_files"}}'),
+    "projectConfigFiles must read the label with .Label",
+  );
+  assert.doesNotMatch(
+    detect,
+    /index\s+\.Labels/,
+    "index .Labels is a runtime error in docker ps templates",
+  );
+});
+
+test("both doors make the SAME pull-or-not decision for every reference", () => {
+  // The supply-chain guard, compared across the two languages rather than
+  // asserted twice. A door that accepted `onecli-agent:dev` would pull
+  // docker.io/library/onecli-agent over a locally built image.
+  for (const ref of [
+    "ghcr.io/onecli/onecli-agent:2.1.0",
+    "ghcr.io/o/a@sha256:abc",
+    "localhost:5000/foo:1",
+    "myreg:5000/team/img:1",
+    "docker.io/library/onecli-agent:dev",
+    "onecli-agent:dev",
+    "onecli-agent",
+    "onecli/onecli-agent:dev",
+    "localhost/foo:1",
+    "/foo:1",
+    "",
+  ]) {
+    const fromShell = shellHook(["--print-ref-pullable", ref]) === "pullable";
+    assert.equal(
+      fromShell,
+      isPullableRef(ref),
+      `doors disagree for ${JSON.stringify(ref)}`,
+    );
+  }
+});


### PR DESCRIPTION
Two upstream changes.

**Slack transport is an explicit choice at attach.** The transport used to be inferred from reachability (TLS reachable → webhooks, otherwise Socket Mode), which silently forced TLS'd self-hosts onto webhooks and lost the choice entirely. Now:

- The attach flow shows a transport picker (`events` = HTTP webhooks, `socket` = Socket Mode) whenever more than one transport is available; the server resolves every stamping path (attach body, complete body, the manifest's `?transport=`) through one `resolveTransport()` in `packages/api/src/services/channels/posture.ts`.
- Requesting an unavailable transport returns 422; a transport that contradicts the pending row returns 409.
- Resume re-mints the OAuth state for the row's stamped transport, so resuming an events-mode attach no longer loses its install URL.
- The org channels card offers Disconnect / Remove workspace in every state where DELETE changes anything (previously only while credentials were present), so an expired org token no longer leaves an unremovable workspace row. Server semantics are unchanged.

**Self-host upgrade actually moves agents onto the new image.** Agent sandboxes are containers the runner creates through the Docker API — not compose services — so `docker compose pull` never refreshes the agent image, the runner only pulls it on a create-404, and `down --remove-orphans` rides past the unlabeled containers: upgrades silently kept agents on the old image. Both front doors (re-running the install script and `pnpm run setup`) now:

- pull the agent sandbox image explicitly, refusing refs whose first segment names no registry so a shorthand like `onecli-agent:dev` can never resolve to a Docker Hub squatter over a locally built image,
- restart this installation's sandbox containers, fenced on the `sh.onecli.managed` + `sh.onecli.installation` label pair — containers only, never the `onecli-home-<sandboxId>` volumes, which carry the identical labels,
- honor `export ONECLI_KEEP_SANDBOXES=1` to leave running sandboxes alone.

`scripts/upgrade-parity.test.mjs` pins the shell (`install.sh`) and Node (`scripts/lib/upgrade.mjs`) halves to identical decisions; `scripts/lib/{upgrade,sandbox-reap}.test.mjs`, `posture.test.ts`, and the channel route/pg suites cover the rest.
