### PR TITLE
fix: per-conversation jcode sessions + busy self-heal, agent report-back contract, standalone ssh-terminator app

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Agents run on your own infrastructure. The runner is outbound-only and holds no 
 - **[Rust Gateway](apps/gateway)**: intercepts outbound requests (HTTPS included, via MITM) and injects credentials. Agents authenticate with access tokens via `Proxy-Authorization` headers.
 - **[Runner](apps/runner)**: starts, parks and reaps agent sandboxes. Outbound-only, and never touches the database.
 - **[Sandbox Supervisor](apps/sandbox-supervisor)**: runs inside each sandbox, speaking a vendor-neutral harness interface so the agent runtime is swappable.
+- **[SSH Terminator](apps/ssh-terminator)**: the SSH front door — terminates `ssh` connections with short-lived certificates and bridges them into agent sandboxes through a pluggable substrate backend.
 - **[Channel Adapter](apps/channel-adapter)**: the Slack daemon, one app per agent.
 - **Secret Store**: AES-256-GCM at rest, decrypted only at request time, matched by host and path pattern, injected as headers or query parameters.
 

--- a/apps/channel-adapter/src/mirror.test.ts
+++ b/apps/channel-adapter/src/mirror.test.ts
@@ -32,7 +32,7 @@ afterEach(async () => {
 
 const turn = (overrides: Partial<AdapterWorkTurn> = {}): AdapterWorkTurn => ({
   id: "t1",
-  status: "completed",
+  status: "done",
   source: "web",
   userId: "u1",
   message: "Deploy it <now>",
@@ -945,7 +945,9 @@ describe("what gets posted", () => {
     expect("blocks" in posted[0]!.form).toBe(false);
   });
 
-  it("posts nothing at all when there is neither answer nor error, but still advances", async () => {
+  it("posts nothing for a DONE turn with neither answer nor error, but still advances", async () => {
+    // Silence is only legal for a clean turn that genuinely said nothing —
+    // a terminal failure always posts (the suite below).
     const controlPlane = createFakeControlPlane(transcriptWith(null));
 
     const next = await mirror({
@@ -955,6 +957,117 @@ describe("what gets posted", () => {
 
     expect(slack.calls).toEqual([]);
     expect(next).toBe("2026-08-06T10:00:00.000Z");
+  });
+});
+
+describe("failure surfacing — never silent on a terminal outcome", () => {
+  /** A transcript holding arbitrary events for t1. */
+  const transcriptOf = (
+    events: { type: string; payload: unknown }[],
+  ): Pick<ControlPlaneClient, "readTranscript"> => ({
+    readTranscript: async () => ({
+      events: events.map((event, index) => ({
+        seq: index + 1,
+        turnId: "t1",
+        ...event,
+      })),
+      nextSince: events.length + 1,
+      hasMore: false,
+    }),
+  });
+
+  it("a FAILED turn with nothing anywhere posts the canonical failure line", async () => {
+    // The incident's exact shape: uncoded failure, error NULL, no text —
+    // six messages died with the seen-reaction stripped and total silence.
+    const controlPlane = createFakeControlPlane(transcriptWith(null));
+
+    const next = await mirror({
+      controlPlane,
+      workItem: item({ source: "slack", status: "failed" }),
+    });
+
+    expect(next).toBe("2026-08-06T10:00:00.000Z");
+    const posted = slack.callsTo("chat.postMessage");
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.form.text).toContain(":warning:");
+    expect(posted[0]?.form.text).toContain(
+      "Something went wrong and this message didn",
+    );
+  });
+
+  it("a FAILED turn with only a transcript error event posts that message", async () => {
+    // Uncoded harness failures leave their text ONLY in the durable error
+    // event (the supervisor sends no turn.result error for them) — the
+    // mirror must read it, like the web's transcript fold does.
+    const controlPlane = createFakeControlPlane(
+      transcriptOf([
+        { type: "error", payload: { message: "the harness said why" } },
+      ]),
+    );
+
+    await mirror({
+      controlPlane,
+      workItem: item({ source: "slack", status: "failed" }),
+    });
+
+    const posted = slack.callsTo("chat.postMessage");
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.form.text).toContain("the harness said why");
+    // The message IS the failure — no extra line after it.
+    expect(posted[0]?.form.text).not.toContain(":warning:");
+  });
+
+  it("turn.error outranks the transcript error event — canonical copy wins", async () => {
+    const controlPlane = createFakeControlPlane(
+      transcriptOf([
+        { type: "error", payload: { message: "raw vendor wording" } },
+      ]),
+    );
+
+    await mirror({
+      controlPlane,
+      workItem: item({
+        source: "slack",
+        status: "failed",
+        error: "The canonical sentence.",
+      }),
+    });
+
+    const posted = slack.callsTo("chat.postMessage");
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.form.text).toContain("The canonical sentence.");
+    expect(posted[0]?.form.text).not.toContain("raw vendor wording");
+  });
+
+  it("a FAILED turn with partial answer text posts the text AND the failure line", async () => {
+    // A partial answer must never masquerade as a normal reply.
+    const controlPlane = createFakeControlPlane(
+      transcriptWith("Half an answer before it fell over"),
+    );
+
+    await mirror({
+      controlPlane,
+      workItem: item({ source: "slack", status: "failed" }),
+    });
+
+    const posted = slack.callsTo("chat.postMessage");
+    expect(posted).toHaveLength(2);
+    expect(posted[0]?.form.text).toContain("Half an answer");
+    expect(posted[1]?.form.text).toContain(":warning:");
+    expect(posted[1]?.form.text).toContain("stopped partway");
+  });
+
+  it("an ABORTED turn with nothing posts the web's quiet closure word", async () => {
+    const controlPlane = createFakeControlPlane(transcriptWith(null));
+
+    await mirror({
+      controlPlane,
+      workItem: item({ source: "slack", status: "aborted" }),
+    });
+
+    const posted = slack.callsTo("chat.postMessage");
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.form.text).toBe("_Stopped._");
   });
 });
 

--- a/apps/channel-adapter/src/mirror.ts
+++ b/apps/channel-adapter/src/mirror.ts
@@ -4,7 +4,12 @@ import type { AdapterWorkItem } from "@onecli/agent-protocol";
 import { getApp } from "@onecli/api/apps/registry";
 // The one definition of "automated turn" — shared with the control plane's
 // continuity bridge, so a new automation source lands in both in one edit.
-import { AUTOMATION_SOURCES } from "@onecli/api/validations/conversation";
+import {
+  AUTOMATION_SOURCES,
+  TURN_FAILED_PARTIAL_MESSAGE,
+  TURN_FAILED_SILENT_MESSAGE,
+  TURN_STOPPED_MESSAGE,
+} from "@onecli/api/validations/conversation";
 import type { ControlPlaneClient } from "./control-plane";
 import { replyTargetForLink, type ChannelPostTarget } from "./targets";
 
@@ -199,24 +204,33 @@ export const providerIconUrl = (provider: string): string => {
  * posts nothing.
  */
 
-const answerFromTranscript = async (
+const transcriptOutcome = async (
   controlPlane: ControlPlaneClient,
   conversationId: string,
   turnId: string,
-): Promise<string | null> => {
+): Promise<{ text: string | null; error: string | null }> => {
   let since: number | undefined;
-  let answer: string | null = null;
+  let text: string | null = null;
+  // The turn's durable `error` event — the harness's terminal message, which
+  // for uncoded failures is the ONLY record (the supervisor deliberately
+  // sends no `turn.result.error` then, so `turn.error` is NULL). Last one
+  // wins, matching the `text` semantics and the web's transcript fold.
+  let error: string | null = null;
   for (let page = 0; page < 100; page += 1) {
     const history = await controlPlane.readTranscript(conversationId, since);
     for (const event of history.events) {
       if (event.turnId !== turnId) continue;
-      const payload = (event.payload ?? {}) as { text?: string };
-      if (event.type === "text" && payload.text) answer = payload.text;
+      const payload = (event.payload ?? {}) as {
+        text?: string;
+        message?: string;
+      };
+      if (event.type === "text" && payload.text) text = payload.text;
+      if (event.type === "error" && payload.message) error = payload.message;
     }
     since = history.nextSince;
     if (!history.hasMore) break;
   }
-  return answer;
+  return { text, error };
 };
 
 /**
@@ -265,6 +279,13 @@ export interface MirrorPosts {
    * call to action: the canonical sentence plus where the key lives. */
   providerError(
     input: ChannelPostTarget & { modelsUrl: string; answer: string },
+  ): Promise<void>;
+  /** Platform chrome for a turn that ended without a normal answer — a
+   * failure line, or the quiet "Stopped." after an abort. Rendered so it
+   * cannot be mistaken for the agent's own voice. `warn` picks the failure
+   * treatment over the muted one. */
+  failureNotice(
+    input: ChannelPostTarget & { message: string; warn: boolean },
   ): Promise<void>;
 }
 
@@ -339,14 +360,22 @@ export const mirrorFinishedTurn = async (
   );
 
   try {
-    const answer =
-      (await answerFromTranscript(
-        deps.controlPlane,
-        item.conversationId,
-        item.turn.id,
-      )) ??
-      item.turn.error ??
-      null;
+    const outcome = await transcriptOutcome(
+      deps.controlPlane,
+      item.conversationId,
+      item.turn.id,
+    );
+    // Precedence mirrors the web (turn-block prefers `turn.error`): the
+    // agent's own text first; then the canonical/raw `turn.error`; then the
+    // transcript's durable error event — the only record an UNCODED harness
+    // failure leaves, which used to fall through to total silence here.
+    const answer = outcome.text ?? item.turn.error ?? outcome.error ?? null;
+    // A failed turn whose post is its PARTIAL answer text must not read as a
+    // normal reply — the failure line rides after it. When the answer came
+    // from `turn.error` or the error event, that text IS the failure message
+    // and posts alone.
+    const failedWithPartialText =
+      item.turn.status === "failed" && outcome.text !== null;
 
     if (automated) {
       await deps.posts.automation({
@@ -440,7 +469,30 @@ export const mirrorFinishedTurn = async (
         } else {
           await deps.posts.answer({ ...target, markdown: answer });
         }
+        if (failedWithPartialText) {
+          await deps.posts.failureNotice({
+            ...target,
+            message: TURN_FAILED_PARTIAL_MESSAGE,
+            warn: true,
+          });
+        }
       }
+    } else if (item.turn.status === "failed") {
+      // NEVER silent on a failure: the cursor has advanced and the "seen"
+      // reaction is already stripped, so posting nothing reads as the agent
+      // ignoring the person (six messages died exactly this way, live).
+      await deps.posts.failureNotice({
+        ...target,
+        message: TURN_FAILED_SILENT_MESSAGE,
+        warn: true,
+      });
+    } else if (item.turn.status === "aborted") {
+      // The web's word for the same moment — closure, not alarm.
+      await deps.posts.failureNotice({
+        ...target,
+        message: TURN_STOPPED_MESSAGE,
+        warn: false,
+      });
     }
   } catch (err) {
     // The cursor already moved: log loudly rather than retry into a double

--- a/apps/channel-adapter/src/slack/mirror-posts.ts
+++ b/apps/channel-adapter/src/slack/mirror-posts.ts
@@ -264,4 +264,17 @@ export const slackMirrorPosts: MirrorPosts = {
       button: "Check the model key",
     });
   },
+  async failureNotice(input) {
+    // Platform chrome, not the agent's voice: one plain italic line (the
+    // automation caption's treatment), with a warning icon for failures and
+    // nothing for the quiet "Stopped." A single postMessage keeps the
+    // rejection modes minimal — this is the mirror's last word for the turn,
+    // posted after the cursor already advanced.
+    const line = `_${escapeSlackText(input.message)}_`;
+    await postMessage(input.credential, {
+      channel: input.channel,
+      text: input.warn ? `:warning: ${line}` : line,
+      ...targetForm(input),
+    });
+  },
 };

--- a/apps/hosted-e2e/tests/live-jcode-incident.test.ts
+++ b/apps/hosted-e2e/tests/live-jcode-incident.test.ts
@@ -1,0 +1,471 @@
+import { expect, test } from "vitest";
+import { scenario, type Cx } from "../src/scenario.js";
+import {
+  seedAnthropicGrant,
+  seedHostedAgent,
+  seedTenant,
+} from "../src/fixtures.js";
+import {
+  fetchTranscript,
+  readTurn,
+  runTurn,
+  transcriptText,
+  v1Client,
+  waitFor,
+  type V1Client,
+} from "../src/v1.js";
+
+/**
+ * THE STUCK-SANDBOX INCIDENT, REPLAYED ON THE FULL LOCAL STACK WITH A REAL
+ * MODEL — real gateway binary (credential injection), real api-server, real
+ * runner, a real sandbox container from the agent image, the REAL jcode
+ * harness, and a REAL Anthropic OAuth token spliced by the gateway (the
+ * customer's exact zero-cred shape).
+ *
+ * Twice env-gated on top of the suite's own config gate: it spends real
+ * model tokens, so it never runs in CI —
+ *
+ *   E2E_ANTHROPIC_OAUTH_TOKEN=sk-ant-oat01-... \
+ *   E2E_ADMIN_DATABASE_URL=... E2E_TEMPLATE_DB=... E2E_AGENT_IMAGE=... \
+ *     pnpm --filter @onecli/hosted-e2e exec vitest run \
+ *       tests/live-jcode-incident.test.ts --testTimeout=900000
+ *
+ * The incident (2026-08-25, self-host): one long CI-watching turn; a second
+ * conversation attached to its busy session; every message bounced silently
+ * for 46 minutes; the finished answer was discarded. Scenario 1 is that
+ * timeline with the FIXED expectations. Scenario 2 is the restart/resume
+ * shape on the same live rig.
+ */
+const OAUTH_TOKEN = process.env.E2E_ANTHROPIC_OAUTH_TOKEN;
+
+const liveScenario = (name: string, body: (cx: Cx) => Promise<void>): void => {
+  if (!OAUTH_TOKEN) {
+    test.skip(name, () => undefined);
+    return;
+  }
+  scenario(name, body);
+};
+
+/** The tenant's SECOND member — the incident's "other channel" voice: a
+ * different person addressing the same agent, which the platform models as
+ * that person's own direct conversation. */
+const seedSecondMember = async (cx: Cx): Promise<string> => {
+  const userId = `${cx.ids.user}-b`;
+  const email = `${userId}@e2e.invalid`;
+  const apiKey = `${cx.ids.apiKey}b`;
+  await cx.prisma.user.create({
+    data: { id: userId, email, externalAuthId: userId },
+  });
+  await cx.prisma.organizationMember.create({
+    data: {
+      organizationId: cx.ids.org,
+      userId,
+      userEmail: email,
+      role: "member",
+    },
+  });
+  await cx.prisma.apiKey.create({
+    data: {
+      id: `${cx.ids.workspace}-key-b`,
+      key: apiKey,
+      scope: "workspace",
+      workspaceId: cx.ids.workspace,
+      userId,
+      userEmail: email,
+    },
+  });
+  return apiKey;
+};
+
+/** Mark the seeded anthropic secret as an OAuth credential — the production
+ * shape for a Claude subscription token: the sandbox gets the
+ * CLAUDE_CODE_OAUTH_TOKEN placeholder and the gateway splices the real one. */
+const markOauth = async (cx: Cx): Promise<void> => {
+  await cx.prisma.secret.update({
+    where: { id: `${cx.ids.workspace}-anthropic` },
+    data: { metadata: { authMode: "oauth" } },
+  });
+};
+
+const noTurnFailed = async (
+  v1: V1Client,
+  conversationId: string,
+): Promise<void> => {
+  const body = await v1.json<{
+    turns: { id: string; status: string; error?: string | null }[];
+  }>(await v1.get(`/v1/conversations/${conversationId}/turns`));
+  const failed = body.turns.filter((turn) => turn.status === "failed");
+  expect(failed, JSON.stringify(failed)).toHaveLength(0);
+};
+
+liveScenario(
+  "the incident timeline on a live agent: long turn + second voice + steer + abort",
+  async (cx) => {
+    const stack = await cx.startStack();
+    if (stack.runner === null) throw new Error("runner expected");
+    await seedTenant(cx.prisma, cx.ids);
+    await seedHostedAgent(cx.prisma, cx.ids, {
+      runnerId: stack.runner.runnerId,
+      harness: "jcode",
+    });
+    await seedAnthropicGrant(cx.prisma, cx.ids, { value: OAUTH_TOKEN });
+    await markOauth(cx);
+    const secondKey = await seedSecondMember(cx);
+    stack.runner.pump();
+
+    const conversationA = await stack.v1.json<{ id: string }>(
+      await stack.v1.put(`/v1/agents/${cx.ids.agent}/conversations/direct`),
+    );
+
+    // ---- The customer's CI-watching turn: a long FOREGROUND local wait.
+    const longTurn = await stack.v1.json<{ id: string }>(
+      await stack.v1.post(`/v1/conversations/${conversationA.id}/turns`, {
+        message:
+          "Run this exact bash command in the foreground and wait for it " +
+          "to finish (do NOT use background tasks or process tools): " +
+          "`for i in $(seq 1 18); do sleep 5; done; echo CI-FINISHED-OK`. " +
+          "This simulates watching a CI run. When it completes, reply with " +
+          "one line containing exactly: CI-RESULT: CI-FINISHED-OK",
+      }),
+    );
+    await waitFor(
+      () => readTurn(stack.v1, conversationA.id, longTurn.id),
+      (turn) => turn?.status === "running",
+      "the long turn to start",
+      180_000,
+    );
+    // Real tool activity, not just the claim: the bash call has begun.
+    await waitFor(
+      () => fetchTranscript(stack.v1, conversationA.id),
+      (events) => events.some((event) => event.type === "tool.started"),
+      "the long turn's bash call to start",
+      180_000,
+    );
+
+    // ---- Mid-turn message in the SAME conversation (the user's "he sent
+    // messages during the task"): rides a soft interrupt into the live run.
+    const followUp = await stack.v1.post(
+      `/v1/conversations/${conversationA.id}/messages`,
+      {
+        message:
+          "Important mid-task update: include the word BANANA somewhere in " +
+          "your final reply.",
+      },
+    );
+    expect(followUp.ok).toBe(true);
+
+    // ---- The second voice mid-turn (the incident's conversation B / the
+    // other-channel mention): a DIFFERENT member's direct conversation with
+    // the same agent, while the long turn is still running. Pre-fix this
+    // attached to the busy session, stalled 60s on control-op timeouts, and
+    // failed silently in the end.
+    const memberB = v1Client(stack.api.origin, secondKey, cx.ids.workspace);
+
+    const conversationB = await memberB.json<{ id: string }>(
+      await memberB.put(`/v1/agents/${cx.ids.agent}/conversations/direct`),
+    );
+    expect(conversationB.id).not.toBe(conversationA.id);
+
+    const bStarted = Date.now();
+    const bTurn = await runTurn(
+      memberB,
+      conversationB.id,
+      "Reply with one line containing exactly: HELLO-FROM-B",
+      180_000,
+    );
+    const bMs = Date.now() - bStarted;
+    expect(bTurn.status).toBe("done");
+    // Pre-fix fingerprint: 60s of control-op timeouts before a silent death.
+    // A fresh session applies preferences instantly; the budget below is
+    // model latency only.
+    expect(bMs).toBeLessThan(120_000);
+    expect(
+      transcriptText(await fetchTranscript(memberB, conversationB.id)),
+    ).toContain("HELLO-FROM-B");
+
+    // The long turn survived the second voice — the incident's core wreck.
+    const midCheck = await readTurn(stack.v1, conversationA.id, longTurn.id);
+    expect(midCheck?.status).toBe("running");
+
+    // ---- The long turn completes and its answer is DELIVERED (pre-fix it
+    // was discarded), with the steer folded in (pre-fix it was purged).
+    const settled = await waitFor(
+      () => readTurn(stack.v1, conversationA.id, longTurn.id),
+      (turn) => turn !== null && turn.status !== "running",
+      "the long turn to finish",
+      420_000,
+    );
+    expect(settled?.status).toBe("done");
+    const aTranscript = transcriptText(
+      await fetchTranscript(stack.v1, conversationA.id),
+    );
+    expect(aTranscript).toContain("CI-RESULT: CI-FINISHED-OK");
+    expect(aTranscript.toUpperCase()).toContain("BANANA");
+
+    // Distinct sessions per conversation — the root fix, observed on the
+    // live rows the incident corrupted.
+    const rows = await cx.prisma.conversation.findMany({
+      where: { id: { in: [conversationA.id, conversationB.id] } },
+      select: { id: true, harnessSessionRef: true },
+    });
+    const refs = rows.map((row) => row.harnessSessionRef);
+    expect(refs[0]).toBeTruthy();
+    expect(refs[1]).toBeTruthy();
+    expect(refs[0]).not.toBe(refs[1]);
+
+    // ---- Stop actually stops: abort a second long turn mid-run, then the
+    // session serves the next message (no orphan wedges it).
+    const abortable = await stack.v1.json<{ id: string }>(
+      await stack.v1.post(`/v1/conversations/${conversationA.id}/turns`, {
+        message:
+          "Run in the foreground: `for i in $(seq 1 60); do sleep 5; done; " +
+          "echo NEVER`. Do not use background tasks. Reply when done.",
+      }),
+    );
+    await waitFor(
+      () => fetchTranscript(stack.v1, conversationA.id),
+      (events) =>
+        events.filter((event) => event.type === "tool.started").length >= 2,
+      "the abortable turn's bash call to start",
+      240_000,
+    );
+    const abortRes = await stack.v1.post(`/v1/turns/${abortable.id}/abort`);
+    expect(abortRes.ok).toBe(true);
+    const aborted = await waitFor(
+      () => readTurn(stack.v1, conversationA.id, abortable.id),
+      (turn) => turn !== null && turn.status !== "running",
+      "the aborted turn to settle",
+      120_000,
+    );
+    expect(aborted?.status).toBe("aborted");
+
+    const afterAbort = await runTurn(
+      stack.v1,
+      conversationA.id,
+      "Reply with one line containing exactly: OK-AFTER-ABORT",
+      240_000,
+    );
+    expect(afterAbort.status).toBe("done");
+    expect(
+      transcriptText(await fetchTranscript(stack.v1, conversationA.id)),
+    ).toContain("OK-AFTER-ABORT");
+
+    // Nothing anywhere died silently.
+    await noTurnFailed(stack.v1, conversationA.id);
+    await noTurnFailed(memberB, conversationB.id);
+
+    await stack.runner.pausePump();
+  },
+);
+
+liveScenario(
+  "restart/resume on a live agent: the session survives a park and wake",
+  async (cx) => {
+    // A short idle window so the sandbox genuinely parks between turns —
+    // the wake then resumes the SAME jcode session by ref in a fresh
+    // container (the restart shape the resume path exists for).
+    const stack = await cx.startStack({
+      apiEnv: { SANDBOX_IDLE_STOP_SECONDS: "3" },
+    });
+    if (stack.runner === null) throw new Error("runner expected");
+    await seedTenant(cx.prisma, cx.ids);
+    await seedHostedAgent(cx.prisma, cx.ids, {
+      runnerId: stack.runner.runnerId,
+      harness: "jcode",
+    });
+    await seedAnthropicGrant(cx.prisma, cx.ids, { value: OAUTH_TOKEN });
+    await markOauth(cx);
+    stack.runner.pump();
+
+    const conversation = await stack.v1.json<{ id: string }>(
+      await stack.v1.put(`/v1/agents/${cx.ids.agent}/conversations/direct`),
+    );
+
+    const first = await runTurn(
+      stack.v1,
+      conversation.id,
+      "Remember this codeword: PINEAPPLE-42. Reply with exactly: NOTED",
+      240_000,
+    );
+    expect(first.status).toBe("done");
+
+    await waitFor(
+      () => cx.prisma.sandbox.findUnique({ where: { id: cx.ids.sandbox } }),
+      (sandbox) => sandbox?.status === "stopped",
+      "the sandbox to park",
+      120_000,
+    );
+
+    const second = await runTurn(
+      stack.v1,
+      conversation.id,
+      "What was the codeword I told you earlier? Reply with one line " +
+        "containing exactly: CODEWORD: <the codeword>",
+      300_000,
+    );
+    expect(second.status).toBe("done");
+    expect(
+      transcriptText(await fetchTranscript(stack.v1, conversation.id)),
+    ).toContain("PINEAPPLE-42");
+
+    await noTurnFailed(stack.v1, conversation.id);
+    await stack.runner.pausePump();
+  },
+);
+
+liveScenario(
+  "a barrage of mid-turn messages is never lost — every message gets consumed",
+  async (cx) => {
+    // The user's exact complaint: "he sent messages during the task and it
+    // wasn't responding". Several messages land while a long turn runs; each
+    // must either JOIN the live run or run as its own turn right after —
+    // never a silent drop, never a failed row.
+    const stack = await cx.startStack();
+    if (stack.runner === null) throw new Error("runner expected");
+    await seedTenant(cx.prisma, cx.ids);
+    await seedHostedAgent(cx.prisma, cx.ids, {
+      runnerId: stack.runner.runnerId,
+      harness: "jcode",
+    });
+    await seedAnthropicGrant(cx.prisma, cx.ids, { value: OAUTH_TOKEN });
+    await markOauth(cx);
+    stack.runner.pump();
+
+    const conversation = await stack.v1.json<{ id: string }>(
+      await stack.v1.put(`/v1/agents/${cx.ids.agent}/conversations/direct`),
+    );
+
+    const longTurn = await stack.v1.json<{ id: string }>(
+      await stack.v1.post(`/v1/conversations/${conversation.id}/turns`, {
+        message:
+          "Run this exact bash command in the foreground and wait (no " +
+          "background tasks): `for i in $(seq 1 12); do sleep 5; done; echo " +
+          "WATCH-DONE`. Then reply including exactly: WATCH-RESULT: WATCH-DONE",
+      }),
+    );
+    await waitFor(
+      () => fetchTranscript(stack.v1, conversation.id),
+      (events) => events.some((event) => event.type === "tool.started"),
+      "the long turn's bash call to start",
+      240_000,
+    );
+
+    // The barrage: three distinct asks, seconds apart, all mid-turn.
+    const asks = [
+      "Also include the word APPLE in your final reply.",
+      "Also include the word CHERRY in your final reply.",
+      "And finally include the word MANGO in your final reply.",
+    ];
+    for (const message of asks) {
+      const sent = await stack.v1.post(
+        `/v1/conversations/${conversation.id}/messages`,
+        { message },
+      );
+      expect(sent.ok).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+
+    // The long turn settles; then every barrage message must be consumed —
+    // joined into the run, or promoted and run as its own turn.
+    await waitFor(
+      () => readTurn(stack.v1, conversation.id, longTurn.id),
+      (turn) => turn !== null && turn.status !== "running",
+      "the long turn to finish",
+      420_000,
+    );
+    const settledTurns = await waitFor(
+      async () => {
+        const body = await stack.v1.json<{
+          turns: { id: string; status: string }[];
+        }>(await stack.v1.get(`/v1/conversations/${conversation.id}/turns`));
+        return body.turns;
+      },
+      (turns) =>
+        turns.every(
+          (turn) =>
+            !["queued", "dispatched", "running", "joining"].includes(
+              turn.status,
+            ),
+        ),
+      "every barrage message to settle",
+      420_000,
+    );
+
+    const failed = settledTurns.filter((turn) => turn.status === "failed");
+    expect(failed, JSON.stringify(failed)).toHaveLength(0);
+
+    // Every word arrived SOMEWHERE in the conversation's answers — steered
+    // into the long turn or answered by its own promoted turn.
+    const transcript = transcriptText(
+      await fetchTranscript(stack.v1, conversation.id),
+    ).toUpperCase();
+    expect(transcript).toContain("WATCH-RESULT: WATCH-DONE");
+    for (const word of ["APPLE", "CHERRY", "MANGO"]) {
+      expect(transcript, `missing ${word}`).toContain(word);
+    }
+
+    await stack.runner.pausePump();
+  },
+);
+
+liveScenario(
+  "two conversations' FIRST turns race a cold sandbox — one daemon, two sessions",
+  async (cx) => {
+    // The launch-memo race: a brand-new container receives two conversations
+    // at once; both startSessions race ensureInstance. Exactly one daemon
+    // may launch (a second launch yanks the live socket), and each
+    // conversation must land on its own session.
+    const stack = await cx.startStack();
+    if (stack.runner === null) throw new Error("runner expected");
+    await seedTenant(cx.prisma, cx.ids);
+    await seedHostedAgent(cx.prisma, cx.ids, {
+      runnerId: stack.runner.runnerId,
+      harness: "jcode",
+    });
+    await seedAnthropicGrant(cx.prisma, cx.ids, { value: OAUTH_TOKEN });
+    await markOauth(cx);
+    const secondKey = await seedSecondMember(cx);
+    stack.runner.pump();
+
+    const memberB = v1Client(stack.api.origin, secondKey, cx.ids.workspace);
+    const conversationA = await stack.v1.json<{ id: string }>(
+      await stack.v1.put(`/v1/agents/${cx.ids.agent}/conversations/direct`),
+    );
+    const conversationB = await memberB.json<{ id: string }>(
+      await memberB.put(`/v1/agents/${cx.ids.agent}/conversations/direct`),
+    );
+
+    const [turnA, turnB] = await Promise.all([
+      runTurn(
+        stack.v1,
+        conversationA.id,
+        "Reply with one line containing exactly: RACE-A-OK",
+        300_000,
+      ),
+      runTurn(
+        memberB,
+        conversationB.id,
+        "Reply with one line containing exactly: RACE-B-OK",
+        300_000,
+      ),
+    ]);
+    expect(turnA.status).toBe("done");
+    expect(turnB.status).toBe("done");
+    expect(
+      transcriptText(await fetchTranscript(stack.v1, conversationA.id)),
+    ).toContain("RACE-A-OK");
+    expect(
+      transcriptText(await fetchTranscript(memberB, conversationB.id)),
+    ).toContain("RACE-B-OK");
+
+    const rows = await cx.prisma.conversation.findMany({
+      where: { id: { in: [conversationA.id, conversationB.id] } },
+      select: { harnessSessionRef: true },
+    });
+    expect(rows[0]?.harnessSessionRef).toBeTruthy();
+    expect(rows[1]?.harnessSessionRef).toBeTruthy();
+    expect(rows[0]?.harnessSessionRef).not.toBe(rows[1]?.harnessSessionRef);
+
+    await stack.runner.pausePump();
+  },
+);

--- a/apps/hosted-e2e/turbo.json
+++ b/apps/hosted-e2e/turbo.json
@@ -12,6 +12,7 @@
         "PATH",
         "HOME",
         "E2E_ADMIN_DATABASE_URL",
+        "E2E_ANTHROPIC_OAUTH_TOKEN",
         "E2E_TEMPLATE_DB",
         "E2E_GATEWAY_BIN",
         "E2E_AGENT_IMAGE",

--- a/apps/runner/src/supervisor-messages.test.ts
+++ b/apps/runner/src/supervisor-messages.test.ts
@@ -135,6 +135,28 @@ describe("supervisor message handler", () => {
     });
   });
 
+  it("forwards harness_busy verbatim too — a NEW code needs no runner change", async () => {
+    // The open-string law end to end: the adapter minted this code after the
+    // busy self-heal exhausted; the runner is a pipe.
+    const { reported } = drive([
+      {
+        kind: "turn.result",
+        turnId: "t1",
+        conversationId: "cv-1",
+        status: "failed",
+        error: "Already processing a message",
+        errorCode: "harness_busy",
+      },
+    ]);
+
+    expect(reported[0]).toMatchObject({
+      kind: "turn.finished",
+      status: "failed",
+      error: "Already processing a message",
+      errorCode: "harness_busy",
+    });
+  });
+
   it("flushes buffered text before the terminal report", () => {
     // Otherwise the transcript can record the turn finishing before the words
     // it said — `seq` is assigned control-plane-side, on arrival.

--- a/apps/sandbox-supervisor/src/capabilities/processes.test.ts
+++ b/apps/sandbox-supervisor/src/capabilities/processes.test.ts
@@ -19,6 +19,7 @@ const stubManager = (): ProcessManager => ({
   watch: vi.fn(() => ({ ok: true })),
   observeUpsert: vi.fn(() => ({ created: false, hasArmedWatch: false })),
   cancelWatch: vi.fn(() => false),
+  armTurnEndSafetyNet: vi.fn(() => 0),
   close: vi.fn(),
   killAllSync: vi.fn(),
 });

--- a/apps/sandbox-supervisor/src/capabilities/processes.ts
+++ b/apps/sandbox-supervisor/src/capabilities/processes.ts
@@ -48,7 +48,11 @@ you through watches.
 - process_stop stops a process_start task; tasks started other ways are
   stopped the way they were started.
 - If the machine restarts, background tasks die and their watches fire with
-  "lost" so you can restart the work.`,
+  "lost" so you can restart the work.
+- Nothing runs between your turns. A promise to "report back" is only real
+  after you arm the watch (or schedule) that will wake you. To follow
+  something outside this machine (a CI run, a deploy), process_start a
+  poller for it and watch that.`,
 };
 
 const startSchema = z

--- a/apps/sandbox-supervisor/src/harness/conformance.ts
+++ b/apps/sandbox-supervisor/src/harness/conformance.ts
@@ -286,24 +286,38 @@ export const runHarnessConformance = (target: ConformanceTarget): void => {
       "resume reopens a session when the capability is declared",
       { timeout },
       async () => {
+        // The TRUE resume shape: a resume ref is only ever handed to a fresh
+        // container (the platform caches the live session in-process), so
+        // the first harness is DISPOSED before the second resumes on the
+        // same home. Resuming while the original session is still live is
+        // corrupted duplicate data, and an adapter may refuse to steal it —
+        // that shape is deliberately not part of this contract.
         const homeDir = mkdtempSync(join(tmpdir(), "conformance-"));
-        const harness = await target.makeHarness({ homeDir });
+        const first = await target.makeHarness({ homeDir });
+        let sessionRef: string | null | undefined;
         try {
-          if (!harness.capabilities.resume) return;
-          const first = await harness.startSession({ homeDir });
-          await collect(first.runTurn({ message: prompt }));
-          expect(first.sessionRef).toBeTruthy();
+          if (!first.capabilities.resume) return;
+          const session = await first.startSession({ homeDir });
+          await collect(session.runTurn({ message: prompt }));
+          sessionRef = session.sessionRef;
+          expect(sessionRef).toBeTruthy();
+        } finally {
+          await first.dispose();
+        }
+        if (!sessionRef) return;
 
-          const resumed = await harness.startSession({
+        const second = await target.makeHarness({ homeDir });
+        try {
+          const resumed = await second.startSession({
             homeDir,
-            resumeSessionRef: first.sessionRef ?? undefined,
+            resumeSessionRef: sessionRef,
           });
-          expect(resumed.sessionRef).toBe(first.sessionRef);
+          expect(resumed.sessionRef).toBe(sessionRef);
           const events = await collect(resumed.runTurn({ message: prompt }));
           const terminal = events.at(-1);
           expect(terminal && isTerminalEvent(terminal)).toBe(true);
         } finally {
-          await harness.dispose();
+          await second.dispose();
         }
       },
     );

--- a/apps/sandbox-supervisor/src/harness/jcode.adapter.test.ts
+++ b/apps/sandbox-supervisor/src/harness/jcode.adapter.test.ts
@@ -1,25 +1,29 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "@onecli/agent-protocol";
 
 /**
- * The jcode adapter's steer plumbing against a MOCKED SDK client — the layer
- * between the pure matcher (jcode.steering.test.ts) and the env-gated live
- * conformance. What only this level can pin:
+ * The jcode adapter against a MOCKED SDK — the layer between the pure
+ * matcher (jcode.steering.test.ts) and the env-gated live suites. What only
+ * this level can pin:
  *
- * - `cancelSoftInterrupts` runs at TURN START, before the gate opens — the
- *   belt against jcode's idle-queue leak (an interrupt still queued when a
- *   turn ends is injected into the NEXT turn; a mid-run message must never
- *   resurface in a later, unrelated run).
- * - `steer` maps to a NON-URGENT `softInterrupt` on the attached session,
- *   refuses between turns, and propagates a coded refusal (the bridge's
- *   one-attached-session law) — a refusal provably injected nothing, so the
- *   caller's promote fallback is safe.
- * - The terminal reconcile: cancel → history → `message.joined` BEFORE the
- *   terminal event; a history failure degrades every pending steer to
- *   missed (no joined events) instead of guessing.
+ * - THE CONNECTION MODEL (the stuck-sandbox incident's root): one
+ *   `launchInstance` per container, one `JcodeClient.connect` per
+ *   conversation, a DISTINCT session per connection — the mock mints
+ *   sessions per connection precisely so a regression back to a shared
+ *   client fails here instead of only in production.
+ * - The launch env pins (`JCODE_DISABLED_TOOLS`, the swarm fence,
+ *   `JCODE_NO_AUTO_UPDATE`, `inheritLogins: false`) at the `launchInstance`
+ *   boundary — previously only the live conformance run could see them.
+ * - The busy self-heal: a send refused with the daemon's busy wording
+ *   cancels the orphan run and resends, bounded; exhaustion fails coded
+ *   (`harness_busy`); a user abort mid-heal is never answered by a resend.
+ * - `applyPreferences` honesty: a daemon-coded refusal earns a notice; an
+ *   SDK `timeout` (a DEFERRED op, not an answer) must not.
+ * - The steer plumbing: turn-start interrupt cancel, non-urgent
+ *   `softInterrupt`, refusal between turns, and the terminal reconcile.
  */
 
 interface FakeCall {
@@ -27,55 +31,107 @@ interface FakeCall {
   args: unknown[];
 }
 
+/** The mock connection, as tests see it: frames can be pushed mid-stream. */
+interface PushableClient {
+  sessionId: string;
+  push(frame: unknown): void;
+}
+
 const state: {
   calls: FakeCall[];
-  events: (
-    | { ev: "turn_done" }
-    | { ev: "text_delta"; text: string }
-    | { ev: "error"; message: string }
-  )[];
+  launches: { options: Record<string, unknown> }[];
+  clients: PushableClient[];
+  connects: { options: Record<string, unknown> }[];
+  sessionCounter: number;
+  /** Frames a successfully-accepted send delivers (the turn's script). */
+  events: { ev: string; [key: string]: unknown }[];
+  /** How many sends the "daemon" refuses busy before accepting. */
+  busyRefusals: number;
   history: { role: string; content: string }[];
   historyError: Error | null;
   softInterruptError: Error | null;
+  setModelError: Error | null;
+  setEffortError: Error | null;
 } = {
   calls: [],
+  launches: [],
+  clients: [],
+  connects: [],
+  sessionCounter: 0,
   events: [{ ev: "turn_done" }],
+  busyRefusals: 0,
   history: [],
   historyError: null,
   softInterruptError: null,
+  setModelError: null,
+  setEffortError: null,
 };
 
 vi.mock("@1jehuang/jcode-sdk", () => {
   const record = (method: string, ...args: unknown[]) => {
     state.calls.push({ method, args });
   };
-  class FakeJcodeClient {
-    static launch() {
-      return Promise.resolve(new FakeJcodeClient());
+  class MockClient {
+    readonly sessionId: string;
+    private readonly frames: unknown[] = [];
+    private streamWaiter?: (result: IteratorResult<unknown>) => void;
+    private streamDone = false;
+    constructor(sessionId: string) {
+      this.sessionId = sessionId;
+    }
+    push(frame: unknown) {
+      const waiter = this.streamWaiter;
+      if (waiter) {
+        this.streamWaiter = undefined;
+        waiter({ value: frame, done: false });
+      } else {
+        this.frames.push(frame);
+      }
+    }
+    static connect(options: Record<string, unknown>) {
+      state.connects.push({ options });
+      state.sessionCounter += 1;
+      const client = new MockClient(`s-${state.sessionCounter}`);
+      state.clients.push(client);
+      return Promise.resolve(client);
     }
     on() {}
     close() {
+      record("close", this.sessionId);
       return Promise.resolve();
     }
     createSession(workingDir: string) {
       record("createSession", workingDir);
-      return Promise.resolve({ session_id: "s-1" });
+      // Session per CONNECTION — the daemon's real model. A shared-client
+      // regression would hand every conversation the same id again.
+      return Promise.resolve({ session_id: this.sessionId });
     }
     attachSession(id: string) {
       record("attachSession", id);
       return Promise.resolve({ session_id: id });
     }
-    detachSession() {
-      return Promise.resolve();
+    setModel(sessionId: string, model: string) {
+      record("setModel", sessionId, model);
+      return state.setModelError
+        ? Promise.reject(state.setModelError)
+        : Promise.resolve();
     }
-    setModel() {
-      return Promise.resolve();
-    }
-    setReasoningEffort() {
-      return Promise.resolve();
+    setReasoningEffort(sessionId: string, effort: string) {
+      record("setReasoningEffort", sessionId, effort);
+      return state.setEffortError
+        ? Promise.reject(state.setEffortError)
+        : Promise.resolve();
     }
     sendMessage(sessionId: string, content: string) {
       record("sendMessage", sessionId, content);
+      if (state.busyRefusals > 0) {
+        state.busyRefusals -= 1;
+        // The daemon's refusal: a broadcast error frame, never a rejection
+        // (the SDK's send is fire-and-forget) — exactly the live shape.
+        this.push({ ev: "error", message: "Already processing a message" });
+      } else {
+        for (const frame of state.events) this.push(frame);
+      }
       return Promise.resolve();
     }
     softInterrupt(sessionId: string, content: string, urgent?: boolean) {
@@ -101,23 +157,57 @@ vi.mock("@1jehuang/jcode-sdk", () => {
     respondToPermission() {
       return Promise.resolve();
     }
-    async *events() {
-      for (const event of state.events) {
-        await new Promise((resolve) => setTimeout(resolve, 1));
-        yield event;
-      }
-      // Stay open like the real stream — the adapter returns on terminal.
-      await new Promise(() => {});
+    events(): AsyncIterableIterator<unknown> {
+      // Hand-rolled like the SDK's real iterator (never an async generator):
+      // `return()` must unblock a PENDING `next()` immediately — an async
+      // generator parked mid-await queues the return call forever, which is
+      // not how the real stream behaves.
+      const finish = (): Promise<IteratorResult<unknown>> => {
+        this.streamDone = true;
+        const waiter = this.streamWaiter;
+        this.streamWaiter = undefined;
+        waiter?.({ value: undefined, done: true });
+        return Promise.resolve({ value: undefined, done: true });
+      };
+      return {
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+        next: (): Promise<IteratorResult<unknown>> => {
+          if (this.frames.length > 0) {
+            return Promise.resolve({ value: this.frames.shift(), done: false });
+          }
+          if (this.streamDone) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          return new Promise((resolve) => {
+            this.streamWaiter = resolve;
+          });
+        },
+        return: finish,
+        throw: finish,
+      };
     }
   }
   return {
-    JcodeClient: FakeJcodeClient,
+    JcodeClient: MockClient,
+    launchInstance: (options: Record<string, unknown>) => {
+      state.launches.push({ options });
+      return Promise.resolve({
+        socketPath: "/tmp/fake-jcode-api.sock",
+        jcodeHome: String(options.jcodeHome ?? ""),
+        process: { once: () => undefined },
+        shutdown: () => Promise.resolve(),
+      });
+    },
     // Something that exists on disk — resolveJcodeBinary demands a real path.
     bundledJcodeBinary: () => process.execPath,
   };
 });
 
-import { createJcodeHarness } from "./jcode";
+import { BUSY_RESEND_DELAYS_MS, createJcodeHarness } from "./jcode";
+
+const ORIGINAL_DELAYS = [...BUSY_RESEND_DELAYS_MS];
 
 const collect = async (
   iterable: AsyncIterable<AgentEvent>,
@@ -127,11 +217,23 @@ const collect = async (
   return events;
 };
 
-const startSession = async () => {
-  const harness = createJcodeHarness();
+const startSession = async (options?: {
+  model?: string;
+  effort?: "low" | "medium" | "high" | "max";
+  resumeSessionRef?: string;
+  harness?: ReturnType<typeof createJcodeHarness>;
+}) => {
+  const harness = options?.harness ?? createJcodeHarness();
   const homeDir = mkdtempSync(join(tmpdir(), "jcode-adapter-"));
-  const session = await harness.startSession({ homeDir });
-  return { harness, session };
+  const session = await harness.startSession({
+    homeDir,
+    ...(options?.model && { model: options.model }),
+    ...(options?.effort && { effort: options.effort }),
+    ...(options?.resumeSessionRef && {
+      resumeSessionRef: options.resumeSessionRef,
+    }),
+  });
+  return { harness, session, homeDir };
 };
 
 const callsOf = (method: string) =>
@@ -139,12 +241,315 @@ const callsOf = (method: string) =>
 
 beforeEach(() => {
   state.calls = [];
+  state.launches = [];
+  state.clients = [];
+  state.connects = [];
+  state.sessionCounter = 0;
   state.events = [{ ev: "turn_done" }];
+  state.busyRefusals = 0;
   state.history = [];
   state.historyError = null;
   state.softInterruptError = null;
+  state.setModelError = null;
+  state.setEffortError = null;
   delete process.env.ONECLI_JCODE_BINARY;
   delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+});
+
+afterEach(() => {
+  // Some suites shorten the heal backoff to keep tests fast; the exported
+  // array is shared module state, so restore it.
+  BUSY_RESEND_DELAYS_MS.splice(
+    0,
+    BUSY_RESEND_DELAYS_MS.length,
+    ...ORIGINAL_DELAYS,
+  );
+});
+
+describe("the connection model", () => {
+  it("launches ONE instance and dials one connection per conversation, with DISTINCT sessions", async () => {
+    // MUTATION-PROOF for the incident's root: a shared client would return
+    // the same session for both conversations — the busy collision.
+    const harness = createJcodeHarness();
+    const homeDir = mkdtempSync(join(tmpdir(), "jcode-adapter-"));
+    const first = await harness.startSession({ homeDir });
+    const second = await harness.startSession({ homeDir });
+
+    expect(state.launches).toHaveLength(1);
+    expect(state.connects).toHaveLength(2);
+    expect(first.sessionRef).toBe("s-1");
+    expect(second.sessionRef).toBe("s-2");
+    expect(first.sessionRef).not.toBe(second.sessionRef);
+  });
+
+  it("pins the launch env at the launchInstance boundary", async () => {
+    await startSession();
+    const options = state.launches[0]?.options as {
+      inheritLogins?: boolean;
+      binary?: string;
+      env?: Record<string, string>;
+    };
+    expect(options.inheritLogins).toBe(false);
+    expect(options.binary).toBe(process.execPath);
+    expect(options.env?.JCODE_NO_TELEMETRY).toBe("1");
+    expect(options.env?.JCODE_NO_AUTO_UPDATE).toBe("1");
+    expect(options.env?.JCODE_DISABLED_TOOLS).toContain("memory");
+    expect(options.env?.JCODE_SWARM_MAX_CONCURRENT_AGENTS).toBe("8");
+    expect(options.env?.JCODE_SWARM_SPAWN_MODE).toBe("headless");
+    expect(options.env?.JCODE_DISABLE_CLAUDE_MCP).toBe("1");
+  });
+
+  it("a resume ref held by a LIVE conversation mints a FRESH session — never steals", async () => {
+    // One ref, one conversation: a live in-process holder means the ref is
+    // corrupted duplicate data (the pre-fix shared-session bug persisted
+    // exactly this to real installs). Stealing would brick the holder's
+    // conversation for the container's life; the resumer gets a fresh
+    // session whose new ref heals the duplication forward.
+    const harness = createJcodeHarness();
+    const homeDir = mkdtempSync(join(tmpdir(), "jcode-adapter-"));
+    const first = await harness.startSession({ homeDir });
+    const firstRef = first.sessionRef;
+    if (!firstRef) throw new Error("expected a session ref");
+
+    const resumed = await harness.startSession({
+      homeDir,
+      resumeSessionRef: firstRef,
+    });
+
+    // Fresh mint: no attach, no close of the live holder, a NEW session id.
+    expect(callsOf("attachSession")).toHaveLength(0);
+    expect(callsOf("close")).toHaveLength(0);
+    expect(resumed.sessionRef).toBe("s-2");
+    // The holder's session still serves — the brick this rule prevents.
+    const events = await collect(first.runTurn({ message: "still alive?" }));
+    expect(events.at(-1)?.type).toBe("turn.done");
+  });
+
+  it("a resume ref with NO live holder attaches normally — the restart shape", async () => {
+    const harness = createJcodeHarness();
+    const homeDir = mkdtempSync(join(tmpdir(), "jcode-adapter-"));
+
+    const resumed = await harness.startSession({
+      homeDir,
+      resumeSessionRef: "s-from-a-previous-container",
+    });
+
+    expect(callsOf("attachSession")).toEqual([
+      { method: "attachSession", args: ["s-from-a-previous-container"] },
+    ]);
+    expect(resumed.sessionRef).toBe("s-from-a-previous-container");
+  });
+
+  it("a busy refusal arriving AFTER the settle window still earns the code", async () => {
+    // A loaded daemon can answer late: the refusal then reaches the live
+    // loop, which must still mint harness_busy (no retry at that point, but
+    // never the silent uncoded shape again).
+    state.events = []; // send accepted, nothing streams
+    const { session } = await startSession();
+    const collected = collect(session.runTurn({ message: "task" }));
+    // Past the settle window, then the refusal lands.
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    state.clients[0]?.push({
+      ev: "error",
+      message: "Already processing a message",
+    });
+    const events = await collected;
+
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      code: "harness_busy",
+    });
+  });
+
+  it("a failed session setup closes ITS connection and stays non-fatal", async () => {
+    let failure: string | undefined;
+    const harness = createJcodeHarness();
+    harness.onFailure((reason) => {
+      failure = reason;
+    });
+    const homeDir = mkdtempSync(join(tmpdir(), "jcode-adapter-"));
+    // A code-LESS error is a dead channel: applyPreferences rethrows it.
+    state.setModelError = new Error("socket ripped");
+    await expect(
+      harness.startSession({ homeDir, model: "some-model" }),
+    ).rejects.toThrow("socket ripped");
+
+    expect(callsOf("close")).toHaveLength(1);
+    // Session-level failure — the container is not declared dead.
+    expect(failure).toBeUndefined();
+
+    // And the harness still serves the next conversation.
+    state.setModelError = null;
+    const session = await harness.startSession({ homeDir });
+    expect(session.sessionRef).toBe("s-2");
+  });
+});
+
+describe("applyPreferences honesty", () => {
+  const noticesOf = async (session: {
+    runTurn: (input: { message: string }) => AsyncIterable<AgentEvent>;
+  }) => {
+    const events = await collect(session.runTurn({ message: "hello" }));
+    return events.filter((e) => e.type === "notice");
+  };
+
+  it("a daemon-coded refusal earns the model notice", async () => {
+    state.setModelError = Object.assign(new Error("invalid_request"), {
+      code: "invalid_request",
+    });
+    const { session } = await startSession({ model: "nope-model" });
+    const notices = await noticesOf(session);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({ type: "notice" });
+    expect((notices[0] as { text: string }).text).toContain(
+      "isn't available here",
+    );
+  });
+
+  it("an SDK timeout is a DEFERRED op, not a refusal — no false notice", async () => {
+    // The incident's 60s lie: a busy session defers control ops, the SDK
+    // times out, and the user was told their model "isn't available".
+    state.setModelError = Object.assign(
+      new Error("timeout: no reply to set_model within 30000ms"),
+      { code: "timeout" },
+    );
+    state.setEffortError = Object.assign(
+      new Error("timeout: no reply to set_reasoning_effort within 30000ms"),
+      { code: "timeout" },
+    );
+    const { session } = await startSession({
+      model: "real-model",
+      effort: "low",
+    });
+    const notices = await noticesOf(session);
+    expect(notices).toHaveLength(0);
+  });
+});
+
+describe("the busy self-heal", () => {
+  beforeEach(() => {
+    // Keep the heal cycle fast; afterEach restores the real backoff.
+    BUSY_RESEND_DELAYS_MS.splice(0, BUSY_RESEND_DELAYS_MS.length, 10, 10, 10);
+  });
+
+  it("a busy refusal cancels the orphan run and resends — the turn completes", async () => {
+    state.busyRefusals = 1;
+    state.events = [
+      { ev: "text_delta", text: "the real answer" },
+      { ev: "turn_done" },
+    ];
+    const { session } = await startSession();
+
+    const events = await collect(session.runTurn({ message: "task" }));
+
+    const order = state.calls.map((c) => c.method);
+    const firstSend = order.indexOf("sendMessage");
+    const cancel = order.indexOf("cancel");
+    const resend = order.lastIndexOf("sendMessage");
+    expect(firstSend).toBeGreaterThan(-1);
+    expect(cancel).toBeGreaterThan(firstSend);
+    expect(resend).toBeGreaterThan(cancel);
+    expect(events.at(-1)?.type).toBe("turn.done");
+    expect(
+      events.some(
+        (e) => e.type === "text.delta" && e.text.includes("real answer"),
+      ),
+    ).toBe(true);
+  });
+
+  it("an actively-streaming orphan's output never leaks into this turn", async () => {
+    state.busyRefusals = 1;
+    state.events = [{ ev: "text_delta", text: "ours" }, { ev: "turn_done" }];
+    const { session } = await startSession();
+
+    const iterator = session
+      .runTurn({ message: "task" })
+      [Symbol.asyncIterator]();
+    // The orphan streams into the subscription before our send settles.
+    state.clients[0]?.push({ ev: "text_delta", text: "ORPHAN-OUTPUT" });
+
+    const events: AgentEvent[] = [];
+    let next = await iterator.next();
+    while (!next.done) {
+      events.push(next.value);
+      next = await iterator.next();
+    }
+
+    expect(
+      events.some(
+        (e) => e.type === "text.delta" && e.text.includes("ORPHAN-OUTPUT"),
+      ),
+    ).toBe(false);
+    expect(
+      events.some((e) => e.type === "text.delta" && e.text === "ours"),
+    ).toBe(true);
+  });
+
+  it("exhaustion fails CODED — harness_busy, visible, never a silent empty error", async () => {
+    state.busyRefusals = 99;
+    const { session } = await startSession();
+
+    const events = await collect(session.runTurn({ message: "task" }));
+
+    const terminal = events.at(-1);
+    expect(terminal).toMatchObject({
+      type: "error",
+      code: "harness_busy",
+    });
+    expect((terminal as { message: string }).message).toContain(
+      "Already processing",
+    );
+    // Bounded: one send per configured backoff slot plus the first.
+    expect(callsOf("sendMessage")).toHaveLength(
+      BUSY_RESEND_DELAYS_MS.length + 1,
+    );
+  });
+
+  it("a user abort mid-heal ends the turn — never answered by a resend", async () => {
+    state.busyRefusals = 99;
+    const { session } = await startSession();
+
+    const collected = collect(session.runTurn({ message: "task" }));
+    // Let the first refusal land, then stop.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const sendsBeforeAbort = callsOf("sendMessage").length;
+    await session.abort();
+    const events = await collected;
+
+    expect(events.at(-1)?.type).toBe("turn.done");
+    // The heal loop noticed the abort: at most one more in-flight send could
+    // have raced the flag, and nothing continued after it.
+    expect(callsOf("sendMessage").length).toBeLessThanOrEqual(
+      sendsBeforeAbort + 1,
+    );
+  });
+
+  it("a stale request reply (reply_to) never terminates the live turn", async () => {
+    // Observed live: a deferred set_reasoning_effort reply arriving minutes
+    // late as an error frame, killing an unrelated stream.
+    state.events = [{ ev: "text_delta", text: "working" }, { ev: "turn_done" }];
+    const { session } = await startSession();
+    const iterator = session
+      .runTurn({ message: "task" })
+      [Symbol.asyncIterator]();
+    await iterator.next(); // turn.started
+    state.clients[0]?.push({
+      ev: "error",
+      reply_to: 8,
+      code: "invalid_request",
+      message: "Reasoning effort is not supported",
+    });
+
+    const events: AgentEvent[] = [];
+    let next = await iterator.next();
+    while (!next.done) {
+      events.push(next.value);
+      next = await iterator.next();
+    }
+
+    expect(events.at(-1)?.type).toBe("turn.done");
+    expect(events.some((e) => e.type === "error")).toBe(false);
+  });
 });
 
 describe("the jcode steer plumbing", () => {
@@ -188,7 +593,7 @@ describe("the jcode steer plumbing", () => {
     expect(callsOf("softInterrupt")).toHaveLength(0);
   });
 
-  it("propagates a coded harness refusal — the one-attached-session law", async () => {
+  it("propagates a coded harness refusal from softInterrupt", async () => {
     state.events = [{ ev: "text_delta", text: "working" }, { ev: "turn_done" }];
     state.softInterruptError = Object.assign(new Error("unknown_session"), {
       code: "unknown_session",

--- a/apps/sandbox-supervisor/src/harness/jcode.pin.test.ts
+++ b/apps/sandbox-supervisor/src/harness/jcode.pin.test.ts
@@ -28,6 +28,7 @@ const sdk = vi.hoisted(() => ({
 vi.mock("@1jehuang/jcode-sdk", () => ({
   bundledJcodeBinary: () => sdk.bundled,
   JcodeClient: class {},
+  launchInstance: () => Promise.reject(new Error("not launched in this suite")),
 }));
 
 const {

--- a/apps/sandbox-supervisor/src/harness/jcode.prompt.test.ts
+++ b/apps/sandbox-supervisor/src/harness/jcode.prompt.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { processesFragment } from "../capabilities/processes";
 import {
   PLATFORM_SYSTEM_PROMPT,
   preparePromptFiles,
@@ -143,5 +144,40 @@ describe("the platform system prompt", () => {
 
     expect(readFileSync(slot, "utf8")).toBe(WRITTEN_PROMPT);
     expect(statSync(slot).mode & 0o777).toBe(0o444);
+  });
+});
+
+describe("the turn-ending contract", () => {
+  // The report-back incident's lesson: every line about watches was
+  // conditioned on "a background task", and nothing told the agent that a
+  // promise without an armed watch cannot be kept. These pins keep the
+  // contract in the prompt — remove any leg and a live agent goes back to
+  // "I'll check the result and report back" followed by silence.
+  it("states that nothing runs between turns", () => {
+    expect(PLATFORM_SYSTEM_PROMPT).toContain("Nothing runs between your turns");
+  });
+
+  it("forbids report-back promises without an armed wake", () => {
+    const flat = PLATFORM_SYSTEM_PROMPT.replace(/\s+/g, " ");
+    expect(flat).toContain(
+      "Never end a turn promising to check on something or report back",
+    );
+    expect(flat).toContain("FIRST armed what will wake you");
+  });
+
+  it("bridges external systems to a watched poller", () => {
+    const flat = PLATFORM_SYSTEM_PROMPT.replace(/\s+/g, " ");
+    expect(flat).toContain("follow something outside this machine");
+    expect(flat).toContain(
+      "start a background poller with process_start and arm a process_watch",
+    );
+  });
+
+  it("the processes fragment carries the same law", () => {
+    const flat = processesFragment.body.replace(/\s+/g, " ");
+    expect(flat).toContain("Nothing runs between your turns");
+    expect(flat).toContain(
+      'A promise to "report back" is only real after you arm the watch',
+    );
   });
 });

--- a/apps/sandbox-supervisor/src/harness/jcode.ts
+++ b/apps/sandbox-supervisor/src/harness/jcode.ts
@@ -4,17 +4,19 @@ import { fileURLToPath } from "node:url";
 import {
   bundledJcodeBinary,
   JcodeClient,
+  launchInstance,
   type ApiEvent,
 } from "@1jehuang/jcode-sdk";
-import type {
-  AgentEffort,
-  AgentEvent,
-  Harness,
-  HarnessSession,
-  StartSessionOptions,
-  SteerInput,
-  TurnInput,
-  TurnUsage,
+import {
+  TURN_FAILURE_CODES,
+  type AgentEffort,
+  type AgentEvent,
+  type Harness,
+  type HarnessSession,
+  type StartSessionOptions,
+  type SteerInput,
+  type TurnInput,
+  type TurnUsage,
 } from "@onecli/agent-protocol";
 import { log } from "../log";
 import { platformToolsSocketPath } from "../platform-tools";
@@ -244,8 +246,8 @@ export const cleanJcodeKnowledgeStores = (
  * `enabled = false` is respected. The harness's own config save would
  * round-trip the file into the repaired shape — its saves serialize both
  * keys unconditionally — which is why this file is rewritten at every
- * container boot (the first session of each supervisor process; ensureClient
- * caches the client after that) and why the env-level tool disable exists
+ * container boot (once, before the daemon instance launches; ensureInstance
+ * memoizes after that) and why the env-level tool disable exists
  * as a second, independent lever that reapplies on every config load.
  */
 export const managedConfigToml = `# Written by the OneCLI supervisor at every container boot — do not edit.
@@ -384,6 +386,14 @@ watch wake-ups to the chat. To be woken when a background task completes,
 arm process_watch — do not use any runtime-level wake or self-notify option;
 wake-ups raised outside the platform run invisibly and their results reach
 no one.
+Nothing runs between your turns: once a turn ends, nothing wakes you except
+a person's message, a schedule, or a watch. Never end a turn promising to
+check on something or report back unless you have FIRST armed what will
+wake you — a process_watch on a background task, or a scheduled task. To
+follow something outside this machine (a CI run, a deploy, a webhook),
+start a background poller with process_start and arm a process_watch on
+it; checking it once in the foreground and ending your turn means you will
+never see the result.
 
 ## External services
 
@@ -567,11 +577,24 @@ const applyPreferences = async (
     try {
       await jcode.setModel(sessionId, target);
     } catch (error) {
-      if (!isHarnessRefusal(error)) throw error;
-      log("warn", "harness rejected the configured model", { model: target });
-      notices.push(
-        `The model ${options.model} isn't available here, so this agent is running its default instead. Pick another in the agent's Models section.`,
-      );
+      // A timeout is not an answer: the daemon defers control ops behind a
+      // busy agent lock and replies only when the turn ends. Keep the default
+      // silently — a slow control op must neither fail the turn nor tell the
+      // user their model "isn't available" (both happened live).
+      if (errorCode(error) === "timeout") {
+        log("warn", "model preference timed out; keeping the default", {
+          model: target,
+        });
+      } else if (isHarnessRefusal(error)) {
+        log("warn", "harness rejected the configured model", {
+          model: target,
+        });
+        notices.push(
+          `The model ${options.model} isn't available here, so this agent is running its default instead. Pick another in the agent's Models section.`,
+        );
+      } else {
+        throw error;
+      }
     }
   }
 
@@ -579,13 +602,20 @@ const applyPreferences = async (
     try {
       await jcode.setReasoningEffort(sessionId, JCODE_EFFORT[options.effort]);
     } catch (error) {
-      if (!isHarnessRefusal(error)) throw error;
-      log("warn", "harness rejected the configured effort", {
-        effort: options.effort,
-      });
-      notices.push(
-        `This model doesn't support the "${options.effort}" thinking level, so it's running at its default.`,
-      );
+      if (errorCode(error) === "timeout") {
+        log("warn", "effort preference timed out; keeping the default", {
+          effort: options.effort,
+        });
+      } else if (isHarnessRefusal(error)) {
+        log("warn", "harness rejected the configured effort", {
+          effort: options.effort,
+        });
+        notices.push(
+          `This model doesn't support the "${options.effort}" thinking level, so it's running at its default.`,
+        );
+      } else {
+        throw error;
+      }
     }
   }
 
@@ -639,11 +669,43 @@ export const JCODE_EFFORT: Record<AgentEffort, string> = {
 };
 
 /**
+ * Codes the SDK mints LOCALLY for channel and launch faults — never the daemon
+ * answering. `timeout` is the load-bearing entry: a control op against a busy
+ * session is deferred daemon-side on the agent lock and only answered when the
+ * turn ends, so the SDK's 30s timeout fires with `code: "timeout"` — treating
+ * that as "the harness refused this model" produced a false "isn't available
+ * here" notice in production (the stuck-sandbox incident, reproduced live).
+ * The rest are listed for completeness; only `timeout` and `disconnected` are
+ * reachable from a request path.
+ */
+const SDK_LOCAL_CODES = new Set([
+  "timeout",
+  "disconnected",
+  "connect_failed",
+  "handshake_failed",
+  "startup_failed",
+  "startup_timeout",
+  "jcode_not_found",
+  "unsupported_transport",
+  "invalid_option",
+  "unexpected_reply",
+  "event_buffer_overflow",
+  "concurrent_next",
+]);
+
+/** The error's `code`, when it carries a string one. */
+const errorCode = (error: unknown): string | undefined => {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+};
+
+/**
  * Did the harness ANSWER, refusing this preference — as opposed to the channel
- * dying under us?
+ * dying under us or the request simply going unanswered?
  *
- * Inverted deliberately. Keying on a single code (`invalid_request`) was too
- * narrow: the SDK's code union is
+ * Broad on the daemon side deliberately. Keying on a single code
+ * (`invalid_request`) was too narrow: the daemon's reply union is
  * `unsupported_version | unknown_request | unknown_session | invalid_request |
  * internal`, and it documents `invalid_request` only for `setModel`. A build
  * without `set_reasoning_effort` answers `unknown_request`, and a provider
@@ -652,15 +714,14 @@ export const JCODE_EFFORT: Record<AgentEffort, string> = {
  * uncached session, so every turn in every conversation of that container fails
  * identically, forever, while it reports healthy.
  *
- * A reply of ANY code means the harness is alive and simply would not take the
- * value, which is a preference problem. Only a non-reply — a dead socket, a
- * closed client — is worth failing for, and that arrives as something without a
- * code.
+ * But an SDK-LOCAL code is not an answer: `timeout` means the daemon never
+ * replied (deferred, not refused), and the transport codes mean the channel
+ * died. Those must never mint a "this model isn't available" notice.
  */
-const isHarnessRefusal = (error: unknown): boolean =>
-  typeof error === "object" &&
-  error !== null &&
-  typeof (error as { code?: unknown }).code === "string";
+const isHarnessRefusal = (error: unknown): boolean => {
+  const code = errorCode(error);
+  return code !== undefined && !SDK_LOCAL_CODES.has(code);
+};
 
 /**
  * Which pending steers actually made it into the run — the reconcile's pure
@@ -706,6 +767,43 @@ export const matchJoinedSteers = (
   return joined;
 };
 
+/**
+ * Vendor wording of the daemon's send refusal while a run is in flight — the
+ * self-heal trigger below. On a per-conversation connection the only run that
+ * can hold the session is this conversation's own earlier, platform-abandoned
+ * one, which is what makes cancelling it safe. Stays inside the adapter
+ * (invariant 9 — the vendor's vocabulary never crosses this boundary).
+ */
+const BUSY_REFUSAL_SHAPE = /already processing a message/i;
+
+/**
+ * The daemon's cancel-path error wording. During the settle phase, after this
+ * turn has cancelled an orphan, an error of this shape is the ORPHAN's residue
+ * — never this turn's terminal. Only consulted there; in the live phase a
+ * cancel-shaped error is a real terminal (a user abort ends exactly this way).
+ */
+const ORPHAN_CANCEL_SHAPE = /cancelled by user/i;
+
+/**
+ * How long after each send frames are held before being trusted as this
+ * turn's own. A busy refusal lands in ~150ms (measured live); the first
+ * genuine model delta takes longer than this window in practice, so in the
+ * common no-orphan case the hold delays nothing observable.
+ */
+export const BUSY_DETECT_WINDOW_MS = 1_000;
+
+/**
+ * Backoff between self-heal resends, exported for the adapter tests. Bounded
+ * on purpose: a session that stays busy through every cancel+resend is
+ * wedged, and the turn must fail coded (`harness_busy`), canonical, and
+ * visible — rather than loop forever. The supervisor's heartbeat runs the
+ * whole time, so the turn stays alive and abortable while this waits.
+ */
+export const BUSY_RESEND_DELAYS_MS = [2_000, 5_000, 10_000, 30_000, 60_000];
+
+/** How long a heal round drains orphan residue before resending. */
+const ORPHAN_DRAIN_MIN_MS = 250;
+
 class JcodeSession implements HarnessSession {
   readonly sessionRef: string;
   /**
@@ -716,6 +814,11 @@ class JcodeSession implements HarnessSession {
   private pendingNotices: string[];
   /** The in-flight gate: `steer` refuses between turns (see the contract). */
   private turnActive = false;
+  /**
+   * Set by `abort()` and read by the self-heal loop: a stopped turn must
+   * never be resent — the user's cancel outranks the recovery.
+   */
+  private abortRequested = false;
   /** Steers delivered to the LIVE turn, reconciled at its terminal. */
   private pendingSteers: SteerInput[] = [];
   /**
@@ -740,10 +843,66 @@ class JcodeSession implements HarnessSession {
   async *runTurn(input: TurnInput): AsyncIterable<AgentEvent> {
     // Subscribe BEFORE sending, or a short turn's first deltas race the
     // subscription (verified SDK behavior — run() does the same).
-    const stream = this.client.events(this.sessionRef);
+    const stream = this.client.events(
+      this.sessionRef,
+    ) as AsyncIterableIterator<ApiEvent>;
     let usage: TurnUsage | undefined;
     let terminal: Extract<AgentEvent, { type: "turn.done" | "error" }> | null =
       null;
+
+    // ONE background reader owns `stream.next()` for the turn's whole life.
+    // The SDK iterator holds a single waker slot, so racing `next()` against
+    // timers directly would orphan a waker and silently drop the frame that
+    // resolves it — every timed read below goes through this queue instead.
+    const queue: ApiEvent[] = [];
+    let streamEnded = false;
+    let wakeReader: (() => void) | undefined;
+    const pump = (async () => {
+      try {
+        for await (const frame of stream) {
+          queue.push(frame);
+          wakeReader?.();
+          wakeReader = undefined;
+        }
+      } catch {
+        // A stream rejection reads as an unexpected end; the loop below
+        // synthesizes the terminal.
+      } finally {
+        streamEnded = true;
+        wakeReader?.();
+        wakeReader = undefined;
+      }
+    })();
+    /** Next frame, or "ended", or — when a deadline is given — "timeout". */
+    const nextFrame = async (
+      deadline?: number,
+    ): Promise<ApiEvent | "ended" | "timeout"> => {
+      for (;;) {
+        const frame = queue.shift();
+        if (frame !== undefined) return frame;
+        if (streamEnded) return "ended";
+        const waitMs =
+          deadline === undefined ? undefined : deadline - Date.now();
+        if (waitMs !== undefined && waitMs <= 0) return "timeout";
+        await new Promise<void>((resolve) => {
+          wakeReader = resolve;
+          if (waitMs !== undefined) {
+            const timer = setTimeout(() => {
+              if (wakeReader === resolve) wakeReader = undefined;
+              resolve();
+            }, waitMs);
+            timer.unref();
+          }
+        });
+      }
+    };
+    /** An orphaned reply to one of our own timed-out requests — the daemon
+     * answered after the SDK gave up, and the SDK re-emits unmatched replies
+     * as events. A request reply is never a turn terminal (observed live: a
+     * deferred set_reasoning_effort reply killing an unrelated stream). */
+    const isStaleReply = (frame: ApiEvent): boolean =>
+      frame.ev === "error" &&
+      (frame as { reply_to?: number }).reply_to !== undefined;
 
     try {
       // Drop interrupts leaked from a previous turn's very end: jcode holds
@@ -754,6 +913,7 @@ class JcodeSession implements HarnessSession {
       // refusal here must not cost the turn.
       await this.client.cancelSoftInterrupts(this.sessionRef).catch(() => {});
       this.pendingSteers = [];
+      this.abortRequested = false;
       this.turnActive = true;
 
       // Inline vision: our TurnImage translates to jcode's [mediaType,
@@ -765,33 +925,139 @@ class JcodeSession implements HarnessSession {
         image.mediaType,
         image.dataBase64,
       ]);
-      await this.client.sendMessage(
-        this.sessionRef,
-        input.message,
-        images.length > 0 ? images : undefined,
-      );
-      // The reconcile window's floor, captured by INDEX while nothing can
-      // have injected yet (injection points exist only inside the turn
-      // loop, after the first model stream). Best-effort: a failed read
-      // falls back to the content anchor at reconcile time.
-      this.turnHistoryBaseline = await this.client
-        .getHistory(this.sessionRef)
-        .then((history) => history.length)
-        .catch(() => null);
+      const imagesArg = images.length > 0 ? images : undefined;
+
+      // The reconcile window's floor, captured by INDEX right after each
+      // send, while nothing can have injected yet (injection points exist
+      // only inside the turn loop, after the first model stream) — re-read
+      // after every self-heal resend below, since the resend is the message
+      // the daemon actually took. Best-effort: a failed read falls back to
+      // the content anchor at reconcile time.
+      const captureBaseline = async () => {
+        this.turnHistoryBaseline = await this.client
+          .getHistory(this.sessionRef)
+          .then((history) => history.length)
+          .catch(() => null);
+      };
+
+      await this.client.sendMessage(this.sessionRef, input.message, imagesArg);
+      await captureBaseline();
       yield { type: "turn.started" };
 
       for (const text of this.pendingNotices.splice(0))
         yield { type: "notice", level: "warn", text };
 
-      for await (const event of stream as AsyncIterable<ApiEvent>) {
+      // THE SETTLE PHASE — the busy self-heal. The daemon acks sends before
+      // deciding whether to take them, so acceptance is only learnable from
+      // the stream: a refusal ("Already processing a message") lands as a
+      // broadcast error frame ~150ms after the send. On this per-conversation
+      // connection the only run that can be holding the session is this
+      // conversation's own earlier, platform-abandoned one — an ORPHAN — so
+      // the recovery is to cancel it and resend, bounded. Frames arriving
+      // before the send settles are HELD, not yielded: an actively-streaming
+      // orphan's output must never leak into this turn's answer. Deliberately
+      // NOT cancelling soft interrupts here — user messages queued during the
+      // busy window must survive into the resent run.
+      const held: ApiEvent[] = [];
+      let healRound = 0;
+      settle: for (;;) {
+        if (this.abortRequested) {
+          // The user's stop outranks the recovery: end cleanly (the fake's
+          // abort precedent); the supervisor's own abort bookkeeping reports
+          // the turn aborted.
+          terminal = { type: "turn.done" };
+          break settle;
+        }
+        const windowEnd = Date.now() + BUSY_DETECT_WINDOW_MS;
+        for (;;) {
+          const frame = await nextFrame(windowEnd);
+          // Window elapsed or stream gone: the held frames are ours; the
+          // live loop below owns the rest (including synthesizing the
+          // unexpected-end terminal).
+          if (frame === "timeout" || frame === "ended") break settle;
+          if (isStaleReply(frame)) continue;
+          if (
+            frame.ev === "error" &&
+            healRound > 0 &&
+            !this.abortRequested &&
+            ORPHAN_CANCEL_SHAPE.test(frame.message ?? "")
+          ) {
+            // The cancelled orphan's own death rattle, not our terminal.
+            continue;
+          }
+          if (
+            frame.ev === "error" &&
+            BUSY_REFUSAL_SHAPE.test(frame.message ?? "")
+          ) {
+            // Our send was refused — everything held so far was the orphan's.
+            held.length = 0;
+            if (healRound >= BUSY_RESEND_DELAYS_MS.length) {
+              terminal = {
+                type: "error",
+                message: frame.message,
+                code: TURN_FAILURE_CODES.harnessBusy,
+              };
+              break settle;
+            }
+            await this.client.cancel(this.sessionRef).catch(() => {});
+            // Drain the dying orphan's residue through the backoff, then
+            // resend into the freed session.
+            const drainEnd =
+              Date.now() +
+              Math.max(
+                BUSY_RESEND_DELAYS_MS[healRound] ?? 0,
+                ORPHAN_DRAIN_MIN_MS,
+              );
+            for (;;) {
+              const drained = await nextFrame(drainEnd);
+              if (drained === "timeout" || drained === "ended") break;
+              if (this.abortRequested) break;
+            }
+            healRound += 1;
+            if (this.abortRequested) {
+              terminal = { type: "turn.done" };
+              break settle;
+            }
+            await this.client.sendMessage(
+              this.sessionRef,
+              input.message,
+              imagesArg,
+            );
+            await captureBaseline();
+            continue settle;
+          }
+          held.push(frame);
+          // A non-busy terminal inside the window is ours: a busy refusal
+          // always precedes any orphan frame that could follow our send.
+          // (Known residual: an orphan that finishes NATURALLY in the few-ms
+          // gap between our subscribe and the daemon processing our send can
+          // land its terminal here and read as an instant empty end — it
+          // needs an abandoned run plus ms-precision timing, and the next
+          // message recovers.)
+          if (frame.ev === "turn_done" || frame.ev === "error") break settle;
+        }
+      }
+
+      // Whether this run visibly progressed — a busy refusal can only be OUR
+      // send's (the daemon mints it nowhere else), so one that slips past the
+      // settle window still deserves its honest code, but only while nothing
+      // has streamed (post-progress it cannot be a send refusal).
+      let progressed = false;
+      while (!terminal) {
+        const frame = held.shift() ?? (await nextFrame());
+        if (frame === "ended" || frame === "timeout") break;
+        const event = frame;
         switch (event.ev) {
           case "text_delta":
+            progressed = true;
             yield { type: "text.delta", text: event.text };
             break;
           case "reasoning_delta":
+            progressed = true;
             yield { type: "thinking.delta", text: event.text };
             break;
           case "tool_start":
+            progressed = true;
             yield {
               type: "tool.started",
               callId: event.call_id,
@@ -823,20 +1089,31 @@ class JcodeSession implements HarnessSession {
           case "turn_done":
             terminal = { type: "turn.done", ...(usage ? { usage } : {}) };
             break;
-          case "error":
+          case "error": {
             // A failed turn emits `error` INSTEAD of `turn_done` (verified) —
             // terminating here is what keeps the loop from hanging forever.
+            // Orphaned request replies are the one exception (see above).
+            if (isStaleReply(event)) break;
+            // A busy refusal that outran the settle window (a loaded daemon
+            // can answer late) still gets its honest code — no retry at this
+            // point, but never the silent uncoded shape again.
+            const lateBusy =
+              !progressed && BUSY_REFUSAL_SHAPE.test(event.message ?? "");
             terminal = {
               type: "error",
               message: event.message,
-              ...(event.code ? { code: event.code } : {}),
+              ...(lateBusy
+                ? { code: TURN_FAILURE_CODES.harnessBusy }
+                : event.code
+                  ? { code: event.code }
+                  : {}),
             };
             break;
+          }
           default:
             // Forward-compat: unknown vendor events are dropped, never leaked.
             break;
         }
-        if (terminal) break;
       }
 
       if (!terminal) {
@@ -855,7 +1132,8 @@ class JcodeSession implements HarnessSession {
       yield terminal;
     } finally {
       this.turnActive = false;
-      await (stream as AsyncIterableIterator<ApiEvent>).return?.(undefined);
+      await stream.return?.(undefined);
+      await pump.catch(() => {});
     }
   }
 
@@ -865,11 +1143,12 @@ class JcodeSession implements HarnessSession {
    * the turn streams — and injected as a user message between tool batches
    * or as the model finishes (which EXTENDS the turn instead of ending it).
    *
-   * Any coded refusal propagates as a throw and means NOTHING was injected —
-   * including `unknown_session`, the bridge's one-attached-session law (only
-   * the connection's currently-attached session accepts `soft_interrupt` /
-   * `get_history` / `cancel_soft_interrupts`; a second concurrently-active
-   * conversation in the same container degrades to the promotion path).
+   * Any coded refusal propagates as a throw and means NOTHING was injected.
+   * The bridge accepts `soft_interrupt` / `get_history` /
+   * `cancel_soft_interrupts` only for the connection's attached session —
+   * which is exactly this session, because every conversation owns its own
+   * connection (concurrent conversations steer first-class now; the old
+   * shared-connection degrade to promotion is gone).
    */
   async steer(input: SteerInput): Promise<void> {
     if (!this.turnActive) {
@@ -939,6 +1218,9 @@ class JcodeSession implements HarnessSession {
   }
 
   async abort(): Promise<void> {
+    // FIRST, before any await: the self-heal loop checks this between its
+    // waits — a stopped turn must never be resent.
+    this.abortRequested = true;
     // Stop means silence, daemon-side too: queued-but-undelivered interrupts
     // die with the turn instead of leaking into the next one.
     await this.client.cancelSoftInterrupts(this.sessionRef).catch(() => {});
@@ -949,7 +1231,28 @@ class JcodeSession implements HarnessSession {
 }
 
 export const createJcodeHarness = (): Harness => {
-  let client: JcodeClient | undefined;
+  /**
+   * The launched daemon instance — ONE per container, memoized as a PROMISE:
+   * `launchInstance` is destructive on re-entry (it unlinks the live socket
+   * and spawns a second daemon onto the same state dir), so a second launch
+   * must be structurally impossible, not merely unlikely. A rejected memo
+   * stays memoized on purpose — a container whose runtime will not launch is
+   * dead, and every later turn should fail identically instead of retrying
+   * the destructive launch.
+   */
+  let instance: Promise<Awaited<ReturnType<typeof launchInstance>>> | undefined;
+  /**
+   * Per-conversation connections (§3.6): the bridge binds ONE session per
+   * connection, so sharing a connection is what made a second conversation
+   * attach to the first's busy session (the stuck-sandbox incident). Every
+   * `startSession` dials its own connection; the maps below exist for
+   * dispose and the duplicate-resume-ref guard.
+   */
+  const clients = new Set<JcodeClient>();
+  const sessionClients = new Map<string, JcodeClient>();
+  /** Connections WE closed — their `close` event is teardown, not death. */
+  const deliberateCloses = new WeakSet<JcodeClient>();
+  let connectionCounter = 0;
   let onFailure: ((reason: string) => void) | undefined;
   /** Terminal failure is reported once, and never for our own teardown. */
   let failed = false;
@@ -962,9 +1265,26 @@ export const createJcodeHarness = (): Harness => {
     onFailure?.(reason);
   };
 
-  const ensureClient = async (homeDir: string): Promise<JcodeClient> => {
-    if (client) return client;
+  const closeClient = async (client: JcodeClient): Promise<void> => {
+    deliberateCloses.add(client);
+    clients.delete(client);
+    for (const [ref, holder] of sessionClients) {
+      if (holder === client) sessionClients.delete(ref);
+    }
+    await client.close().catch(() => {});
+  };
 
+  const ensureInstance = (
+    homeDir: string,
+  ): Promise<Awaited<ReturnType<typeof launchInstance>>> => {
+    if (instance) return instance;
+    instance = launchDaemon(homeDir);
+    return instance;
+  };
+
+  const launchDaemon = async (
+    homeDir: string,
+  ): Promise<Awaited<ReturnType<typeof launchInstance>>> => {
     // §3.6: the harness's own session state lives ON the home volume,
     // which is exactly what makes resume survive a container stop/start.
     const jcodeHome = join(homeDir, JCODE_HOME_DIRNAME);
@@ -1021,14 +1341,13 @@ export const createJcodeHarness = (): Harness => {
       );
     }
 
-    const launched = await JcodeClient.launch({
+    const launched = await launchInstance({
       workingDir: homeDir,
       jcodeHome,
       // Pinned, never the SDK's guess (which ends at bare "jcode" on PATH).
       binary: resolveJcodeBinary(),
       inheritLogins: false,
       startupTimeoutMs: 60_000,
-      clientName: "onecli-supervisor/0",
       env: {
         JCODE_NO_TELEMETRY: "1",
         // Presence-based upstream (any value disables, even "0"): without it
@@ -1059,12 +1378,38 @@ export const createJcodeHarness = (): Harness => {
       },
     });
 
+    // ONE of the two death signals this adapter owes the supervisor: the
+    // bridge process exiting means no connection can ever be served again.
+    // The per-connection `close` handler below is the other (and usually
+    // faster) signal — first one wins, `fail` is one-shot.
+    launched.process.once("exit", () => {
+      fail("jcode instance exited");
+    });
+
+    return launched;
+  };
+
+  /**
+   * Dial a fresh connection for one conversation. The bridge binds exactly
+   * one session per connection, so this is what gives every conversation its
+   * own session, its own busy state, and its own event scope — the incident's
+   * root fix. Mirrors the SDK's own `globalEvents` child-connection pattern.
+   */
+  const connectClient = async (homeDir: string): Promise<JcodeClient> => {
+    const inst = await ensureInstance(homeDir);
+    connectionCounter += 1;
+    const connected = await JcodeClient.connect({
+      socketPath: inst.socketPath,
+      clientName: `onecli-supervisor/0/conv-${connectionCounter}`,
+    });
+
     // Node treats an unlistened "error" as fatal; the SDK reserves it for
-    // transport faults and remaps protocol errors to "harness_error".
-    launched.on("error", (err) => {
+    // transport faults and remaps protocol errors to "harness_error". Both
+    // are per-EventEmitter, so every connection needs its own listeners.
+    connected.on("error", (err) => {
       log("error", "jcode transport error", { error: String(err) });
     });
-    launched.on(
+    connected.on(
       "harness_error",
       (frame: { code?: string; message?: string }) => {
         // Code + message only: a whole vendor frame can carry request/response
@@ -1077,18 +1422,21 @@ export const createJcodeHarness = (): Harness => {
       },
     );
 
-    // THE signal this adapter owes the supervisor. The SDK raises `close` when
-    // its socket to the jcode process goes away, which is exactly what a dead
-    // harness looks like from in here — and from that moment every request
-    // rejects with "harness connection closed", including the ones that open a
-    // new session for a new conversation. Observed live: one crash and the
-    // sandbox served nothing again for the rest of its life.
-    launched.on("close", (error?: Error) => {
+    // THE other death signal. These are unix-socket connections to a local
+    // daemon: an unexpected close means the daemon died, and from that moment
+    // every request on every connection rejects with "harness connection
+    // closed" — including the ones that open sessions for new conversations.
+    // Observed live: one crash and the sandbox served nothing again for the
+    // rest of its life. A close WE initiated (dispose, a failed session
+    // setup) is teardown, not death.
+    connected.on("close", (error?: Error) => {
+      clients.delete(connected);
+      if (deliberateCloses.has(connected)) return;
       fail(error ? String(error) : "harness connection closed");
     });
 
-    client = launched;
-    return launched;
+    clients.add(connected);
+    return connected;
   };
 
   return {
@@ -1114,44 +1462,74 @@ export const createJcodeHarness = (): Harness => {
     async startSession(options: StartSessionOptions) {
       let jcode: JcodeClient;
       try {
-        jcode = await ensureClient(options.homeDir);
+        jcode = await connectClient(options.homeDir);
       } catch (error) {
-        // Launching the runtime is this adapter's whole reason to exist. If it
-        // will not come up, the container can never serve a turn — and failing
-        // only the turn would hide that behind an error the user is invited to
-        // retry forever. Session-level failures on a LIVE client (a stale
-        // resume ref, say) deliberately do not come through here.
+        // Launching the runtime is this adapter's whole reason to exist, and
+        // a connect refused by a LOCAL daemon means that daemon is gone. If
+        // it will not come up, the container can never serve a turn — and
+        // failing only the turn would hide that behind an error the user is
+        // invited to retry forever. Session-level failures on a live
+        // connection (a stale resume ref, say) deliberately do not come
+        // through here.
         fail(`harness launch failed: ${String(error)}`);
         throw error;
       }
 
-      const session = options.resumeSessionRef
-        ? await jcode.attachSession(options.resumeSessionRef)
-        : await jcode.createSession(options.homeDir);
-
       try {
+        const resumeRef = options.resumeSessionRef;
+        // ONE ref, one conversation. A resume ref held by a LIVE client in
+        // this process is corrupted duplicate data — two conversations
+        // persisted the same ref, which is exactly what the pre-fix
+        // shared-session bug wrote to real installs. Never steal the live
+        // session out from under its conversation (that would brick it for
+        // the container's life): mint a FRESH session for the resumer
+        // instead. Its new ref rides the next `turn.result` and heals the
+        // duplication forward.
+        const holder = resumeRef ? sessionClients.get(resumeRef) : undefined;
+        if (resumeRef && holder) {
+          log(
+            "warn",
+            "resume ref is held by a live conversation; minting fresh",
+            {
+              resumeSessionRef: resumeRef,
+            },
+          );
+        }
+        const session =
+          resumeRef && !holder
+            ? await jcode.attachSession(resumeRef)
+            : await jcode.createSession(options.homeDir);
+
         const notices = await applyPreferences(
           jcode,
           session.session_id,
           options,
         );
+        sessionClients.set(session.session_id, jcode);
         return new JcodeSession(jcode, session.session_id, notices);
       } catch (error) {
-        // The session exists but is unusable. Detaching matters: without it,
-        // every retry creates another live session on the durable volume that
+        // The connection exists but its session is unusable. Closing the
+        // connection IS the detach (one attachment per connection) — without
+        // it, every retry would leak a socket and a live attachment that
         // nothing will ever reach again.
-        await jcode.detachSession(session.session_id).catch(() => {});
+        await closeClient(jcode);
         throw error;
       }
     },
     async dispose() {
-      // Set BEFORE the close, because closing the client raises the very
-      // `close` event that means "the harness died" — and a deliberate
-      // teardown reported as a failure would have the sandbox recycled on
-      // every ordinary shutdown.
+      // Set BEFORE any close, because both teardown steps raise the very
+      // signals that mean "the harness died" — every connection's `close`,
+      // then the instance process's `exit` — and a deliberate teardown
+      // reported as a failure would have the sandbox recycled on every
+      // ordinary shutdown.
       disposing = true;
-      await client?.close();
-      client = undefined;
+      await Promise.allSettled([...clients].map((c) => closeClient(c)));
+      sessionClients.clear();
+      if (instance) {
+        const inst = await instance.catch(() => undefined);
+        await inst?.shutdown();
+        instance = undefined;
+      }
     },
   };
 };

--- a/apps/sandbox-supervisor/src/harness/testing/mock-provider.ts
+++ b/apps/sandbox-supervisor/src/harness/testing/mock-provider.ts
@@ -1,0 +1,160 @@
+/**
+ * Mock OpenAI-compatible model provider for the LIVE jcode suites.
+ *
+ * Serves `POST <base>/chat/completions` as SSE. A request whose LAST user
+ * message contains "LONGRUN" streams a keepalive delta every `keepaliveMs`
+ * and finishes after `longMs` — an arbitrarily long "busy" turn with zero
+ * real credentials (the incident's CI-watching turn, minus the wait).
+ * Anything else answers fast. Keyed on the last user message, not the whole
+ * body, because jcode sends full history — a steer injected after a LONGRUN
+ * turn must not re-trigger the long path.
+ *
+ * jcode is pointed here via a named provider profile in config.toml:
+ *
+ *   [providers.mockai]
+ *   type = "openai-compatible"
+ *   base_url = "http://127.0.0.1:<port>/v1"
+ *   api_key = "sk-mock"
+ *   default_model = "mock-model"
+ *   models = [{ id = "mock-model" }]
+ *
+ * plus `default_model = "mockai:mock-model"` under `[provider]` — verified
+ * live against v0.78.1 to bind fresh sessions to this provider.
+ */
+import { createServer, type Server } from "node:http";
+
+export const LONG_RUN_MARKER = "LONGRUN";
+export const FINAL_ANSWER_MARKER = "THE-FINAL-ANSWER";
+
+export interface MockProvider {
+  server: Server;
+  port: number;
+  /** One entry per /chat/completions request: when, and the routed kind. */
+  requests: { at: number; kind: "long" | "quick" }[];
+  close: () => Promise<void>;
+}
+
+const chunk = (text: string, finish: string | null) =>
+  `data: ${JSON.stringify({
+    id: "chatcmpl-mock",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "mock-model",
+    choices: [
+      {
+        index: 0,
+        delta: finish ? {} : { content: text },
+        finish_reason: finish,
+      },
+    ],
+  })}\n\n`;
+
+/** The last user message's text, however the body nests it. */
+const lastUserContent = (body: string): string => {
+  try {
+    const parsed = JSON.parse(body) as {
+      messages?: { role?: string; content?: unknown }[];
+    };
+    const last = [...(parsed.messages ?? [])]
+      .reverse()
+      .find((message) => message.role === "user");
+    if (!last) return "";
+    return typeof last.content === "string"
+      ? last.content
+      : JSON.stringify(last.content ?? "");
+  } catch {
+    return body;
+  }
+};
+
+export const startMockProvider = (options: {
+  longMs: number;
+  keepaliveMs: number;
+}): Promise<MockProvider> =>
+  new Promise((resolve) => {
+    const requests: MockProvider["requests"] = [];
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (piece: Buffer) => (body += piece.toString()));
+      req.on("end", () => {
+        if (!req.url?.includes("/chat/completions")) {
+          res.writeHead(404).end();
+          return;
+        }
+        const long = lastUserContent(body).includes(LONG_RUN_MARKER);
+        requests.push({ at: Date.now(), kind: long ? "long" : "quick" });
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-mock",
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: "mock-model",
+            choices: [
+              { index: 0, delta: { role: "assistant" }, finish_reason: null },
+            ],
+          })}\n\n`,
+        );
+        res.write(
+          chunk(long ? "Working on the long task" : "Quick answer", null),
+        );
+        const finish = () => {
+          res.write(
+            `data: ${JSON.stringify({
+              id: "chatcmpl-mock",
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: "mock-model",
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+              usage: {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+              },
+            })}\n\n`,
+          );
+          res.write("data: [DONE]\n\n");
+          res.end();
+        };
+        if (!long) {
+          finish();
+          return;
+        }
+        const keepalive = setInterval(() => {
+          res.write(chunk(" ...still working", null));
+        }, options.keepaliveMs);
+        const done = setTimeout(() => {
+          clearInterval(keepalive);
+          res.write(chunk(` ${FINAL_ANSWER_MARKER}`, null));
+          finish();
+        }, options.longMs);
+        // res 'close', not req 'close': the REQUEST stream closes as soon as
+        // its body is consumed in modern Node, which would clear these timers
+        // immediately and leave the SSE hanging open forever. The RESPONSE
+        // closes when the peer (jcode cancelling the run) goes away — the
+        // signal that actually means "stop streaming".
+        res.on("close", () => {
+          clearInterval(keepalive);
+          clearTimeout(done);
+        });
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({
+        server,
+        port,
+        requests,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+            server.closeAllConnections();
+          }),
+      });
+    });
+  });

--- a/apps/sandbox-supervisor/src/jcode-incident.live.test.ts
+++ b/apps/sandbox-supervisor/src/jcode-incident.live.test.ts
@@ -1,0 +1,413 @@
+import { mkdtempSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  SupervisorMessage,
+  SupervisorTransport,
+  WorkItem,
+} from "@onecli/agent-protocol";
+
+/**
+ * THE STUCK-SANDBOX INCIDENT REGRESSION SUITE — live, against the real jcode
+ * binary and the real supervisor, with only the model provider mocked (a
+ * slow SSE stream stands in for the incident's CI-watching turn).
+ *
+ * The incident (2026-08-25, self-host): one long turn; a second conversation
+ * attached to its BUSY session, two 30s control-op timeouts became false
+ * "model isn't available" notices, the busy refusal's broadcast error frame
+ * failed the live turn 23 minutes early with an empty error, every follow-up
+ * died silently in ~150ms, and the finished answer was discarded. Each
+ * scenario here asserts the FIXED behavior; each failed on the pre-fix tree.
+ *
+ * Env-gated like the live conformance run — it needs a jcode runtime
+ * (ONECLI_JCODE_BINARY, or the SDK's bundled platform binary):
+ *
+ *   JCODE_LIVE_TEST=1 pnpm --filter @onecli/sandbox-supervisor \
+ *     exec vitest run src/jcode-incident.live.test.ts
+ */
+const LIVE = Boolean(process.env.JCODE_LIVE_TEST);
+
+/** Injected into the managed config.toml by the writeManagedFile wrap. */
+let mockProviderToml = "";
+
+// The adapter rewrites config.toml at instance launch — wrap the shared
+// managed write to add the mock provider profile and pin the default model
+// route onto it, exactly as if the image shipped this provider.
+vi.mock("./home/fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./home/fs")>();
+  return {
+    ...original,
+    writeManagedFile: (path: string, content: string, mode: number) => {
+      if (path.endsWith("config.toml")) {
+        content =
+          content.replace(
+            "[provider]\n",
+            '[provider]\ndefault_model = "mockai:mock-model"\n',
+          ) + mockProviderToml;
+      }
+      return original.writeManagedFile(path, content, mode);
+    },
+  };
+});
+
+const { createJcodeHarness } = await import("./harness/jcode");
+const { runSupervisor } = await import("./supervisor");
+const { startMockProvider, FINAL_ANSWER_MARKER, LONG_RUN_MARKER } =
+  await import("./harness/testing/mock-provider");
+
+interface Stamped {
+  at: number;
+  message: SupervisorMessage;
+}
+
+const createTransport = () => {
+  const sent: Stamped[] = [];
+  const queue: WorkItem[] = [];
+  let notify: (() => void) | undefined;
+  return {
+    sent,
+    push(item: WorkItem) {
+      queue.push(item);
+      notify?.();
+      notify = undefined;
+    },
+    resultsOf(turnId: string) {
+      return sent
+        .filter(
+          (s) =>
+            s.message.kind === "turn.result" && s.message.turnId === turnId,
+        )
+        .map((s) => ({
+          at: s.at,
+          result: s.message as Extract<
+            SupervisorMessage,
+            { kind: "turn.result" }
+          >,
+        }));
+    },
+    eventsOf(turnId: string) {
+      return sent.filter(
+        (s) => s.message.kind === "event" && s.message.turnId === turnId,
+      );
+    },
+    textOf(turnId: string) {
+      return this.eventsOf(turnId)
+        .map((s) => s.message as Extract<SupervisorMessage, { kind: "event" }>)
+        .filter((m) => m.event.type === "text" || m.event.type === "text.delta")
+        .map((m) => (m.event as { text: string }).text)
+        .join("");
+    },
+    async until(predicate: () => boolean, label: string, timeoutMs: number) {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (predicate()) return;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      throw new Error(`timed out waiting for ${label}`);
+    },
+    transport: {
+      async *incoming(): AsyncIterable<WorkItem> {
+        for (;;) {
+          while (queue.length > 0) {
+            const item = queue.shift();
+            if (!item) continue;
+            yield item;
+            if (item.kind === "shutdown") return;
+          }
+          await new Promise<void>((resolve) => {
+            notify = resolve;
+          });
+        }
+      },
+      send(message: SupervisorMessage) {
+        sent.push({ at: Date.now(), message });
+      },
+      close() {
+        return Promise.resolve();
+      },
+    } satisfies SupervisorTransport,
+  };
+};
+
+const stubHarvester = {
+  poll: async () => undefined,
+  harvestFile: async () => "refused" as const,
+  forgetFile: () => undefined,
+  handleResult: () => undefined,
+  stop: () => undefined,
+};
+
+/** A short /tmp home — the daemon binds a unix socket under it, and macOS's
+ * /var/folders tmpdir overflows SUN_LEN (proven in the incident repro). */
+const shortHome = () => mkdtempSync("/tmp/ocl-");
+
+const supervisorConfig = (homeDir: string) => ({
+  homeDir,
+  model: "mock-model",
+  effort: "low" as const,
+  instructions: "incident regression agent",
+  agentName: "Donna",
+  harness: "jcode",
+  runnerWsUrl: undefined,
+  bootstrapToken: undefined,
+});
+
+const deliver = (
+  turnId: string,
+  conversationId: string,
+  message: string,
+): WorkItem => ({ kind: "turn.deliver", turnId, conversationId, message });
+
+const withMock = async (
+  longMs: number,
+  body: (mock: Awaited<ReturnType<typeof startMockProvider>>) => Promise<void>,
+) => {
+  const mock = await startMockProvider({ longMs, keepaliveMs: 5_000 });
+  mockProviderToml = `
+[providers.mockai]
+type = "openai-compatible"
+base_url = "http://127.0.0.1:${mock.port}/v1"
+api_key = "sk-mock"
+default_model = "mock-model"
+models = [{ id = "mock-model" }]
+`;
+  try {
+    await body(mock);
+  } finally {
+    await mock.close();
+  }
+};
+
+describe("jcode incident live gate", () => {
+  // vitest errors on a file with no runnable tests, so the gate holds one
+  // cheap assertion for the skipped case (the conformance file's pattern).
+  it.skipIf(!LIVE)("declares the capabilities the scenarios lean on", () => {
+    expect(createJcodeHarness().capabilities).toMatchObject({
+      resume: true,
+      steer: true,
+    });
+  });
+});
+
+describe.skipIf(!LIVE)("the stuck-sandbox incident, fixed (live jcode)", () => {
+  it("a second conversation runs CONCURRENTLY and the long turn's answer is delivered", async () => {
+    // The incident timeline with the fixed expectations: B gets its OWN
+    // session instantly (no 30s control-op deferrals — the bug's timing
+    // fingerprint), both turns complete, nothing fails, and A's final
+    // answer reaches the transport instead of being discarded.
+    await withMock(40_000, async () => {
+      const t = createTransport();
+      const run = runSupervisor(
+        supervisorConfig(shortHome()),
+        createJcodeHarness(),
+        t.transport,
+        { memoryHarvester: stubHarvester },
+      );
+
+      try {
+        t.push(deliver("t-a", "cv-a", `${LONG_RUN_MARKER} watch the CI`));
+        await t.until(
+          () => t.eventsOf("t-a").length > 0,
+          "conversation A to start streaming",
+          60_000,
+        );
+
+        const bPushedAt = Date.now();
+        t.push(deliver("t-b", "cv-b", "hey, what are you working on?"));
+        await t.until(
+          () => t.resultsOf("t-b").length > 0,
+          "conversation B's result",
+          30_000,
+        );
+
+        const [b] = t.resultsOf("t-b");
+        // B completed fast — pre-fix this took 60s of timeouts and failed.
+        expect(b!.result.status).toBe("done");
+        expect(b!.at - bPushedAt).toBeLessThan(15_000);
+        expect(t.textOf("t-b")).toContain("Quick answer");
+
+        // A keeps running to completion — pre-fix it was failed the moment
+        // B's refusal frame landed in its stream.
+        await t.until(
+          () => t.resultsOf("t-a").length > 0,
+          "conversation A's result",
+          90_000,
+        );
+        const [a] = t.resultsOf("t-a");
+        expect(a!.result.status).toBe("done");
+        expect(t.textOf("t-a")).toContain(FINAL_ANSWER_MARKER);
+
+        // The collision itself: distinct sessions per conversation.
+        expect(a!.result.sessionRef).toBeDefined();
+        expect(b!.result.sessionRef).toBeDefined();
+        expect(a!.result.sessionRef).not.toBe(b!.result.sessionRef);
+      } finally {
+        t.push({ kind: "shutdown" });
+        await run;
+      }
+      // An ordinary shutdown closes N connections and the instance — none of
+      // that may read as a harness death (the disposing-flag ordering this
+      // restructure depends on).
+      expect(t.sent.filter((s) => s.message.kind === "unhealthy")).toHaveLength(
+        0,
+      );
+    });
+  }, 240_000);
+
+  it("an abandoned run is self-healed away — the next message still gets its answer", async () => {
+    // The follow-up shape: the platform walked away from a turn (here, by
+    // abandoning the iterator — the pre-fix supervisor did exactly this
+    // when the refusal frame killed its stream) while the daemon kept
+    // executing. The NEXT message hits the busy session; the self-heal
+    // cancels the orphan and resends. Pre-fix: failed in ~150ms, empty
+    // error, six times in a row.
+    await withMock(120_000, async (mock) => {
+      const harness = createJcodeHarness();
+      let failure: string | undefined;
+      harness.onFailure((reason) => {
+        failure = reason;
+      });
+      const homeDir = shortHome();
+      try {
+        const session = await harness.startSession({
+          homeDir,
+          model: "mock-model",
+        });
+
+        const first = session
+          .runTurn({ message: `${LONG_RUN_MARKER} watch the CI` })
+          [Symbol.asyncIterator]();
+        // Consume just past the send, then walk away mid-run.
+        await first.next();
+        await t0Streaming(mock);
+        await first.return?.(undefined);
+
+        const events = [];
+        for await (const event of session.runTurn({
+          message: "quick status please",
+        })) {
+          events.push(event);
+        }
+
+        expect(events.at(-1)?.type).toBe("turn.done");
+        const text = events
+          .filter((e) => e.type === "text.delta")
+          .map((e) => (e as { text: string }).text)
+          .join("");
+        expect(text).toContain("Quick answer");
+        // The abandoned orphan and its cancel are one turn's business —
+        // never a harness death.
+        expect(failure).toBeUndefined();
+      } finally {
+        await harness.dispose();
+      }
+    });
+  }, 240_000);
+
+  it("resume-by-ref works across container lives — the restart shape, live", async () => {
+    // A conversation resumes by sessionRef only in a FRESH container (the
+    // supervisor caches live sessions in-process), so the first harness is
+    // disposed before the second resumes on the same home — verified here
+    // against the real bridge, not the mock. A resume ref held by a LIVE
+    // conversation is corrupted duplicate data and mints fresh instead (the
+    // adapter unit suite pins that arm).
+    await withMock(20_000, async () => {
+      const homeDir = shortHome();
+      const first = createJcodeHarness();
+      let ref: string | null | undefined;
+      try {
+        const session = await first.startSession({
+          homeDir,
+          model: "mock-model",
+        });
+        ref = session.sessionRef;
+        if (!ref) throw new Error("expected a session ref");
+        // A quick turn proves the session serves before the restart.
+        for await (const event of session.runTurn({ message: "warm up" })) {
+          if (event.type === "error") {
+            throw new Error(`warm-up failed: ${event.message}`);
+          }
+        }
+      } finally {
+        await first.dispose();
+      }
+
+      const second = createJcodeHarness();
+      try {
+        const resumed = await second.startSession({
+          homeDir,
+          model: "mock-model",
+          resumeSessionRef: ref,
+        });
+        expect(resumed.sessionRef).toBe(ref);
+
+        const events = [];
+        for await (const event of resumed.runTurn({
+          message: "still there?",
+        })) {
+          events.push(event);
+        }
+        expect(events.at(-1)?.type).toBe("turn.done");
+      } finally {
+        await second.dispose();
+      }
+    });
+  }, 240_000);
+
+  it("a message steered into the live long turn JOINS it — never purged, never lost", async () => {
+    // The mid-turn messages the user sent "while it was working": they ride
+    // soft interrupts into the run and must reconcile as joined on the
+    // terminal report. Pre-fix, the false failure purged the queue and the
+    // re-run died against the busy session.
+    await withMock(20_000, async () => {
+      const t = createTransport();
+      const run = runSupervisor(
+        supervisorConfig(shortHome()),
+        createJcodeHarness(),
+        t.transport,
+        { memoryHarvester: stubHarvester },
+      );
+
+      try {
+        t.push(deliver("t-a", "cv-a", `${LONG_RUN_MARKER} watch the CI`));
+        await t.until(
+          () => t.eventsOf("t-a").length > 0,
+          "the long turn to start",
+          60_000,
+        );
+        t.push({
+          kind: "turn.message",
+          turnId: "f-1",
+          targetTurnId: "t-a",
+          conversationId: "cv-a",
+          message: "also check the linter output",
+        });
+
+        await t.until(
+          () => t.resultsOf("t-a").length > 0,
+          "the long turn's result",
+          120_000,
+        );
+        const [a] = t.resultsOf("t-a");
+        expect(a!.result.status).toBe("done");
+        expect(a!.result.followUps).toEqual([
+          { turnId: "f-1", outcome: "joined" },
+        ]);
+      } finally {
+        t.push({ kind: "shutdown" });
+        await run;
+      }
+    });
+  }, 240_000);
+});
+
+/** Wait until the mock has served the long request (the run is truly live). */
+const t0Streaming = async (
+  mock: Awaited<ReturnType<typeof startMockProvider>>,
+) => {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (mock.requests.some((request) => request.kind === "long")) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("the long run never reached the mock provider");
+};

--- a/apps/sandbox-supervisor/src/processes/manager.test.ts
+++ b/apps/sandbox-supervisor/src/processes/manager.test.ts
@@ -7,6 +7,7 @@ import {
   createProcessManager,
   MAX_PROCESSES_PER_SANDBOX,
   MAX_WATCHES_PER_PROCESS,
+  TURN_END_SAFETY_NET_PROMPT,
   type ProcessManager,
 } from "./manager";
 
@@ -490,5 +491,113 @@ describe("observed entries (the native-task mirror)", () => {
     expect(latest(sent, "obs-1").watches[0]?.status).toBe("canceled");
     expect(manager.cancelWatch("obs-1", watchId)).toBe(false); // inert now
     expect(manager.cancelWatch("obs-1", "nope")).toBe(false);
+  });
+});
+
+describe("the turn-end safety net", () => {
+  it("arms a default exit watch on running processes with no watch", async () => {
+    const { manager, sent } = rig();
+    const id = startId(manager.start({ command: "sleep 5" }, null));
+
+    const armed = manager.armTurnEndSafetyNet({
+      conversationId: "cv-end",
+      turnId: "t-end",
+    });
+
+    expect(armed).toBe(1);
+    const p = latest(sent, id);
+    expect(p.watches).toHaveLength(1);
+    expect(p.watches[0]?.status).toBe("armed");
+    expect(p.watches[0]?.kind).toBe("exit");
+    expect(p.watches[0]?.prompt).toBe(TURN_END_SAFETY_NET_PROMPT);
+    // Context-less process → the ending turn's context is the fallback
+    // (the frame flattens watch context into conversationId/turnId).
+    expect(p.watches[0]?.conversationId).toBe("cv-end");
+    expect(p.watches[0]?.turnId).toBe("t-end");
+    manager.stop({ processId: id });
+  });
+
+  it("prefers the process's own arm-time context over the fallback", async () => {
+    // The honest origin: the chat where the task was STARTED — a net re-arm
+    // from a watch- or cron-sourced turn must not point the report at a
+    // hidden automation conversation.
+    const { manager, sent } = rig();
+    const id = startId(
+      manager.start(
+        { command: "sleep 5" },
+        { conversationId: "cv-origin", turnId: "t-origin" },
+      ),
+    );
+
+    manager.armTurnEndSafetyNet({
+      conversationId: "cv-automation",
+      turnId: "t-automation",
+    });
+
+    const p = latest(sent, id);
+    expect(p.watches[0]?.conversationId).toBe("cv-origin");
+    expect(p.watches[0]?.turnId).toBe("t-origin");
+    manager.stop({ processId: id });
+  });
+
+  it("skips processes that already have an armed watch — no double report", async () => {
+    const { manager } = rig();
+    const id = startId(manager.start({ command: "sleep 5" }, null));
+    manager.watch({ processId: id, kind: "exit", prompt: "mine" }, null);
+
+    const armed = manager.armTurnEndSafetyNet({
+      conversationId: "cv",
+      turnId: "t",
+    });
+
+    expect(armed).toBe(0);
+    manager.stop({ processId: id });
+  });
+
+  it("skips terminal processes — their completion was visible to the turn", async () => {
+    const { manager, sent } = rig();
+    const id = startId(manager.start({ command: "true" }, null));
+    await waitFor(sent, id, (x) => x.status !== "running");
+
+    const armed = manager.armTurnEndSafetyNet({
+      conversationId: "cv",
+      turnId: "t",
+    });
+
+    expect(armed).toBe(0);
+    expect(latest(sent, id).watches).toHaveLength(0);
+  });
+
+  it("covers OBSERVED harness-native tasks the same way", async () => {
+    const { manager, sent } = rig();
+    manager.observeUpsert(
+      {
+        ref: "native-1",
+        command: "native build",
+        status: "running",
+        startedAt: new Date().toISOString(),
+        wantsWake: false,
+      },
+      null,
+    );
+
+    const armed = manager.armTurnEndSafetyNet({
+      conversationId: "cv",
+      turnId: "t",
+    });
+
+    expect(armed).toBe(1);
+    const p = latest(sent, "native-1");
+    expect(p.watches[0]?.status).toBe("armed");
+    expect(p.watches[0]?.prompt).toBe(TURN_END_SAFETY_NET_PROMPT);
+  });
+
+  it("is inert after close", () => {
+    const { manager } = rig();
+    manager.start({ command: "sleep 5" }, null);
+    manager.close();
+    expect(
+      manager.armTurnEndSafetyNet({ conversationId: "cv", turnId: "t" }),
+    ).toBe(0);
   });
 });

--- a/apps/sandbox-supervisor/src/processes/manager.ts
+++ b/apps/sandbox-supervisor/src/processes/manager.ts
@@ -69,6 +69,15 @@ export interface TurnContext {
   turnId: string;
 }
 
+/**
+ * What the turn-end safety net's watch instructs the fired turn to do. The
+ * net exists for work the agent left running with NOTHING armed to report
+ * it — a completion nobody would ever hear about otherwise (the running row
+ * already holds the machine awake; it is the RESULT that evaporates).
+ */
+export const TURN_END_SAFETY_NET_PROMPT =
+  "A background task was still running when your turn ended without any watch on it. Check its outcome (process_status shows its output) and report the result concisely — the report is delivered to the chat where the task was started. If nothing needs reporting, say so briefly.";
+
 export type ToolOutcome = {
   ok: boolean;
   result?: unknown;
@@ -119,6 +128,15 @@ export interface ProcessManager {
   /** Cancel one ARMED watch (armed→canceled + frame) — the wake-revoke
    * surface. Inert for unknown refs or non-armed watches. */
   cancelWatch(processRef: string, watchRef: string): boolean;
+  /**
+   * The turn-end safety net: arm a default exit-watch on every RUNNING
+   * process that has no armed watch, so work the agent left behind reports
+   * its outcome instead of completing invisibly. Each watch carries the
+   * process's own arm-time context (the chat where it was started);
+   * `fallbackContext` — the ending turn's — covers context-less entries.
+   * Returns how many were armed; inert when closed.
+   */
+  armTurnEndSafetyNet(fallbackContext: TurnContext): number;
   /** Orderly teardown: SIGTERM every group (no wait), destroy pipes, stop
    * the sweeper. Sends nothing — after container stop the control plane's
    * lost sweep owns the truth. */
@@ -330,6 +348,77 @@ export const createProcessManager = (
   const sweeper = setInterval(sweep, sweepIntervalMs);
   sweeper.unref();
 
+  /**
+   * The shared arm path — the `watch` tool and the turn-end safety net both
+   * go through it, so one place owns the caps, the arm-on-a-corpse immediate
+   * trigger, and the frame.
+   */
+  const armWatch = (
+    entry: ProcessEntry,
+    args: {
+      kind: "exit" | "pattern" | "silence";
+      pattern?: string;
+      silenceSeconds?: number;
+      prompt: string;
+      expiresInSeconds?: number;
+    },
+    context: TurnContext | null,
+  ): ToolOutcome => {
+    const armed = entry.watches.filter(
+      (watch) => watch.status === "armed",
+    ).length;
+    if (armed >= MAX_WATCHES_PER_PROCESS) {
+      return {
+        ok: false,
+        error: `This process already has ${MAX_WATCHES_PER_PROCESS} armed watches.`,
+      };
+    }
+    if (entry.watches.length >= MAX_WATCHES_PER_PROCESS_WIRE) {
+      return {
+        ok: false,
+        error: "Too many watches on this process — start a fresh one.",
+      };
+    }
+    const expiresInSeconds = Math.min(
+      Math.max(
+        args.expiresInSeconds ?? WATCH_EXPIRES_DEFAULT_SECONDS,
+        WATCH_EXPIRES_MIN_SECONDS,
+      ),
+      WATCH_EXPIRES_MAX_SECONDS,
+    );
+    const watch: WatchEntry = {
+      ref: randomUUID(),
+      kind: args.kind,
+      ...(args.kind === "pattern" && { pattern: args.pattern }),
+      ...(args.kind === "silence" && {
+        silenceSeconds: args.silenceSeconds,
+      }),
+      prompt: args.prompt,
+      status: "armed",
+      expiresAt: now() + expiresInSeconds * 1000,
+      context,
+    };
+    entry.watches.push(watch);
+    // Arming on an already-ended process triggers IMMEDIATELY — the
+    // status-check-then-arm TOCTOU cannot produce a watch that waits on a
+    // corpse.
+    if (entry.status !== "running") {
+      triggerWatch(entry, watch, "exited");
+    }
+    sendFrame(entry);
+    return {
+      ok: true,
+      result: {
+        watchId: watch.ref,
+        expiresAt: new Date(watch.expiresAt).toISOString(),
+        note:
+          watch.status === "triggered"
+            ? "The process had already ended, so this watch fired immediately."
+            : "Armed. It fires once, then is done; it also fires if the process ends first, whatever its kind.",
+      },
+    };
+  };
+
   // The process_start cap counts only OWNED entries: harness-native tasks
   // the observer mirrors must never brick the agent's own tool.
   const ownedRunningCount = (): number =>
@@ -527,59 +616,36 @@ export const createProcessManager = (
       if (!entry) {
         return { ok: false, error: `No process "${args.processId}".` };
       }
-      const armed = entry.watches.filter(
-        (watch) => watch.status === "armed",
-      ).length;
-      if (armed >= MAX_WATCHES_PER_PROCESS) {
-        return {
-          ok: false,
-          error: `This process already has ${MAX_WATCHES_PER_PROCESS} armed watches.`,
-        };
+      return armWatch(entry, args, context);
+    },
+
+    armTurnEndSafetyNet(fallbackContext) {
+      if (closed) return 0;
+      let armed = 0;
+      for (const entry of processes.values()) {
+        if (entry.status !== "running") continue;
+        // Any armed watch already guarantees a wake on exit (finalize fires
+        // them ALL) — the net exists only for work nothing will report.
+        if (entry.watches.some((watch) => watch.status === "armed")) continue;
+        const outcome = armWatch(
+          entry,
+          {
+            kind: "exit",
+            prompt: TURN_END_SAFETY_NET_PROMPT,
+            // The MAX, not the default: a day-long build's report must
+            // still land (the observer's implicit-wake choice).
+            expiresInSeconds: WATCH_EXPIRES_MAX_SECONDS,
+          },
+          // The process's own first-sight context is the honest origin —
+          // "the chat where the task was started" — and it also keeps a
+          // net re-arm from a watch- or cron-sourced turn from pointing
+          // the report at a hidden automation conversation. The ending
+          // turn's context only covers context-less observed tasks.
+          entry.context ?? fallbackContext,
+        );
+        if (outcome.ok) armed += 1;
       }
-      if (entry.watches.length >= MAX_WATCHES_PER_PROCESS_WIRE) {
-        return {
-          ok: false,
-          error: "Too many watches on this process — start a fresh one.",
-        };
-      }
-      const expiresInSeconds = Math.min(
-        Math.max(
-          args.expiresInSeconds ?? WATCH_EXPIRES_DEFAULT_SECONDS,
-          WATCH_EXPIRES_MIN_SECONDS,
-        ),
-        WATCH_EXPIRES_MAX_SECONDS,
-      );
-      const watch: WatchEntry = {
-        ref: randomUUID(),
-        kind: args.kind,
-        ...(args.kind === "pattern" && { pattern: args.pattern }),
-        ...(args.kind === "silence" && {
-          silenceSeconds: args.silenceSeconds,
-        }),
-        prompt: args.prompt,
-        status: "armed",
-        expiresAt: now() + expiresInSeconds * 1000,
-        context,
-      };
-      entry.watches.push(watch);
-      // Arming on an already-ended process triggers IMMEDIATELY — the
-      // status-check-then-arm TOCTOU cannot produce a watch that waits on a
-      // corpse.
-      if (entry.status !== "running") {
-        triggerWatch(entry, watch, "exited");
-      }
-      sendFrame(entry);
-      return {
-        ok: true,
-        result: {
-          watchId: watch.ref,
-          expiresAt: new Date(watch.expiresAt).toISOString(),
-          note:
-            watch.status === "triggered"
-              ? "The process had already ended, so this watch fired immediately."
-              : "Armed. It fires once, then is done; it also fires if the process ends first, whatever its kind.",
-        },
-      };
+      return armed;
     },
 
     observeUpsert(snapshot, context) {

--- a/apps/sandbox-supervisor/src/supervisor.conversations.test.ts
+++ b/apps/sandbox-supervisor/src/supervisor.conversations.test.ts
@@ -14,6 +14,7 @@ import {
   createFakeSessionStore,
   type FakeSessionStore,
 } from "./harness/fake";
+import type { ProcessManager } from "./processes/manager";
 import { runSupervisor } from "./supervisor";
 
 /**
@@ -902,5 +903,275 @@ describe("a model-provider refusal on a live harness", () => {
     const failed = t.of("turn.result").find((r) => r.turnId === "t1");
     expect(failed?.status).toBe("failed");
     expect(failed?.errorCode).toBe("agent_restarted");
+  });
+});
+
+/** Wrap a harness so its sessions count `abort()` calls — the defensive
+ * abort has no other observable on the fake (its `aborted` flag resets per
+ * turn). Delegation, not spread: session methods live on the prototype. */
+const withAbortCounter = (base: Harness) => {
+  const counter = { aborts: 0 };
+  const startSession = base.startSession.bind(base);
+  const harness: Harness = {
+    ...base,
+    startSession: async (options) => {
+      const session = await startSession(options);
+      return {
+        sessionRef: session.sessionRef,
+        runTurn: (input) => session.runTurn(input),
+        ...(session.steer && {
+          steer: session.steer.bind(session),
+        }),
+        abort: async () => {
+          counter.aborts += 1;
+          await session.abort();
+        },
+      };
+    },
+  };
+  return { harness, counter };
+};
+
+describe("a busy harness on a live session", () => {
+  const BUSY = "Already processing a message";
+
+  it("a harness_busy terminal earns the code, with the raw refusal beside it", async () => {
+    // The adapter mints the code when its self-heal exhausts; the supervisor
+    // must carry it — and attach the raw text as the version-skew guard (an
+    // old control plane ignores the code, and a NULL error there is the
+    // silent-failure shape this whole fix exists to kill).
+    const t = createTestTransport();
+    const harness = createFakeHarness({
+      script: () => [{ type: "error", message: BUSY, code: "harness_busy" }],
+    });
+    const run = runSupervisor(config(home("sup-busy-")), harness, t.transport);
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(() => t.of("turn.result").length === 1, "the failed turn");
+    await t.finish(run);
+
+    const [failed] = t.of("turn.result");
+    expect(failed?.status).toBe("failed");
+    expect(failed?.errorCode).toBe("harness_busy");
+    expect(failed?.error).toBe(BUSY);
+    // Busy is one turn's problem, never a dead harness.
+    expect(t.of("unhealthy")).toHaveLength(0);
+  });
+
+  it("the busy VOCABULARY alone never mints the code — only the adapter's event code does", async () => {
+    // Invariant 9: the vendor's wording is the adapter's to interpret. A
+    // terminal that merely quotes it (uncoded) stays the raw passthrough.
+    const t = createTestTransport();
+    const harness = createFakeHarness({
+      script: () => [{ type: "error", message: BUSY }],
+    });
+    const run = runSupervisor(config(home("sup-busy-")), harness, t.transport);
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(() => t.of("turn.result").length === 1, "the failed turn");
+    await t.finish(run);
+
+    const [failed] = t.of("turn.result");
+    expect(failed?.status).toBe("failed");
+    expect(failed?.errorCode).toBeUndefined();
+  });
+});
+
+describe("the defensive abort", () => {
+  it("cancels the harness run when a turn fails without a clean end", async () => {
+    // The orphan-burn fix: a turn reported failed while the harness may
+    // still be executing its run must not leave that run alive (23 minutes,
+    // live). The session's abort is the cancel.
+    const t = createTestTransport();
+    const { harness, counter } = withAbortCounter(
+      createFakeHarness({
+        script: () => [{ type: "error", message: "stream fell over" }],
+      }),
+    );
+    const run = runSupervisor(
+      config(home("sup-dabort-")),
+      harness,
+      t.transport,
+    );
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(() => t.of("turn.result").length === 1, "the failed turn");
+    await t.finish(run);
+
+    expect(counter.aborts).toBe(1);
+    // Cleanup, never a reclassification: the failure stays a failure.
+    const [failed] = t.of("turn.result");
+    expect(failed?.status).toBe("failed");
+  });
+
+  it("never fires for a clean turn", async () => {
+    const t = createTestTransport();
+    const { harness, counter } = withAbortCounter(createFakeHarness());
+    const run = runSupervisor(
+      config(home("sup-dabort-")),
+      harness,
+      t.transport,
+    );
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(() => t.of("turn.result").length === 1, "the clean turn");
+    await t.finish(run);
+
+    expect(counter.aborts).toBe(0);
+  });
+
+  it("never doubles a user abort", async () => {
+    const t = createTestTransport();
+    const { harness, counter } = withAbortCounter(
+      createFakeHarness({ script: longScript }),
+    );
+    const run = runSupervisor(
+      config(home("sup-dabort-")),
+      harness,
+      t.transport,
+    );
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(
+      () => deltasOf(t, "t1").length >= 3,
+      "the turn to be mid-stream",
+    );
+    t.push({ kind: "turn.abort", turnId: "t1", conversationId: "cv-a" });
+    await t.until(() => t.of("turn.result").length === 1, "the aborted turn");
+    await t.finish(run);
+
+    const [result] = t.of("turn.result");
+    expect(result?.status).toBe("aborted");
+    // Exactly the user's abort — the defensive arm must not fire again.
+    expect(counter.aborts).toBe(1);
+  });
+
+  it("never fires against a dead harness", async () => {
+    const t = createTestTransport();
+    const { harness, counter } = withAbortCounter(
+      createFakeHarness({ script: longScript }),
+    );
+    const fake = harness as Harness & { simulateFailure: (r?: string) => void };
+    const run = runSupervisor(
+      config(home("sup-dabort-")),
+      harness,
+      t.transport,
+    );
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(
+      () => deltasOf(t, "t1").length >= 3,
+      "the turn to be mid-stream",
+    );
+    fake.simulateFailure("harness connection closed");
+    await run;
+
+    const [failed] = t.of("turn.result");
+    expect(failed?.status).toBe("failed");
+    expect(failed?.errorCode).toBe("agent_restarted");
+    // Nothing to cancel on a dead harness.
+    expect(counter.aborts).toBe(0);
+  });
+});
+
+/** A ProcessManager stub that records safety-net calls — the net's timing
+ * and gating live in the supervisor; the arming itself is manager-tested. */
+const netStub = () => {
+  const netCalls: { conversationId: string; turnId: string }[] = [];
+  const manager: ProcessManager = {
+    start: () => ({ ok: true }),
+    status: () => ({ ok: true }),
+    stop: () => ({ ok: true }),
+    watch: () => ({ ok: true }),
+    observeUpsert: () => ({ created: false, hasArmedWatch: false }),
+    cancelWatch: () => false,
+    armTurnEndSafetyNet: (context) => {
+      netCalls.push(context);
+      return 1;
+    },
+    close: () => undefined,
+    killAllSync: () => undefined,
+  };
+  return { manager, netCalls };
+};
+
+describe("the turn-end safety net (supervisor gating)", () => {
+  it("arms after a DONE turn, with the ending turn's context as fallback", async () => {
+    const t = createTestTransport();
+    const { manager, netCalls } = netStub();
+    const run = runSupervisor(
+      config(home("sup-net-")),
+      createFakeHarness(),
+      t.transport,
+      { processManager: manager },
+    );
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(() => t.of("turn.result").length === 1, "the turn");
+    await t.finish(run);
+
+    expect(netCalls).toEqual([{ conversationId: "cv-a", turnId: "t1" }]);
+  });
+
+  it("arms after a FAILED turn — leftover work still deserves its report", async () => {
+    const t = createTestTransport();
+    const { manager, netCalls } = netStub();
+    const run = runSupervisor(
+      config(home("sup-net-")),
+      createFakeHarness({
+        script: () => [{ type: "error", message: "stream fell over" }],
+      }),
+      t.transport,
+      { processManager: manager },
+    );
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(() => t.of("turn.result").length === 1, "the failed turn");
+    await t.finish(run);
+
+    expect(netCalls).toHaveLength(1);
+  });
+
+  it("never arms after a user abort — stop means silence", async () => {
+    const t = createTestTransport();
+    const { manager, netCalls } = netStub();
+    const run = runSupervisor(
+      config(home("sup-net-")),
+      createFakeHarness({ script: longScript }),
+      t.transport,
+      { processManager: manager },
+    );
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(
+      () => deltasOf(t, "t1").length >= 3,
+      "the turn to be mid-stream",
+    );
+    t.push({ kind: "turn.abort", turnId: "t1", conversationId: "cv-a" });
+    await t.until(() => t.of("turn.result").length === 1, "the aborted turn");
+    await t.finish(run);
+
+    expect(t.of("turn.result")[0]?.status).toBe("aborted");
+    expect(netCalls).toHaveLength(0);
+  });
+
+  it("never arms against a dead harness — the container is going down", async () => {
+    const t = createTestTransport();
+    const { manager, netCalls } = netStub();
+    const harness = createFakeHarness({ script: longScript });
+    const run = runSupervisor(config(home("sup-net-")), harness, t.transport, {
+      processManager: manager,
+    });
+
+    t.push(deliver("t1", "cv-a"));
+    await t.until(
+      () => deltasOf(t, "t1").length >= 3,
+      "the turn to be mid-stream",
+    );
+    harness.simulateFailure("harness connection closed");
+    await run;
+
+    expect(t.of("turn.result")[0]?.status).toBe("failed");
+    expect(netCalls).toHaveLength(0);
   });
 });

--- a/apps/sandbox-supervisor/src/supervisor.ts
+++ b/apps/sandbox-supervisor/src/supervisor.ts
@@ -468,19 +468,35 @@ export const runSupervisor = async (
     let usage: TurnUsage | undefined;
     /** The harness's terminal `error` message, kept for failure classing. */
     let terminalError: string | undefined;
+    /** The terminal `error` event's protocol code, when the adapter minted
+     * one — today only `harness_busy` (the adapter's self-heal exhausting). */
+    let terminalErrorCode: string | undefined;
+    /** Set on the failure arms: a turn that ended `failed` without a clean
+     * terminal may have left the harness still executing its run — the
+     * `finally` cancels it so an orphan can never burn for half an hour
+     * under a row nobody is reading (proven live in the incident). */
+    let uncleanFailure = false;
+    /** How this turn ended, for the `finally`'s safety net: done/failed
+     * turns get their leftover background work watched; aborted turns do
+     * not (stop means silence). */
+    let endedStatus: "done" | "failed" | "aborted" | undefined;
 
     /**
-     * The failure class for this turn. A DEATH code always outranks a
-     * refusal — the death codes carry lifecycle semantics (revival,
-     * visibility, the unhealthy recycle) the provider code must never usurp;
-     * a dying harness whose last words mention a rate limit is still a dead
-     * harness.
+     * The failure class for this turn. A DEATH code always outranks
+     * everything — the death codes carry lifecycle semantics (revival,
+     * visibility, the unhealthy recycle) no other code may usurp; a dying
+     * harness whose last words mention a rate limit is still a dead harness.
+     * `harness_busy` comes only from the terminal error EVENT's code (the
+     * adapter mints it; the catch arm's raw throw never does), and outranks
+     * the provider-refusal prose match.
      */
     const classify = (raw: string | undefined): string | undefined =>
       failureCode(runtime) ??
-      (raw && isProviderRefusal(raw)
-        ? TURN_FAILURE_CODES.modelProviderError
-        : undefined);
+      (terminalErrorCode === TURN_FAILURE_CODES.harnessBusy
+        ? TURN_FAILURE_CODES.harnessBusy
+        : raw && isProviderRefusal(raw)
+          ? TURN_FAILURE_CODES.modelProviderError
+          : undefined);
 
     /** Everything the agent said this turn, rebuilt from the deltas. */
     let answer = "";
@@ -564,6 +580,7 @@ export const runSupervisor = async (
           conversationId: item.conversationId,
           turnId: item.turnId,
         });
+        endedStatus = "aborted";
         transport.send({
           kind: "turn.result",
           turnId: item.turnId,
@@ -656,6 +673,7 @@ export const runSupervisor = async (
         }
         if (event.type === "error") {
           terminalError = event.message;
+          terminalErrorCode = event.code;
         }
       }
 
@@ -675,6 +693,8 @@ export const runSupervisor = async (
       }
       const errorCode =
         status === "failed" ? classify(terminalError) : undefined;
+      uncleanFailure = status === "failed" && !harnessDead;
+      endedStatus = status;
       transport.send({
         kind: "turn.result",
         turnId: item.turnId,
@@ -684,10 +704,14 @@ export const runSupervisor = async (
         // The raw refusal rides beside the code — the control plane stores
         // only the canonical copy and keeps this for its server log (and an
         // old control plane's raw passthrough matches the catch arm below).
-        // Uncoded failures keep today's shape: no error field, the transcript
-        // stream's own error event is the witness. Sliced at the source per
-        // the transport's truncate-at-sender law: this frame must deliver.
-        ...(errorCode === TURN_FAILURE_CODES.modelProviderError &&
+        // `harness_busy` attaches it too, as the version-skew guard: an old
+        // control plane that ignores the code then stores visible text
+        // instead of regressing to the silent NULL shape. Uncoded failures
+        // keep today's shape: no error field, the transcript stream's own
+        // error event is the witness. Sliced at the source per the
+        // transport's truncate-at-sender law: this frame must deliver.
+        ...((errorCode === TURN_FAILURE_CODES.modelProviderError ||
+          errorCode === TURN_FAILURE_CODES.harnessBusy) &&
           terminalError && {
             error: terminalError.slice(0, MAX_TURN_RESULT_ERROR_CHARS),
           }),
@@ -713,6 +737,8 @@ export const runSupervisor = async (
         await new Promise((resolve) => setImmediate(resolve));
       }
       const errorCode = wasAborted() ? undefined : classify(String(error));
+      uncleanFailure = !wasAborted() && !harnessDead;
+      endedStatus = wasAborted() ? "aborted" : "failed";
       const followUps = followUpOutcomes(runtime);
       transport.send({
         kind: "turn.result",
@@ -742,6 +768,57 @@ export const runSupervisor = async (
         (entry) => entry.targetTurnId !== item.turnId,
       );
       runtime.steered = new Map();
+      // THE DEFENSIVE ABORT. A turn that ended `failed` without a clean
+      // terminal may have walked away from a run the harness is still
+      // executing — which then burns invisibly under a row nobody reads
+      // (23 minutes, live) and blocks the session for the next message.
+      // Cancel it. AWAITED, not fire-and-forget: the conversation queue
+      // advances when this `finally` resolves, and an unawaited cancel could
+      // be written to the socket AFTER the next turn's send — killing the
+      // fresh run instead of the orphan. The terminal `turn.result` is
+      // already out (sent in the arms above), so nothing user-facing waits
+      // on this; worst case on a wedged harness is one request timeout
+      // delaying only this conversation's next turn, which is blocked on
+      // the wedged session anyway. Deliberately NOT via `abort()`/
+      // `abortedTurnId` — this is cleanup, and a failure must never be
+      // re-reported as a user cancel.
+      if (uncleanFailure && runtime.streamStarted && runtime.session) {
+        await runtime.session
+          .abort()
+          .catch((error: unknown) =>
+            log("warn", "defensive abort failed", { error: String(error) }),
+          );
+      }
+      // THE TURN-END SAFETY NET. Background work left running with nothing
+      // armed to report it completes invisibly: the running row keeps the
+      // machine awake, but no wake source exists, so the RESULT reaches no
+      // one (observed live — "I'll report back", then silence). Arm a
+      // default exit-watch on every such process. Aborted turns are
+      // excluded (stop means silence), and a dead harness is going down
+      // with its processes — N "lost" wake turns on top of the restart
+      // notice would be noise.
+      if (
+        (endedStatus === "done" || endedStatus === "failed") &&
+        !harnessDead
+      ) {
+        // Caught like the defensive abort above: a throw inside a `finally`
+        // would mask the turn's real completion — the net is best-effort.
+        try {
+          const armed = processes.armTurnEndSafetyNet({
+            conversationId: item.conversationId,
+            turnId: item.turnId,
+          });
+          if (armed > 0) {
+            log("info", "turn-end safety net armed exit watches", {
+              conversationId: item.conversationId,
+              turnId: item.turnId,
+              armed,
+            });
+          }
+        } catch (error) {
+          log("warn", "turn-end safety net failed", { error: String(error) });
+        }
+      }
     }
   };
 

--- a/apps/ssh-terminator/build.mjs
+++ b/apps/ssh-terminator/build.mjs
@@ -1,0 +1,26 @@
+import { build } from "esbuild";
+
+// Production bundle: inline the app plus its @onecli/* workspace deps (which
+// export raw .ts), keep every npm package external so it resolves from
+// node_modules at runtime.
+await build({
+  entryPoints: ["src/index.ts"],
+  outfile: "dist/index.mjs",
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  sourcemap: true,
+  plugins: [
+    {
+      name: "external-node-modules",
+      setup(builder) {
+        // Bare specifiers only: relative ("./"), absolute ("/"), and
+        // package-internal "#" subpath imports stay with esbuild's resolver.
+        builder.onResolve({ filter: /^[^./#]/ }, (args) =>
+          args.path.startsWith("@onecli/") ? undefined : { external: true },
+        );
+      },
+    },
+  ],
+});

--- a/apps/ssh-terminator/eslint.config.js
+++ b/apps/ssh-terminator/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from "@onecli/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/apps/ssh-terminator/package.json
+++ b/apps/ssh-terminator/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@onecli/ssh-terminator",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "start": "node dist/index.mjs",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint --max-warnings 0",
+    "lint:fix": "eslint --fix --max-warnings 0",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.1014.0",
+    "@aws-sdk/client-secrets-manager": "^3.1014.0",
+    "@kubernetes/client-node": "2.0.0",
+    "@onecli/ssh-cert": "workspace:*",
+    "pino": "^10.3.1",
+    "ssh2": "^1.17.0"
+  },
+  "devDependencies": {
+    "@onecli/eslint-config": "workspace:*",
+    "@onecli/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "@types/ssh2": "^1.15.5",
+    "esbuild": "^0.28.0",
+    "pino-pretty": "^13.1.3",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.6"
+  }
+}

--- a/apps/ssh-terminator/src/auth.test.ts
+++ b/apps/ssh-terminator/src/auth.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { ED25519_CERT_TYPE, ed25519KeyBlob } from "@onecli/ssh-cert";
+import { authenticate, certificateLineOf, type AuthContextLike } from "./auth";
+import {
+  createTestCa,
+  createTestUserKey,
+  mintTestCertificate,
+} from "./test-fixtures";
+
+interface CtxRecorder extends AuthContextLike {
+  accepted: boolean;
+  rejected: boolean;
+  rejectedMethods: string[] | undefined;
+}
+
+const makeCtx = (over: {
+  method?: string;
+  username?: string;
+  key?: { algo: string; data: Buffer };
+  signature?: Buffer;
+  blob?: Buffer;
+}): CtxRecorder => {
+  const ctx: CtxRecorder = {
+    method: over.method ?? "publickey",
+    username: over.username ?? "agent-1",
+    key: over.key,
+    signature: over.signature,
+    blob: over.blob,
+    accepted: false,
+    rejected: false,
+    rejectedMethods: undefined,
+    accept() {
+      ctx.accepted = true;
+    },
+    reject(methods) {
+      ctx.rejected = true;
+      ctx.rejectedMethods = methods;
+    },
+  };
+  return ctx;
+};
+
+const ca = createTestCa();
+const user = createTestUserKey();
+
+describe("authenticate", () => {
+  it("advertises publickey-only for other methods, uncounted", () => {
+    const ctx = makeCtx({ method: "none" });
+    const outcome = authenticate(ctx, { caPublicKey: ca.publicKey });
+    expect(outcome).toEqual({ state: "rejected", counted: false });
+    expect(ctx.rejected).toBe(true);
+    expect(ctx.rejectedMethods).toEqual(["publickey"]);
+  });
+
+  it("rejects password auth", () => {
+    const ctx = makeCtx({ method: "password" });
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey }).state).toBe(
+      "rejected",
+    );
+  });
+
+  it("rejects a bare (non-certificate) ed25519 key", () => {
+    const ctx = makeCtx({
+      key: { algo: "ssh-ed25519", data: ed25519KeyBlob(user.publicKey) },
+    });
+    const outcome = authenticate(ctx, { caPublicKey: ca.publicKey });
+    expect(outcome).toEqual({ state: "rejected", counted: true });
+    expect(ctx.accepted).toBe(false);
+  });
+
+  it("answers PK_OK in the check phase for a valid certificate", async () => {
+    const cert = await mintTestCertificate(ca, user);
+    const ctx = makeCtx({
+      key: { algo: ED25519_CERT_TYPE, data: cert.blob },
+    });
+    const outcome = authenticate(ctx, { caPublicKey: ca.publicKey });
+    expect(outcome.state).toBe("check-passed");
+    expect(ctx.accepted).toBe(true);
+  });
+
+  it("authenticates when possession is proven in the signature phase", async () => {
+    const cert = await mintTestCertificate(ca, user);
+    const blob = Buffer.from("signed-auth-blob");
+    const ctx = makeCtx({
+      key: { algo: ED25519_CERT_TYPE, data: cert.blob },
+      blob,
+      signature: user.sign(blob),
+    });
+    const outcome = authenticate(ctx, { caPublicKey: ca.publicKey });
+    expect(outcome.state).toBe("authenticated");
+    if (outcome.state === "authenticated") {
+      expect(outcome.username).toBe("agent-1");
+      expect(certificateLineOf(outcome.certificate)).toBe(cert.line);
+    }
+    expect(ctx.accepted).toBe(true);
+  });
+
+  it("rejects a possession signature from the wrong key", async () => {
+    const cert = await mintTestCertificate(ca, user);
+    const stranger = createTestUserKey();
+    const blob = Buffer.from("signed-auth-blob");
+    const ctx = makeCtx({
+      key: { algo: ED25519_CERT_TYPE, data: cert.blob },
+      blob,
+      signature: stranger.sign(blob),
+    });
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey })).toEqual({
+      state: "rejected",
+      counted: true,
+    });
+  });
+
+  it("rejects a foreign-CA certificate", async () => {
+    const foreignCa = createTestCa();
+    const cert = await mintTestCertificate(foreignCa, user);
+    const ctx = makeCtx({
+      key: { algo: ED25519_CERT_TYPE, data: cert.blob },
+    });
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey })).toEqual({
+      state: "rejected",
+      counted: true,
+    });
+  });
+
+  it("rejects an expired certificate", async () => {
+    const cert = await mintTestCertificate(ca, user, {
+      validAfter: new Date(Date.now() - 7_200_000),
+      validBefore: new Date(Date.now() - 3_600_000),
+    });
+    const ctx = makeCtx({
+      key: { algo: ED25519_CERT_TYPE, data: cert.blob },
+    });
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey })).toEqual({
+      state: "rejected",
+      counted: true,
+    });
+  });
+
+  it("rejects a not-yet-valid certificate", async () => {
+    const cert = await mintTestCertificate(ca, user, {
+      validAfter: new Date(Date.now() + 3_600_000),
+      validBefore: new Date(Date.now() + 7_200_000),
+    });
+    const ctx = makeCtx({
+      key: { algo: ED25519_CERT_TYPE, data: cert.blob },
+    });
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey }).state).toBe(
+      "rejected",
+    );
+  });
+
+  it("rejects when the username is not the certified principal", async () => {
+    const cert = await mintTestCertificate(ca, user, {
+      principal: "agent-1",
+    });
+    const ctx = makeCtx({
+      username: "agent-2",
+      key: { algo: ED25519_CERT_TYPE, data: cert.blob },
+    });
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey })).toEqual({
+      state: "rejected",
+      counted: true,
+    });
+  });
+
+  it("rejects a tampered certificate blob", async () => {
+    const cert = await mintTestCertificate(ca, user);
+    const tampered = Buffer.from(cert.blob);
+    tampered[tampered.length - 10] =
+      (tampered[tampered.length - 10] ?? 0) ^ 0xff;
+    const ctx = makeCtx({
+      key: { algo: ED25519_CERT_TYPE, data: tampered },
+    });
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey }).state).toBe(
+      "rejected",
+    );
+  });
+
+  it("rejects a missing key outright", () => {
+    const ctx = makeCtx({});
+    expect(authenticate(ctx, { caPublicKey: ca.publicKey })).toEqual({
+      state: "rejected",
+      counted: true,
+    });
+  });
+});

--- a/apps/ssh-terminator/src/auth.ts
+++ b/apps/ssh-terminator/src/auth.ts
@@ -1,0 +1,86 @@
+import {
+  ED25519_CERT_TYPE,
+  assertValidUserCertificate,
+  parseCertificateBlob,
+  verifyPossession,
+  type SshCertificate,
+} from "@onecli/ssh-cert";
+
+/**
+ * The publickey auth state machine, pure over a structural ssh2 context so
+ * it unit-tests without a live handshake. Certificates only: ssh2 passes
+ * OpenSSH cert blobs through UNPARSED (ctx.key.data is the whole cert blob —
+ * never call its parseKey on one), so all parsing and verification is ours.
+ *
+ * Two-phase per the SSH protocol: the check phase (no signature) answers
+ * PK_OK only after the full certificate law passes — CA signature, validity,
+ * user-cert type, no critical options, principal === username — and the
+ * signature phase additionally proves possession of the certified key.
+ * Rejections are hint-free (a bare reject, no methods-left beyond the
+ * standard publickey advertisement).
+ */
+
+export interface AuthContextLike {
+  method: string;
+  username: string;
+  key?: { algo: string; data: Buffer };
+  signature?: Buffer;
+  blob?: Buffer;
+  accept(): void;
+  reject(authMethodsLeft?: string[]): void;
+}
+
+export type AuthOutcome =
+  | { state: "check-passed" }
+  | { state: "authenticated"; certificate: SshCertificate; username: string }
+  /** `counted` = a real credential failure (feeds SshAuthFailures); the
+   * routine `none`-probe rejection every client starts with is not one. */
+  | { state: "rejected"; counted: boolean };
+
+export interface AuthenticateOptions {
+  /** Raw 32-byte CA public key — the terminator's trust anchor. */
+  caPublicKey: Buffer;
+  now?: Date;
+}
+
+export const authenticate = (
+  ctx: AuthContextLike,
+  options: AuthenticateOptions,
+): AuthOutcome => {
+  if (ctx.method !== "publickey") {
+    ctx.reject(["publickey"]);
+    return { state: "rejected", counted: false };
+  }
+  const key = ctx.key;
+  if (!key || key.algo !== ED25519_CERT_TYPE) {
+    ctx.reject(["publickey"]);
+    return { state: "rejected", counted: true };
+  }
+  let certificate: SshCertificate;
+  try {
+    certificate = parseCertificateBlob(key.data);
+    assertValidUserCertificate(certificate, {
+      caPublicKey: options.caPublicKey,
+      principal: ctx.username,
+      now: options.now,
+    });
+  } catch {
+    ctx.reject(["publickey"]);
+    return { state: "rejected", counted: true };
+  }
+  if (ctx.signature === undefined || ctx.blob === undefined) {
+    // Check phase — echo PK_OK; the client signs and comes back.
+    ctx.accept();
+    return { state: "check-passed" };
+  }
+  if (!verifyPossession(certificate, ctx.blob, ctx.signature)) {
+    ctx.reject(["publickey"]);
+    return { state: "rejected", counted: true };
+  }
+  ctx.accept();
+  return { state: "authenticated", certificate, username: ctx.username };
+};
+
+/** The single-line form the control plane and broker re-verify. */
+export const certificateLineOf = (certificate: SshCertificate): string =>
+  `${ED25519_CERT_TYPE} ${certificate.raw.toString("base64")}`;

--- a/apps/ssh-terminator/src/backend/kube/exec-backend.test.ts
+++ b/apps/ssh-terminator/src/backend/kube/exec-backend.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { exitCodeOf } from "./exec-backend";
+
+describe("exitCodeOf", () => {
+  it("maps Success to 0", () => {
+    expect(exitCodeOf({ status: "Success" })).toBe(0);
+  });
+
+  it("extracts the guest exit code from NonZeroExitCode causes", () => {
+    expect(
+      exitCodeOf({
+        status: "Failure",
+        reason: "NonZeroExitCode",
+        details: {
+          causes: [{ reason: "ExitCode", message: "42" }],
+        },
+      }),
+    ).toBe(42);
+  });
+
+  it("collapses failures without an honest code to 1", () => {
+    expect(exitCodeOf({ status: "Failure", reason: "InternalError" })).toBe(1);
+    expect(exitCodeOf({ status: "Failure", reason: "NonZeroExitCode" })).toBe(
+      1,
+    );
+    expect(
+      exitCodeOf({
+        status: "Failure",
+        reason: "NonZeroExitCode",
+        details: { causes: [{ reason: "ExitCode", message: "not-a-number" }] },
+      }),
+    ).toBe(1);
+    expect(
+      exitCodeOf({
+        status: "Failure",
+        reason: "NonZeroExitCode",
+        details: { causes: [{ reason: "ExitCode", message: "9000" }] },
+      }),
+    ).toBe(1);
+  });
+});

--- a/apps/ssh-terminator/src/backend/kube/exec-backend.ts
+++ b/apps/ssh-terminator/src/backend/kube/exec-backend.ts
@@ -1,0 +1,155 @@
+import { PassThrough } from "node:stream";
+import { Exec, KubeConfig, type V1Status } from "@kubernetes/client-node";
+import { logger } from "../../logger";
+import { ExecDisconnectedError, type ExecBackend } from "../types";
+
+const log = logger.child({ component: "exec-backend" });
+
+/**
+ * The kube substrate's exec backend: one byte pipe into the sandbox via the
+ * Kubernetes API's `pods/exec` subresource. The target vocabulary below is
+ * this backend's own — the core threads it opaquely.
+ */
+
+export interface KubeExecTarget {
+  namespace: string;
+  pod: string;
+  container: string;
+  /** The broker-minted per-session ServiceAccount token. */
+  token: string;
+  /** `https://host:port` of the API server. */
+  server: string;
+  /**
+   * CA bundle file for the API server. The terminator pod runs with
+   * automountServiceAccountToken: false, so the in-cluster default CA path
+   * does not exist — the chart mounts the kube-root-ca ConfigMap instead.
+   */
+  caFile: string;
+}
+
+/**
+ * Map the exec V1Status to a POSIX exit code. `Success` is 0; a non-zero
+ * guest exit arrives as `Failure`/`NonZeroExitCode` with the code riding a
+ * cause message. Any other failure shape (signal death, container gone) has
+ * no honest code — collapse to 1.
+ */
+export const exitCodeOf = (status: V1Status): number => {
+  if (status.status === "Success") return 0;
+  if (status.reason === "NonZeroExitCode") {
+    const cause = status.details?.causes?.find(
+      (candidate) => candidate.reason === "ExitCode",
+    );
+    const code = Number(cause?.message);
+    if (Number.isInteger(code) && code >= 0 && code <= 255) return code;
+  }
+  return 1;
+};
+
+/**
+ * client-node wires the exec RESIZE channel only when the stdout stream it
+ * receives looks like a TTY (`columns`/`rows` fields + a 'resize' event) —
+ * this augmented PassThrough is the sanctioned bridge from ssh2's
+ * window-change events.
+ */
+class ResizableStdout extends PassThrough {
+  columns = 80;
+  rows = 24;
+}
+
+/**
+ * The transport has NO built-in keepalive and the NLB idles connections out
+ * at ~350s — a quiet-but-open shell must be pinged under that.
+ */
+const PING_INTERVAL_MS = 25_000;
+
+export const createKubeExecBackend = (): ExecBackend<KubeExecTarget> => ({
+  async exec(target, command, io, tty) {
+    // Per-session KubeConfig, built by hand: the pod holds no ServiceAccount
+    // credentials (automount off), so loadFromCluster() has nothing to read —
+    // trust is the mounted root CA file plus the broker-minted token.
+    const kubeConfig = new KubeConfig();
+    kubeConfig.loadFromClusterAndUser(
+      {
+        name: "terminator",
+        server: target.server,
+        caFile: target.caFile,
+        skipTLSVerify: false,
+      },
+      { name: "ssh-session", token: target.token },
+    );
+    const exec = new Exec(kubeConfig);
+
+    let settled = false;
+    let resolveExit: (code: number) => void = () => undefined;
+    let rejectExit: (error: Error) => void = () => undefined;
+    const exited = new Promise<number>((resolve, reject) => {
+      resolveExit = (code) => {
+        if (settled) return;
+        settled = true;
+        resolve(code);
+      };
+      rejectExit = (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+    });
+
+    // Intermediates own the library's end() calls (it ends the streams it is
+    // handed when the status arrives) so the ssh2 channel's lifecycle stays
+    // with the relay: pipe without end propagation.
+    const stdout = new ResizableStdout();
+    stdout.pipe(io.stdout, { end: false });
+    let stderr: PassThrough | null = null;
+    if (io.stderr && !tty) {
+      const sink = io.stderr;
+      stderr = new PassThrough();
+      stderr.pipe(sink, { end: false });
+    }
+
+    const ws = await exec.exec(
+      target.namespace,
+      target.pod,
+      target.container,
+      command,
+      stdout,
+      stderr,
+      io.stdin,
+      tty,
+      (status) => resolveExit(exitCodeOf(status)),
+    );
+
+    const pinger = setInterval(() => {
+      try {
+        ws.ping();
+      } catch (error) {
+        log.debug({ err: error }, "exec ping failed");
+      }
+    }, PING_INTERVAL_MS);
+    pinger.unref();
+
+    ws.on("error", (error: Error) => {
+      rejectExit(
+        new ExecDisconnectedError(`exec transport error: ${error.message}`),
+      );
+    });
+    ws.on("close", () => {
+      clearInterval(pinger);
+      // A close before any exit status is pod churn or a severed dial — an
+      // honest relay_error, never a fabricated exit code.
+      rejectExit(new ExecDisconnectedError("exec transport closed"));
+    });
+    void exited.catch(() => undefined).then(() => clearInterval(pinger));
+
+    return {
+      exited,
+      ...(tty && {
+        resize: (cols: number, rows: number) => {
+          stdout.columns = cols;
+          stdout.rows = rows;
+          stdout.emit("resize");
+        },
+      }),
+    };
+  },
+});

--- a/apps/ssh-terminator/src/backend/kube/index.ts
+++ b/apps/ssh-terminator/src/backend/kube/index.ts
@@ -1,0 +1,12 @@
+import type { TerminatorBackend } from "../types";
+import { createKubeExecBackend, type KubeExecTarget } from "./exec-backend";
+import { createKubeResolver, type KubeResolverOptions } from "./resolver";
+
+/** The kube substrate, fully assembled: the manager-broker resolver paired
+ *  with the pods/exec backend, speaking one target vocabulary. */
+export const createKubeBackend = (
+  options: KubeResolverOptions,
+): TerminatorBackend<KubeExecTarget> => ({
+  resolver: createKubeResolver(options),
+  exec: createKubeExecBackend(),
+});

--- a/apps/ssh-terminator/src/backend/kube/resolver.test.ts
+++ b/apps/ssh-terminator/src/backend/kube/resolver.test.ts
@@ -1,0 +1,197 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  ResolverRefusedError,
+  ResolverUnreachableError,
+  type Resolver,
+} from "../types";
+import type { KubeExecTarget } from "./exec-backend";
+import { createKubeResolver } from "./resolver";
+
+/**
+ * The kube resolver's wire law, over a REAL socket: the manager's four
+ * refusal codes are deterministic (ResolverRefusedError), EVERYTHING else —
+ * 401 rotation skew, unknown codes, malformed bodies — is transport-class
+ * (the wake poll rides it out, bounded); and a ready answer comes back as a
+ * COMPLETE KubeExecTarget: the broker's per-session fields merged with the
+ * boot-constant API-server coordinates, plus the parsed expiry that drives
+ * the session's reuse-margin cache.
+ */
+
+const KUBE = { server: "https://kube.test:443", caFile: "/tmp/ca.crt" };
+const INPUT = { certificate: "cert-line", grant: "grant-blob" };
+
+let server: Server;
+let resolver: Resolver<KubeExecTarget>;
+let answer: { status: number; body: string };
+let seen: { authorization: string | undefined; method: string; url: string }[];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    seen.push({
+      authorization: req.headers.authorization,
+      method: req.method ?? "",
+      url: req.url ?? "",
+    });
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(answer.status, { "content-type": "application/json" });
+      res.end(answer.body);
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (typeof address !== "object" || address === null) {
+    throw new Error("server did not bind");
+  }
+  resolver = createKubeResolver({
+    managerUrl: `http://127.0.0.1:${address.port}`,
+    getSecret: () => "broker-secret",
+    kube: KUBE,
+  });
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  seen = [];
+  answer = { status: 200, body: JSON.stringify({ status: "waking" }) };
+});
+
+describe("open — the ready merge", () => {
+  it("completes the broker's fields with the boot kube coordinates and parses the expiry", async () => {
+    const expiresAt = new Date(Date.now() + 600_000);
+    answer = {
+      status: 200,
+      body: JSON.stringify({
+        status: "ready",
+        namespace: "ws-1",
+        pod: "pod-1",
+        container: "sandbox",
+        token: "tok-1",
+        tokenExpiresAt: expiresAt.toISOString(),
+      }),
+    };
+    await expect(resolver.open(INPUT)).resolves.toEqual({
+      status: "ready",
+      target: {
+        namespace: "ws-1",
+        pod: "pod-1",
+        container: "sandbox",
+        token: "tok-1",
+        server: KUBE.server,
+        caFile: KUBE.caFile,
+      },
+      expiresAt,
+    });
+    expect(seen[0]?.authorization).toBe("Bearer broker-secret");
+    expect(seen[0]?.url).toBe("/v1/ssh-sessions");
+  });
+
+  it("passes a waking answer through", async () => {
+    await expect(resolver.open(INPUT)).resolves.toEqual({ status: "waking" });
+  });
+
+  it.each([
+    ["namespace", { pod: "p", container: "c", token: "t" }],
+    ["pod", { namespace: "n", container: "c", token: "t" }],
+    ["container", { namespace: "n", pod: "p", token: "t" }],
+    ["token", { namespace: "n", pod: "p", container: "c" }],
+  ])(
+    "a ready missing %s is fail-closed transport-class",
+    async (_missing, fields) => {
+      answer = {
+        status: 200,
+        body: JSON.stringify({
+          status: "ready",
+          ...fields,
+          tokenExpiresAt: new Date().toISOString(),
+        }),
+      };
+      await expect(resolver.open(INPUT)).rejects.toBeInstanceOf(
+        ResolverUnreachableError,
+      );
+    },
+  );
+
+  it("a ready with an unparsable expiry is fail-closed transport-class", async () => {
+    answer = {
+      status: 200,
+      body: JSON.stringify({
+        status: "ready",
+        namespace: "n",
+        pod: "p",
+        container: "c",
+        token: "t",
+        tokenExpiresAt: "not-a-date",
+      }),
+    };
+    await expect(resolver.open(INPUT)).rejects.toBeInstanceOf(
+      ResolverUnreachableError,
+    );
+  });
+
+  it("an unknown status is fail-closed transport-class", async () => {
+    answer = { status: 200, body: JSON.stringify({ status: "surprise" }) };
+    await expect(resolver.open(INPUT)).rejects.toBeInstanceOf(
+      ResolverUnreachableError,
+    );
+  });
+});
+
+describe("open — the refusal vocabulary", () => {
+  it.each([
+    "ssh_not_configured",
+    "cert_refused",
+    "grant_refused",
+    "identity_mismatch",
+  ])("the manager's %s refusal is deterministic", async (code) => {
+    answer = {
+      status: 403,
+      body: JSON.stringify({ error: { code, message: "no" } }),
+    };
+    const failure = await resolver.open(INPUT).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(failure).toBeInstanceOf(ResolverRefusedError);
+    expect((failure as ResolverRefusedError).code).toBe(code);
+  });
+
+  it("a 401 (secret-rotation skew) is transport-class, never a refusal", async () => {
+    answer = { status: 401, body: "" };
+    await expect(resolver.open(INPUT)).rejects.toBeInstanceOf(
+      ResolverUnreachableError,
+    );
+  });
+
+  it("an unknown refusal code (version skew) is transport-class", async () => {
+    answer = {
+      status: 403,
+      body: JSON.stringify({ error: { code: "novel_code", message: "no" } }),
+    };
+    await expect(resolver.open(INPUT)).rejects.toBeInstanceOf(
+      ResolverUnreachableError,
+    );
+  });
+});
+
+describe("close", () => {
+  it("tolerates a 404 (idempotent by contract)", async () => {
+    answer = { status: 404, body: "" };
+    await expect(resolver.close("sess-1")).resolves.toBeUndefined();
+    expect(seen[0]?.method).toBe("DELETE");
+    expect(seen[0]?.url).toBe("/v1/ssh-sessions/sess-1");
+  });
+
+  it("throws transport-class on any other failure", async () => {
+    answer = { status: 500, body: "" };
+    await expect(resolver.close("sess-1")).rejects.toBeInstanceOf(
+      ResolverUnreachableError,
+    );
+  });
+});

--- a/apps/ssh-terminator/src/backend/kube/resolver.ts
+++ b/apps/ssh-terminator/src/backend/kube/resolver.ts
@@ -1,0 +1,159 @@
+import {
+  ResolverRefusedError,
+  ResolverUnreachableError,
+  type Resolver,
+  type ResolverAnswer,
+} from "../types";
+import type { KubeExecTarget } from "./exec-backend";
+
+/**
+ * The kube substrate's resolver: a client for the sandbox-manager's session
+ * broker (/v1/ssh-sessions on the manager, behind the broker's OWN bearer
+ * secret — never the runner↔manager one). The broker independently verifies
+ * the certificate AND the control-plane grant against its own trust anchor,
+ * so this client just carries both through and parses the answer fail-closed,
+ * then completes the target with the boot-constant API-server coordinates
+ * (server + caFile) — the core never learns kube vocabulary. Bodies are
+ * never logged (they carry the certificate and the grant).
+ */
+
+const OPEN_TIMEOUT_MS = 10_000;
+const CLOSE_TIMEOUT_MS = 5_000;
+
+/** The manager's refusal codes — anything else is transport-class. */
+const REFUSAL_CODES = new Set([
+  "ssh_not_configured",
+  "cert_refused",
+  "grant_refused",
+  "identity_mismatch",
+]);
+
+const nonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value !== "";
+
+/** The manager envelope's code/message, when the body carries one. */
+const refusalOf = (body: unknown): { code: string; message: string } | null => {
+  if (typeof body !== "object" || body === null || !("error" in body)) {
+    return null;
+  }
+  const error: unknown = body.error;
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return null;
+  }
+  const code: unknown = error.code;
+  if (typeof code !== "string" || code === "") return null;
+  const message =
+    "message" in error && typeof error.message === "string"
+      ? error.message
+      : "broker refused the session";
+  return { code, message };
+};
+
+export interface KubeResolverOptions {
+  /** Manager base URL for the session broker (/v1/ssh-sessions). */
+  managerUrl: string;
+  /** The broker secret, loaded at boot (null until then — calls refuse). */
+  getSecret: () => string | null;
+  /** Boot-constant API-server coordinates merged into every ready target. */
+  kube: Pick<KubeExecTarget, "server" | "caFile">;
+}
+
+export const createKubeResolver = (
+  options: KubeResolverOptions,
+): Resolver<KubeExecTarget> => {
+  const base = options.managerUrl.replace(/\/$/, "");
+
+  const parseAnswer = (body: unknown): ResolverAnswer<KubeExecTarget> => {
+    if (typeof body !== "object" || body === null) {
+      throw new ResolverUnreachableError("broker answered a non-object body");
+    }
+    const record: Record<string, unknown> = { ...body };
+    if (record.status === "waking") return { status: "waking" };
+    if (record.status === "ready") {
+      const expiresAt = nonEmptyString(record.tokenExpiresAt)
+        ? new Date(record.tokenExpiresAt)
+        : new Date(Number.NaN);
+      if (
+        !nonEmptyString(record.namespace) ||
+        !nonEmptyString(record.pod) ||
+        !nonEmptyString(record.container) ||
+        !nonEmptyString(record.token) ||
+        Number.isNaN(expiresAt.getTime())
+      ) {
+        throw new ResolverUnreachableError("broker answered a malformed ready");
+      }
+      return {
+        status: "ready",
+        target: {
+          namespace: record.namespace,
+          pod: record.pod,
+          container: record.container,
+          token: record.token,
+          server: options.kube.server,
+          caFile: options.kube.caFile,
+        },
+        expiresAt,
+      };
+    }
+    throw new ResolverUnreachableError("broker answered an unknown status");
+  };
+
+  const call = async (
+    path: string,
+    init: { method: string; body?: string; timeoutMs: number },
+  ): Promise<Response> => {
+    const secret = options.getSecret();
+    if (!secret) {
+      throw new ResolverUnreachableError("broker secret not loaded yet");
+    }
+    try {
+      return await fetch(`${base}/v1/ssh-sessions${path}`, {
+        method: init.method,
+        headers: {
+          authorization: `Bearer ${secret}`,
+          ...(init.body !== undefined && {
+            "content-type": "application/json",
+          }),
+        },
+        ...(init.body !== undefined && { body: init.body }),
+        signal: AbortSignal.timeout(init.timeoutMs),
+      });
+    } catch (error) {
+      throw new ResolverUnreachableError(
+        `broker unreachable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+
+  return {
+    async open(input) {
+      const answer = await call("", {
+        method: "POST",
+        body: JSON.stringify(input),
+        timeoutMs: OPEN_TIMEOUT_MS,
+      });
+      if (answer.ok) return parseAnswer(await answer.json().catch(() => null));
+      const refusal = refusalOf(await answer.json().catch(() => null));
+      if (refusal && REFUSAL_CODES.has(refusal.code)) {
+        throw new ResolverRefusedError(refusal.code, refusal.message);
+      }
+      // A 401 here is secret-rotation skew, unknown codes are version skew —
+      // both transport-class: the wake poll rides them out, bounded.
+      throw new ResolverUnreachableError(
+        `broker open answered ${answer.status}`,
+      );
+    },
+
+    async close(sessionId) {
+      const answer = await call(`/${encodeURIComponent(sessionId)}`, {
+        method: "DELETE",
+        timeoutMs: CLOSE_TIMEOUT_MS,
+      });
+      if (!answer.ok && answer.status !== 404) {
+        throw new ResolverUnreachableError(
+          `broker close answered ${answer.status}`,
+        );
+      }
+    },
+  };
+};

--- a/apps/ssh-terminator/src/backend/types.ts
+++ b/apps/ssh-terminator/src/backend/types.ts
@@ -1,0 +1,101 @@
+import type { Readable, Writable } from "node:stream";
+
+/**
+ * The terminator's substrate seam. A backend is the pair of answers to the
+ * two questions only a substrate can answer — "where is this session's
+ * sandbox, and may it be reached?" (the Resolver) and "give me a byte pipe
+ * into it" (the ExecBackend) — behind types the core (server/session/relay)
+ * threads opaquely: the target `T` is the backend's own vocabulary, and the
+ * core never learns it. Substrates are ADDED as new `backend/<name>/`
+ * directories, never as edits to the core — the same law as the runner's
+ * SandboxBackend.
+ */
+
+export type ResolverAnswer<T> =
+  | { status: "waking" }
+  | {
+      status: "ready";
+      /** Complete dial coordinates — the exec backend's whole input. */
+      target: T;
+      /** When the target's credentials lapse — drives the session's
+       *  reuse-margin cache; resolvers re-mint per open(), never cache. */
+      expiresAt: Date;
+    };
+
+/**
+ * Turns an authenticated session's (certificate, grant) pair into dial
+ * coordinates. A resolver must verify BOTH artifacts against its own trust
+ * anchor (never trust the terminator's word — the grant exists to make a
+ * compromised relay harmless) and answer `waking` while the sandbox is
+ * still coming up; the session's wake poll rides that out, bounded.
+ */
+export interface Resolver<T> {
+  open(input: {
+    certificate: string;
+    grant: string;
+  }): Promise<ResolverAnswer<T>>;
+  /** Idempotent by contract; throws on transport failure (call sites are
+   * best-effort). */
+  close(sessionId: string): Promise<void>;
+}
+
+/** Deterministic refusal — retrying the identical request cannot succeed. */
+export class ResolverRefusedError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ResolverRefusedError";
+  }
+}
+
+/** Transport-class failure — the wake poll rides it out, bounded. */
+export class ResolverUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ResolverUnreachableError";
+  }
+}
+
+export interface ExecIo {
+  stdout: Writable;
+  /** Null with a TTY — the transport merges stderr into the TTY stream. */
+  stderr: Writable | null;
+  stdin: Readable;
+}
+
+export interface ExecHandle {
+  /** Present only when the backend supports mid-session terminal resizes. */
+  resize?: (cols: number, rows: number) => void;
+  /**
+   * Resolves with the remote exit code; rejects when the transport dies
+   * before an exit status arrives (sandbox churn, network) — the relay
+   * reports that honestly as `relay_error`.
+   */
+  exited: Promise<number>;
+}
+
+export class ExecDisconnectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExecDisconnectedError";
+  }
+}
+
+/** Opens one byte pipe into the target the resolver answered with. */
+export interface ExecBackend<T> {
+  exec(
+    target: T,
+    command: string[],
+    io: ExecIo,
+    tty: boolean,
+  ): Promise<ExecHandle>;
+}
+
+/** One substrate, fully assembled: the resolver and the exec backend that
+ *  speak the same target vocabulary. */
+export interface TerminatorBackend<T> {
+  resolver: Resolver<T>;
+  exec: ExecBackend<T>;
+}

--- a/apps/ssh-terminator/src/config.test.ts
+++ b/apps/ssh-terminator/src/config.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { formatEd25519PublicKeyLine } from "@onecli/ssh-cert";
+import { ConfigError } from "./errors";
+import { loadTerminatorConfig } from "./config";
+import { createTestCa } from "./test-fixtures";
+
+const CA_LINE = formatEd25519PublicKeyLine(createTestCa().publicKey);
+
+const baseEnv = (): NodeJS.ProcessEnv => ({
+  TERMINATOR_HOST_KEY: "fake-host-key",
+  TERMINATOR_CA_PUBLIC_KEY: CA_LINE,
+  TERMINATOR_CONTROL_PLANE_URL: "http://control-plane.test",
+  TERMINATOR_CONTROL_PLANE_TOKEN: "cp-secret",
+  TERMINATOR_MANAGER_URL: "http://manager.test:8090",
+  TERMINATOR_BROKER_TOKEN: "broker-secret",
+});
+
+describe("loadTerminatorConfig", () => {
+  it("loads with defaults", () => {
+    const config = loadTerminatorConfig(baseEnv());
+    expect(config.port).toBe(2222);
+    expect(config.healthPort).toBe(8091);
+    expect(config.wakeWaitSeconds).toBe(180);
+    expect(config.maxSessions).toBe(256);
+    expect(config.maxSessionsPerIp).toBe(8);
+    expect(config.preauthPerIpPerMinute).toBe(12);
+    expect(config.preauthTimeoutSeconds).toBe(30);
+    expect(config.kubeCaFile).toBe("/var/run/onecli/kube-root-ca/ca.crt");
+    expect(config.caPublicKey).toHaveLength(32);
+    expect(config.kubeServer).toBeNull();
+  });
+
+  it("derives the API server address from the injected kubelet env", () => {
+    const config = loadTerminatorConfig({
+      ...baseEnv(),
+      KUBERNETES_SERVICE_HOST: "10.100.0.1",
+      KUBERNETES_SERVICE_PORT: "443",
+    });
+    expect(config.kubeServer).toBe("https://10.100.0.1:443");
+  });
+
+  it("brackets an IPv6 API server host", () => {
+    const config = loadTerminatorConfig({
+      ...baseEnv(),
+      KUBERNETES_SERVICE_HOST: "fd00::1",
+      KUBERNETES_SERVICE_PORT: "443",
+    });
+    expect(config.kubeServer).toBe("https://[fd00::1]:443");
+  });
+
+  it.each([
+    ["TERMINATOR_HOST_KEY", "host key"],
+    ["TERMINATOR_CA_PUBLIC_KEY", "trust anchor"],
+    ["TERMINATOR_CONTROL_PLANE_URL", "control plane"],
+    ["TERMINATOR_CONTROL_PLANE_TOKEN", "control plane secret"],
+    ["TERMINATOR_MANAGER_URL", "manager"],
+    ["TERMINATOR_BROKER_TOKEN", "broker secret"],
+  ])("refuses to boot without %s", (key) => {
+    const env = baseEnv();
+    delete env[key];
+    expect(() => loadTerminatorConfig(env)).toThrow(ConfigError);
+  });
+
+  it("accepts secret ARNs in place of direct secrets", () => {
+    const env = baseEnv();
+    delete env.TERMINATOR_HOST_KEY;
+    delete env.TERMINATOR_CONTROL_PLANE_TOKEN;
+    delete env.TERMINATOR_BROKER_TOKEN;
+    env.TERMINATOR_HOST_KEY_SECRET_ARN = "arn:aws:secretsmanager:x:1:secret:hk";
+    env.TERMINATOR_CONTROL_PLANE_SECRET_ARN =
+      "arn:aws:secretsmanager:x:1:secret:cp";
+    env.TERMINATOR_BROKER_SECRET_ARN = "arn:aws:secretsmanager:x:1:secret:bk";
+    env.SANDBOX_METRIC_NAMESPACE = "OneCLI/SandboxPlatform/dev";
+    const config = loadTerminatorConfig(env);
+    expect(config.hostKeySecretArn).toContain("secret:hk");
+    expect(config.controlPlaneSecretArn).toContain("secret:cp");
+    expect(config.brokerSecretArn).toContain("secret:bk");
+    expect(config.metricNamespace).toBe("OneCLI/SandboxPlatform/dev");
+  });
+
+  it("refuses cloud mode (host key via ARN) without a metric namespace — a base-namespace fallback would publish into a namespace-conditioned AccessDenied", () => {
+    const env = baseEnv();
+    delete env.TERMINATOR_HOST_KEY;
+    env.TERMINATOR_HOST_KEY_SECRET_ARN = "arn:aws:secretsmanager:x:1:secret:hk";
+    expect(() => loadTerminatorConfig(env)).toThrow(/SANDBOX_METRIC_NAMESPACE/);
+  });
+
+  it("falls back to the base namespace in local/token mode only", () => {
+    expect(loadTerminatorConfig(baseEnv()).metricNamespace).toBe(
+      "OneCLI/SandboxPlatform",
+    );
+  });
+
+  it("refuses a non-ed25519 CA line", () => {
+    const env = baseEnv();
+    env.TERMINATOR_CA_PUBLIC_KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB";
+    expect(() => loadTerminatorConfig(env)).toThrow(ConfigError);
+  });
+
+  it("refuses a garbage CA line", () => {
+    const env = baseEnv();
+    env.TERMINATOR_CA_PUBLIC_KEY = "not-a-key";
+    expect(() => loadTerminatorConfig(env)).toThrow(ConfigError);
+  });
+
+  it("throws on a SET but unparsable integer, never a silent default", () => {
+    expect(() =>
+      loadTerminatorConfig({ ...baseEnv(), TERMINATOR_PORT: "222x" }),
+    ).toThrow(ConfigError);
+    expect(() =>
+      loadTerminatorConfig({ ...baseEnv(), TERMINATOR_MAX_SESSIONS: "0" }),
+    ).toThrow(ConfigError);
+    expect(() =>
+      loadTerminatorConfig({
+        ...baseEnv(),
+        TERMINATOR_WAKE_WAIT_SECONDS: "-5",
+      }),
+    ).toThrow(ConfigError);
+  });
+
+  it("applies explicit overrides", () => {
+    const config = loadTerminatorConfig({
+      ...baseEnv(),
+      TERMINATOR_PORT: "2022",
+      TERMINATOR_MAX_SESSIONS_PER_IP: "3",
+      TERMINATOR_KUBE_CA_FILE: "/tmp/ca.crt",
+    });
+    expect(config.port).toBe(2022);
+    expect(config.maxSessionsPerIp).toBe(3);
+    expect(config.kubeCaFile).toBe("/tmp/ca.crt");
+  });
+});

--- a/apps/ssh-terminator/src/config.ts
+++ b/apps/ssh-terminator/src/config.ts
@@ -1,0 +1,200 @@
+import { parseEd25519PublicKeyLine } from "@onecli/ssh-cert";
+import { ConfigError } from "./errors";
+import { resolveMetricNamespace } from "./metric-namespace";
+
+/**
+ * Terminator boot configuration (step 5 — the SSH front door). Same law as
+ * the manager's and parkd's loaders: a SET but unparsable value throws at
+ * boot, never a silent fallback — the terminator is the platform's only
+ * public listener, and a mis-fenced knob nobody notices is exactly the
+ * failure mode it must never have.
+ */
+export interface TerminatorConfig {
+  /** The ssh2 listener's port (NLB target). */
+  port: number;
+  /** Plain-HTTP health listener (NLB health checks; never internet-facing). */
+  healthPort: number;
+  /** Host private key provided directly (tests, dev). */
+  hostKey: string | null;
+  /** Secrets Manager ARN of the host key (cloud; workflow-minted). */
+  hostKeySecretArn: string | null;
+  /** The CA trust anchor, parsed from an authorized_keys line to raw 32B. */
+  caPublicKey: Buffer;
+  /** Control-plane base URL for the terminator surface (/v1/ssh-terminator). */
+  controlPlaneUrl: string;
+  /** Terminator↔control-plane secret, provided directly (tests, dev). */
+  controlPlaneToken: string | null;
+  /** Secrets Manager ARN of that secret (cloud). */
+  controlPlaneSecretArn: string | null;
+  /** Manager base URL for the session broker (/v1/ssh-sessions). */
+  managerUrl: string;
+  /** Terminator↔broker secret — its OWN channel, never the runner secret. */
+  brokerToken: string | null;
+  /** Secrets Manager ARN of the broker secret (cloud). */
+  brokerSecretArn: string | null;
+  /**
+   * API-server CA bundle path. The pod runs automountServiceAccountToken:
+   * false (zero standing credential), so the chart mounts the kube-root-ca
+   * ConfigMap as a plain volume — this file is the only TLS trust source.
+   */
+  kubeCaFile: string;
+  /**
+   * `https://host:port` of the API server, from the injected
+   * KUBERNETES_SERVICE_HOST/PORT env (present regardless of automount).
+   * Null outside a cluster — the boot fails loud, tests inject fakes.
+   */
+  kubeServer: string | null;
+  /** How long a session holds open waiting for a sleeping agent to wake. */
+  wakeWaitSeconds: number;
+  /** Global concurrent-connection ceiling. */
+  maxSessions: number;
+  /** Concurrent-connection ceiling per source IP. */
+  maxSessionsPerIp: number;
+  /** Pre-auth token bucket: connection attempts per IP per minute. */
+  preauthPerIpPerMinute: number;
+  /** Sockets not authenticated within this window are destroyed. */
+  preauthTimeoutSeconds: number;
+  /** CloudWatch namespace — per-env in cloud (dev and prod share one AWS
+   * account). Required in cloud mode (host key via ARN): the metrics IAM
+   * grant is namespace-conditioned, so a base fallback would silently
+   * AccessDeny every publish. Local/test falls back to the base constant. */
+  metricNamespace: string;
+}
+
+const int = (
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+): number => {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0 || String(n) !== raw.trim()) {
+    throw new ConfigError(`${name} must be a positive integer, got "${raw}".`);
+  }
+  return n;
+};
+
+export const loadTerminatorConfig = (
+  env: NodeJS.ProcessEnv,
+): TerminatorConfig => {
+  const hostKey = env.TERMINATOR_HOST_KEY?.trim() || null;
+  const hostKeySecretArn = env.TERMINATOR_HOST_KEY_SECRET_ARN?.trim() || null;
+  if (!hostKey && !hostKeySecretArn) {
+    throw new ConfigError(
+      "One of TERMINATOR_HOST_KEY or TERMINATOR_HOST_KEY_SECRET_ARN is " +
+        "required — an SSH server with no host key cannot handshake.",
+    );
+  }
+
+  const caLine = env.TERMINATOR_CA_PUBLIC_KEY?.trim();
+  if (!caLine) {
+    throw new ConfigError(
+      "TERMINATOR_CA_PUBLIC_KEY is required — with no trust anchor every " +
+        "certificate would be refused (or worse, none would be).",
+    );
+  }
+  let caPublicKey: Buffer;
+  try {
+    caPublicKey = parseEd25519PublicKeyLine(caLine);
+  } catch (error) {
+    throw new ConfigError(
+      "TERMINATOR_CA_PUBLIC_KEY must be an ssh-ed25519 authorized_keys line: " +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const controlPlaneUrl = env.TERMINATOR_CONTROL_PLANE_URL?.trim();
+  if (!controlPlaneUrl) {
+    throw new ConfigError(
+      "TERMINATOR_CONTROL_PLANE_URL is required — session-open is the " +
+        "access-law gate, and there is no safe default to point it at.",
+    );
+  }
+  const controlPlaneToken = env.TERMINATOR_CONTROL_PLANE_TOKEN?.trim() || null;
+  const controlPlaneSecretArn =
+    env.TERMINATOR_CONTROL_PLANE_SECRET_ARN?.trim() || null;
+  if (!controlPlaneToken && !controlPlaneSecretArn) {
+    throw new ConfigError(
+      "One of TERMINATOR_CONTROL_PLANE_TOKEN or " +
+        "TERMINATOR_CONTROL_PLANE_SECRET_ARN is required — an " +
+        "unauthenticatable terminator could never open a session.",
+    );
+  }
+
+  const managerUrl = env.TERMINATOR_MANAGER_URL?.trim();
+  if (!managerUrl) {
+    throw new ConfigError(
+      "TERMINATOR_MANAGER_URL is required — without the broker no session " +
+        "can ever reach a pod.",
+    );
+  }
+  const brokerToken = env.TERMINATOR_BROKER_TOKEN?.trim() || null;
+  const brokerSecretArn = env.TERMINATOR_BROKER_SECRET_ARN?.trim() || null;
+  if (!brokerToken && !brokerSecretArn) {
+    throw new ConfigError(
+      "One of TERMINATOR_BROKER_TOKEN or TERMINATOR_BROKER_SECRET_ARN is " +
+        "required — the broker channel has its own secret, never the " +
+        "runner's or the control plane's.",
+    );
+  }
+
+  // Cloud mode (host key via ARN) must name its per-env namespace — see
+  // resolveMetricNamespace.
+  const metricNamespace = resolveMetricNamespace(
+    env.SANDBOX_METRIC_NAMESPACE,
+    Boolean(hostKeySecretArn),
+  );
+
+  // Injected by kubelet into every pod regardless of automount; absent when
+  // running outside a cluster (tests, dev) — the boot layer decides.
+  const kubeHost = env.KUBERNETES_SERVICE_HOST?.trim();
+  const kubePort = env.KUBERNETES_SERVICE_PORT?.trim();
+  const kubeServer =
+    kubeHost && kubePort
+      ? `https://${kubeHost.includes(":") ? `[${kubeHost}]` : kubeHost}:${kubePort}`
+      : null;
+
+  return {
+    port: int("TERMINATOR_PORT", env.TERMINATOR_PORT, 2222),
+    healthPort: int("TERMINATOR_HEALTH_PORT", env.TERMINATOR_HEALTH_PORT, 8091),
+    hostKey,
+    hostKeySecretArn,
+    caPublicKey,
+    controlPlaneUrl,
+    controlPlaneToken,
+    controlPlaneSecretArn,
+    managerUrl,
+    brokerToken,
+    brokerSecretArn,
+    kubeCaFile:
+      env.TERMINATOR_KUBE_CA_FILE?.trim() ||
+      "/var/run/onecli/kube-root-ca/ca.crt",
+    kubeServer,
+    wakeWaitSeconds: int(
+      "TERMINATOR_WAKE_WAIT_SECONDS",
+      env.TERMINATOR_WAKE_WAIT_SECONDS,
+      180,
+    ),
+    maxSessions: int(
+      "TERMINATOR_MAX_SESSIONS",
+      env.TERMINATOR_MAX_SESSIONS,
+      256,
+    ),
+    maxSessionsPerIp: int(
+      "TERMINATOR_MAX_SESSIONS_PER_IP",
+      env.TERMINATOR_MAX_SESSIONS_PER_IP,
+      8,
+    ),
+    preauthPerIpPerMinute: int(
+      "TERMINATOR_PREAUTH_PER_IP_PER_MINUTE",
+      env.TERMINATOR_PREAUTH_PER_IP_PER_MINUTE,
+      12,
+    ),
+    preauthTimeoutSeconds: int(
+      "TERMINATOR_PREAUTH_TIMEOUT_SECONDS",
+      env.TERMINATOR_PREAUTH_TIMEOUT_SECONDS,
+      30,
+    ),
+    metricNamespace,
+  };
+};

--- a/apps/ssh-terminator/src/control-plane-client.test.ts
+++ b/apps/ssh-terminator/src/control-plane-client.test.ts
@@ -1,0 +1,102 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  ControlPlaneUnreachableError,
+  createControlPlaneClient,
+  type ControlPlaneClient,
+} from "./control-plane-client";
+
+/**
+ * The heartbeat's status law, over a REAL socket: a revocation is ONLY a 200
+ * with `{revoked: true}` — every non-ok answer and every malformed 200 is
+ * transport-class (ControlPlaneUnreachableError, the caller's strike
+ * accounting), never a revoked verdict. The old collapse of a non-ok into
+ * `{revoked: true}` killed live SSH sessions with a "your access was revoked"
+ * lie on the first WAF-blocked or deploy-window beat.
+ */
+
+let server: Server;
+let client: ControlPlaneClient;
+let answer: { status: number; body: string };
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(answer.status, { "content-type": "application/json" });
+      res.end(answer.body);
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (typeof address !== "object" || address === null) {
+    throw new Error("server did not bind");
+  }
+  client = createControlPlaneClient({
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    getSecret: () => "terminator-secret",
+  });
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  answer = { status: 200, body: JSON.stringify({ revoked: false }) };
+});
+
+describe("heartbeat status law", () => {
+  it("passes a clean 200 verdict through", async () => {
+    await expect(client.heartbeat("sess-1", true)).resolves.toEqual({
+      revoked: false,
+    });
+  });
+
+  it("passes a real revocation (200 + revoked:true) through with its reason", async () => {
+    answer = {
+      status: 200,
+      body: JSON.stringify({ revoked: true, reason: "access_revoked" }),
+    };
+    await expect(client.heartbeat("sess-1", true)).resolves.toEqual({
+      revoked: true,
+      reason: "access_revoked",
+    });
+  });
+
+  it.each([403, 401, 404, 500, 503])(
+    "a %i answer throws transport-class, never a revoked verdict",
+    async (status) => {
+      answer = { status, body: JSON.stringify({ error: "blocked" }) };
+      await expect(client.heartbeat("sess-1", true)).rejects.toBeInstanceOf(
+        ControlPlaneUnreachableError,
+      );
+    },
+  );
+
+  it("a 200 with a non-object body throws, never a guess", async () => {
+    answer = { status: 200, body: "null" };
+    await expect(client.heartbeat("sess-1", true)).rejects.toBeInstanceOf(
+      ControlPlaneUnreachableError,
+    );
+  });
+
+  it("a 200 without a boolean verdict throws, never a guess", async () => {
+    answer = { status: 200, body: JSON.stringify({ reason: "whatever" }) };
+    await expect(client.heartbeat("sess-1", true)).rejects.toBeInstanceOf(
+      ControlPlaneUnreachableError,
+    );
+  });
+
+  it("a transport failure throws the same class (one strike path)", async () => {
+    const dead = createControlPlaneClient({
+      baseUrl: "http://127.0.0.1:1", // nothing listens there
+      getSecret: () => "terminator-secret",
+    });
+    await expect(dead.heartbeat("sess-1", true)).rejects.toBeInstanceOf(
+      ControlPlaneUnreachableError,
+    );
+  });
+});

--- a/apps/ssh-terminator/src/control-plane-client.ts
+++ b/apps/ssh-terminator/src/control-plane-client.ts
@@ -1,0 +1,240 @@
+import { logger } from "./logger";
+
+const log = logger.child({ component: "control-plane-client" });
+
+/**
+ * The terminator's client for the control plane's dedicated surface
+ * (/v1/ssh-terminator, authenticated with `x-terminator-secret`). The
+ * control plane is the ONLY authority on access: session-open re-verifies
+ * the certificate and runs the full access law server-side, so this client's
+ * job is transport plus fail-closed response parsing — a malformed answer is
+ * an error, never a guess. Request and response bodies are never logged (the
+ * open body carries the user's certificate).
+ */
+
+export interface SessionPolicy {
+  maxSessionSeconds: number;
+  idleTimeoutSeconds: number;
+  heartbeatSeconds: number;
+}
+
+export interface OpenedSession {
+  sessionId: string;
+  /** CA-signed grant, opaque here — only the broker interprets it. */
+  grant: string;
+  policy: SessionPolicy;
+}
+
+export interface HeartbeatAnswer {
+  revoked: boolean;
+  reason?: string;
+}
+
+/** The control plane deterministically refused to open the session. */
+export class SessionOpenRefusedError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SessionOpenRefusedError";
+  }
+}
+
+export class ControlPlaneUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ControlPlaneUnreachableError";
+  }
+}
+
+export interface ControlPlaneClient {
+  openSession(input: {
+    certificate: string;
+    sourceIp: string;
+  }): Promise<OpenedSession>;
+  /**
+   * Returns the revocation verdict. A revocation is ALWAYS a 200 with
+   * `{revoked: true}` — the service closes a revoked session server-side at
+   * detection and answers the verdict; it never expresses one as an HTTP
+   * status. So a non-OK answer (a WAF block, a deploy window, secret-rotation
+   * skew) and a malformed body both throw ControlPlaneUnreachableError, and
+   * the caller's consecutive-strike accounting decides when to fail closed —
+   * the lease expiring server-side bounds how long a deaf relay can run.
+   */
+  heartbeat(sessionId: string, attached: boolean): Promise<HeartbeatAnswer>;
+  /** Throws on failure; call sites treat close reporting as best-effort. */
+  close(sessionId: string, reason: string): Promise<void>;
+}
+
+const OPEN_TIMEOUT_MS = 10_000;
+const HEARTBEAT_TIMEOUT_MS = 5_000;
+const CLOSE_TIMEOUT_MS = 5_000;
+
+const positiveInt = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value > 0;
+
+const nonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value !== "";
+
+/** The API's one error shape: `{error: {message, type}}`. */
+const refusalMessageOf = (body: unknown): string => {
+  if (typeof body === "object" && body !== null && "error" in body) {
+    const error: unknown = body.error;
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "message" in error &&
+      typeof error.message === "string"
+    ) {
+      return error.message;
+    }
+  }
+  return "session refused";
+};
+
+const parseOpened = (body: unknown): OpenedSession => {
+  if (typeof body !== "object" || body === null) {
+    throw new ControlPlaneUnreachableError(
+      "session-open answered a non-object",
+    );
+  }
+  const record: Record<string, unknown> = { ...body };
+  const policy: Record<string, unknown> =
+    typeof record.policy === "object" && record.policy !== null
+      ? { ...record.policy }
+      : {};
+  if (
+    !nonEmptyString(record.sessionId) ||
+    !nonEmptyString(record.grant) ||
+    !positiveInt(policy.maxSessionSeconds) ||
+    !positiveInt(policy.idleTimeoutSeconds) ||
+    !positiveInt(policy.heartbeatSeconds)
+  ) {
+    throw new ControlPlaneUnreachableError(
+      "session-open answered a malformed body",
+    );
+  }
+  return {
+    sessionId: record.sessionId,
+    grant: record.grant,
+    policy: {
+      maxSessionSeconds: policy.maxSessionSeconds,
+      idleTimeoutSeconds: policy.idleTimeoutSeconds,
+      heartbeatSeconds: policy.heartbeatSeconds,
+    },
+  };
+};
+
+export interface ControlPlaneClientOptions {
+  baseUrl: string;
+  /** The terminator secret, loaded at boot (null until then — calls refuse). */
+  getSecret: () => string | null;
+}
+
+export const createControlPlaneClient = (
+  options: ControlPlaneClientOptions,
+): ControlPlaneClient => {
+  const base = options.baseUrl.replace(/\/$/, "");
+
+  const call = async (
+    path: string,
+    body: unknown,
+    timeoutMs: number,
+  ): Promise<Response> => {
+    const secret = options.getSecret();
+    if (!secret) {
+      throw new ControlPlaneUnreachableError(
+        "terminator secret not loaded yet",
+      );
+    }
+    try {
+      return await fetch(`${base}/v1/ssh-terminator${path}`, {
+        method: "POST",
+        headers: {
+          "x-terminator-secret": secret,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      throw new ControlPlaneUnreachableError(
+        `control plane unreachable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+
+  return {
+    async openSession(input) {
+      const answer = await call("/sessions", input, OPEN_TIMEOUT_MS);
+      if (answer.ok) return parseOpened(await answer.json().catch(() => null));
+      if (answer.status >= 400 && answer.status < 500) {
+        const body: unknown = await answer.json().catch(() => null);
+        throw new SessionOpenRefusedError(
+          answer.status,
+          refusalMessageOf(body),
+        );
+      }
+      throw new ControlPlaneUnreachableError(
+        `session-open answered ${answer.status}`,
+      );
+    },
+
+    async heartbeat(sessionId, attached) {
+      const answer = await call(
+        `/sessions/${encodeURIComponent(sessionId)}/heartbeat`,
+        { attached },
+        HEARTBEAT_TIMEOUT_MS,
+      );
+      if (!answer.ok) {
+        // NOT a revocation: the service answers a real revocation as a 200
+        // with {revoked:true} and closes the row server-side at detection —
+        // it never expresses one as an HTTP status. A non-ok here is
+        // infrastructure between us and the service (a WAF block on the
+        // public path, an api-server deploy window, secret-rotation skew —
+        // the broker client's own 401-is-transport stance). Treating it as
+        // revoked killed live sessions with a "your access was revoked" lie
+        // on the first blocked beat; throwing routes it into the caller's
+        // consecutive-strike accounting instead, and the server-side lease
+        // bounds how long a deaf relay can keep running.
+        log.warn({ status: answer.status }, "heartbeat answered non-ok");
+        throw new ControlPlaneUnreachableError(
+          `heartbeat answered ${answer.status}`,
+        );
+      }
+      // Malformed 200s are errors too, never a guess (the file's own law) —
+      // a verdict-less body means we did not hear the control plane, not
+      // that it revoked the session.
+      const body: unknown = await answer.json().catch(() => null);
+      if (typeof body !== "object" || body === null) {
+        throw new ControlPlaneUnreachableError(
+          "heartbeat answered a non-object",
+        );
+      }
+      const record: Record<string, unknown> = { ...body };
+      if (typeof record.revoked !== "boolean") {
+        throw new ControlPlaneUnreachableError(
+          "heartbeat answered a malformed body",
+        );
+      }
+      return {
+        revoked: record.revoked,
+        ...(nonEmptyString(record.reason) && { reason: record.reason }),
+      };
+    },
+
+    async close(sessionId, reason) {
+      const answer = await call(
+        `/sessions/${encodeURIComponent(sessionId)}/close`,
+        { reason },
+        CLOSE_TIMEOUT_MS,
+      );
+      if (!answer.ok) {
+        throw new ControlPlaneUnreachableError(
+          `session-close answered ${answer.status}`,
+        );
+      }
+    },
+  };
+};

--- a/apps/ssh-terminator/src/e2e.test.ts
+++ b/apps/ssh-terminator/src/e2e.test.ts
@@ -1,0 +1,675 @@
+import { execFile, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer, type Server as HttpServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  parseCertificateLine,
+  parseEd25519PublicKeyLine,
+  signGrant,
+  verifyGrant,
+} from "@onecli/ssh-cert";
+import type { KubeExecTarget } from "./backend/kube/exec-backend";
+import { createKubeResolver } from "./backend/kube/resolver";
+import { createControlPlaneClient } from "./control-plane-client";
+import { createConnectionLimits } from "./limits";
+import { createLocalExecBackend } from "./local-exec-backend";
+import { createFakeTerminatorMetrics } from "./metrics";
+import { createTerminatorServer, type TerminatorServer } from "./server";
+import {
+  createTestCa,
+  mintTestCertificate,
+  type TestCa,
+} from "./test-fixtures";
+
+/**
+ * End-to-end: the REAL terminator server (real ssh2, real cert auth, real
+ * session/relay wiring) with in-process fake control-plane and broker HTTP
+ * servers and a local child_process exec backend — dialed by the REAL
+ * OpenSSH client binaries. This is the interop proof for ssh2's
+ * cert-blob-passthrough auth, the PTY relay, and the raw-channel sftp pipe,
+ * run before any cluster exists.
+ */
+
+const sshAvailable = ((): boolean => {
+  const probe = spawnSync("ssh", ["-V"]);
+  return probe.error === undefined;
+})();
+
+const SFTP_SERVER_CANDIDATES = [
+  "/usr/lib/openssh/sftp-server",
+  "/usr/libexec/sftp-server",
+  "/usr/lib/ssh/sftp-server",
+];
+const localSftpServer = SFTP_SERVER_CANDIDATES.find((path) => existsSync(path));
+
+const POLICY = {
+  maxSessionSeconds: 600,
+  idleTimeoutSeconds: 120,
+  heartbeatSeconds: 1,
+};
+
+interface CliResult {
+  code: number | string;
+  stdout: string;
+  stderr: string;
+}
+
+const runCli = (bin: string, args: string[]): Promise<CliResult> =>
+  new Promise((resolve) => {
+    execFile(bin, args, { timeout: 15_000 }, (error, stdout, stderr) => {
+      resolve({ code: error ? (error.code ?? 255) : 0, stdout, stderr });
+    });
+  });
+
+const readJsonBody = (request: NodeJS.ReadableStream): Promise<unknown> =>
+  new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+
+const listen = (server: HttpServer): Promise<number> =>
+  new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve(
+        address !== null && typeof address === "object" ? address.port : 0,
+      );
+    });
+  });
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null ? { ...value } : {};
+
+interface FakeControlPlaneRecords {
+  opens: Array<{ certificate: string; sourceIp: string }>;
+  heartbeats: Array<{ sessionId: string; attached: boolean }>;
+  closes: Array<{ sessionId: string; reason: string }>;
+}
+
+interface FakeBrokerRecords {
+  opens: Array<{ certificate: string; grant: string }>;
+  deletes: string[];
+}
+
+interface Harness {
+  port: number;
+  ca: TestCa;
+  controlPlane: FakeControlPlaneRecords;
+  broker: FakeBrokerRecords;
+  metrics: ReturnType<typeof createFakeTerminatorMetrics>;
+  close(): Promise<void>;
+}
+
+const CP_SECRET = "cp-secret";
+const BROKER_SECRET = "broker-secret";
+const SESSION_ID = "sess-e2e-1";
+
+const startHarness = async (options?: {
+  workDir?: string;
+  preauthPerIpPerMinute?: number;
+  /** Broker answers `waking` this many times before `ready` (default 1). */
+  wakingAnswers?: number;
+  /** Make session-open refuse (the per-agent cap / revoked-access shape). */
+  openRefusal?: { status: number; message: string };
+  /** Latency before the session-open answer (dev's api-server is ~20-300ms). */
+  openDelayMs?: number;
+  /** Scripted heartbeat statuses (infrastructure noise: a WAF 403, a deploy
+   * window's 503) — one shifted per beat; an empty queue answers the clean
+   * 200 verdict. */
+  heartbeatStatuses?: number[];
+}): Promise<Harness> => {
+  const ca = createTestCa();
+  const controlPlane: FakeControlPlaneRecords = {
+    opens: [],
+    heartbeats: [],
+    closes: [],
+  };
+  const broker: FakeBrokerRecords = { opens: [], deletes: [] };
+  const metrics = createFakeTerminatorMetrics();
+  const workDir = options?.workDir ?? mkdtempSync(join(tmpdir(), "term-e2e-"));
+
+  const controlPlaneHttp = createServer((request, response) => {
+    void (async () => {
+      const body = asRecord(await readJsonBody(request));
+      if (request.headers["x-terminator-secret"] !== CP_SECRET) {
+        response.writeHead(401).end();
+        return;
+      }
+      const url = request.url ?? "";
+      if (request.method === "POST" && url === "/v1/ssh-terminator/sessions") {
+        controlPlane.opens.push({
+          certificate:
+            typeof body.certificate === "string" ? body.certificate : "",
+          sourceIp: typeof body.sourceIp === "string" ? body.sourceIp : "",
+        });
+        if (options?.openDelayMs) {
+          await new Promise((done) => setTimeout(done, options.openDelayMs));
+        }
+        const refusal = options?.openRefusal;
+        if (refusal) {
+          response
+            .writeHead(refusal.status, { "content-type": "application/json" })
+            .end(
+              JSON.stringify({
+                error: { message: refusal.message, type: "conflict_error" },
+              }),
+            );
+          return;
+        }
+        const grant = await signGrant(
+          {
+            sessionId: SESSION_ID,
+            agentId: "agent-1",
+            sandboxId: "sbx-1",
+            workspaceId: "ws-1",
+            expiresAt: BigInt(Math.floor(Date.now() / 1000) + 600),
+          },
+          ca.signer,
+        );
+        response
+          .writeHead(200, { "content-type": "application/json" })
+          .end(
+            JSON.stringify({ sessionId: SESSION_ID, grant, policy: POLICY }),
+          );
+        return;
+      }
+      const heartbeat =
+        /^\/v1\/ssh-terminator\/sessions\/([^/]+)\/heartbeat$/.exec(url);
+      if (request.method === "POST" && heartbeat) {
+        controlPlane.heartbeats.push({
+          sessionId: decodeURIComponent(heartbeat[1] ?? ""),
+          attached: body.attached === true,
+        });
+        const scripted = options?.heartbeatStatuses?.shift();
+        if (scripted !== undefined && scripted !== 200) {
+          response
+            .writeHead(scripted, { "content-type": "application/json" })
+            .end(JSON.stringify({ error: "blocked" }));
+          return;
+        }
+        response
+          .writeHead(200, { "content-type": "application/json" })
+          .end(JSON.stringify({ revoked: false }));
+        return;
+      }
+      const close = /^\/v1\/ssh-terminator\/sessions\/([^/]+)\/close$/.exec(
+        url,
+      );
+      if (request.method === "POST" && close) {
+        controlPlane.closes.push({
+          sessionId: decodeURIComponent(close[1] ?? ""),
+          reason: typeof body.reason === "string" ? body.reason : "",
+        });
+        response.writeHead(204).end();
+        return;
+      }
+      response.writeHead(404).end();
+    })();
+  });
+
+  let brokerPolls = 0;
+  const wakingAnswers = options?.wakingAnswers ?? 1;
+  const brokerHttp = createServer((request, response) => {
+    void (async () => {
+      const body = asRecord(await readJsonBody(request));
+      if (request.headers.authorization !== `Bearer ${BROKER_SECRET}`) {
+        response.writeHead(401).end();
+        return;
+      }
+      const url = request.url ?? "";
+      if (request.method === "POST" && url === "/v1/ssh-sessions") {
+        broker.opens.push({
+          certificate:
+            typeof body.certificate === "string" ? body.certificate : "",
+          grant: typeof body.grant === "string" ? body.grant : "",
+        });
+        brokerPolls += 1;
+        const answer =
+          brokerPolls <= wakingAnswers
+            ? { status: "waking" }
+            : {
+                status: "ready",
+                namespace: "ws-ws-1",
+                pod: "sandbox-pod-1",
+                container: "sandbox",
+                token: "exec-token-1",
+                tokenExpiresAt: new Date(Date.now() + 600_000).toISOString(),
+              };
+        response
+          .writeHead(200, { "content-type": "application/json" })
+          .end(JSON.stringify(answer));
+        return;
+      }
+      if (request.method === "DELETE" && url.startsWith("/v1/ssh-sessions/")) {
+        broker.deletes.push(
+          decodeURIComponent(url.slice("/v1/ssh-sessions/".length)),
+        );
+        response.writeHead(204).end();
+        return;
+      }
+      response.writeHead(404).end();
+    })();
+  });
+
+  const [controlPlanePort, brokerPort] = await Promise.all([
+    listen(controlPlaneHttp),
+    listen(brokerHttp),
+  ]);
+
+  // The guest command paths do not exist on a dev machine: land in the test
+  // work dir and run the LOCAL sftp-server, keeping the real relay-built
+  // command (quoting included) otherwise intact.
+  const mapCommand = (command: string[]): string[] => {
+    const script = command[command.length - 1] ?? "";
+    return [
+      "/bin/sh",
+      "-c",
+      script
+        .replace(
+          "mkdir -p /workspace/.home 2>/dev/null || true; cd /workspace 2>/dev/null || cd /home/node",
+          `cd ${workDir} 2>/dev/null`,
+        )
+        .replace(
+          "/usr/lib/openssh/sftp-server",
+          localSftpServer ?? "/usr/lib/openssh/sftp-server",
+        ),
+    ];
+  };
+
+  const server: TerminatorServer = createTerminatorServer({
+    hostKey: hostKeyPem,
+    caPublicKey: ca.publicKey,
+    controlPlane: createControlPlaneClient({
+      baseUrl: `http://127.0.0.1:${controlPlanePort}`,
+      getSecret: () => CP_SECRET,
+    }),
+    backend: {
+      // The REAL kube resolver against the fake broker HTTP server — the
+      // wire parse path stays covered end-to-end; only the exec dial is
+      // substituted (the local backend ignores the merged server/caFile).
+      resolver: createKubeResolver({
+        managerUrl: `http://127.0.0.1:${brokerPort}`,
+        getSecret: () => BROKER_SECRET,
+        kube: { server: "https://kube.invalid:443", caFile: "/dev/null" },
+      }),
+      exec: createLocalExecBackend<KubeExecTarget>({ mapCommand }),
+    },
+    metrics,
+    limits: createConnectionLimits({
+      maxSessions: 32,
+      maxSessionsPerIp: 16,
+      preauthPerIpPerMinute: options?.preauthPerIpPerMinute ?? 100,
+    }),
+    wakeWaitSeconds: 10,
+    preauthTimeoutSeconds: 5,
+    wakePollMs: 25,
+  });
+  const port = await server.listen(0, "127.0.0.1");
+
+  return {
+    port,
+    ca,
+    controlPlane,
+    broker,
+    metrics,
+    close: async () => {
+      await server.close();
+      await new Promise<void>((done) => controlPlaneHttp.close(() => done()));
+      await new Promise<void>((done) => brokerHttp.close(() => done()));
+    },
+  };
+};
+
+// One-time key material (real ssh-keygen so the client-side files are in the
+// formats OpenSSH expects; the CERTIFICATE is minted by our codec).
+const fixturesDir = sshAvailable
+  ? mkdtempSync(join(tmpdir(), "term-e2e-keys-"))
+  : "";
+let hostKeyPem = "";
+let userKeyPath = "";
+let userCertPath = "";
+if (sshAvailable) {
+  const hostKeyPath = join(fixturesDir, "host_key");
+  spawnSync("ssh-keygen", ["-q", "-t", "ed25519", "-N", "", "-f", hostKeyPath]);
+  hostKeyPem = readFileSync(hostKeyPath, "utf8");
+  userKeyPath = join(fixturesDir, "id_ed25519");
+  spawnSync("ssh-keygen", ["-q", "-t", "ed25519", "-N", "", "-f", userKeyPath]);
+  userCertPath = `${userKeyPath}-cert.pub`;
+}
+
+const mintClientCert = async (
+  ca: TestCa,
+  overrides: Parameters<typeof mintTestCertificate>[2] = {},
+): Promise<void> => {
+  const publicKeyLine = readFileSync(`${userKeyPath}.pub`, "utf8");
+  const raw = parseEd25519PublicKeyLine(publicKeyLine);
+  const cert = await mintTestCertificate(
+    ca,
+    { publicKey: raw, sign: () => Buffer.alloc(0) },
+    overrides,
+  );
+  writeFileSync(userCertPath, `${cert.line}\n`);
+};
+
+const clientOpts = (): string[] => [
+  "-F",
+  "/dev/null",
+  "-o",
+  "StrictHostKeyChecking=no",
+  "-o",
+  "UserKnownHostsFile=/dev/null",
+  "-o",
+  "IdentitiesOnly=yes",
+  "-o",
+  "IdentityAgent=none",
+  "-o",
+  `CertificateFile=${userCertPath}`,
+  "-i",
+  userKeyPath,
+];
+
+const harnesses: Harness[] = [];
+const openHarness = async (
+  options?: Parameters<typeof startHarness>[0],
+): Promise<Harness> => {
+  const harness = await startHarness(options);
+  harnesses.push(harness);
+  return harness;
+};
+
+afterEach(async () => {
+  await Promise.allSettled(harnesses.splice(0).map((h) => h.close()));
+});
+
+describe.skipIf(!sshAvailable)("terminator e2e (real OpenSSH client)", () => {
+  it("relays an exec round-trip and walks the full session lifecycle", async () => {
+    const h = await openHarness();
+    await mintClientCert(h.ca);
+    const answer = await runCli("ssh", [
+      "-tt",
+      ...clientOpts(),
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "echo hello-from-guest",
+    ]);
+    expect(answer.stderr).not.toContain("Permission denied");
+    expect(answer.code).toBe(0);
+    expect(answer.stdout).toContain("hello-from-guest");
+    // The single waking poll surfaced the friendly progress line on the PTY.
+    expect(answer.stdout).toContain("waking your agent");
+
+    // Session-open carried the REAL certificate line and the client IP.
+    expect(h.controlPlane.opens).toHaveLength(1);
+    const opened = h.controlPlane.opens[0];
+    const cert = parseCertificateLine(opened?.certificate ?? "");
+    expect(cert.principals).toEqual(["agent-1"]);
+    expect(opened?.sourceIp).toBe("127.0.0.1");
+
+    // The broker got cert + a grant that verifies against the CA.
+    expect(h.broker.opens.length).toBeGreaterThanOrEqual(2);
+    const grant = verifyGrant(h.broker.opens[0]?.grant ?? "", h.ca.publicKey);
+    expect(grant.sessionId).toBe(SESSION_ID);
+    expect(grant.agentId).toBe("agent-1");
+
+    // Attach heartbeat + close report + broker cleanup all landed.
+    await vi.waitFor(() => {
+      expect(h.controlPlane.heartbeats.some((beat) => beat.attached)).toBe(
+        true,
+      );
+      expect(h.controlPlane.closes).toEqual([
+        { sessionId: SESSION_ID, reason: "client_disconnect" },
+      ]);
+      expect(h.broker.deletes).toContain(SESSION_ID);
+    });
+    expect(h.metrics.counts.opened).toBe(1);
+    expect(h.metrics.counts.closed).toBe(1);
+    expect(h.metrics.wakeWaits).toHaveLength(1);
+  }, 30_000);
+
+  it("propagates the guest exit code", async () => {
+    const h = await openHarness({ wakingAnswers: 0 });
+    await mintClientCert(h.ca);
+    const answer = await runCli("ssh", [
+      ...clientOpts(),
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "exit 7",
+    ]);
+    expect(answer.code).toBe(7);
+  }, 30_000);
+
+  it("refuses a foreign-CA certificate before any session exists", async () => {
+    const h = await openHarness();
+    const foreignCa = createTestCa();
+    await mintClientCert(foreignCa);
+    const answer = await runCli("ssh", [
+      ...clientOpts(),
+      "-o",
+      "NumberOfPasswordPrompts=0",
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "echo should-never-run",
+    ]);
+    expect(answer.code).not.toBe(0);
+    expect(answer.stdout).not.toContain("should-never-run");
+    expect(h.controlPlane.opens).toHaveLength(0);
+    expect(h.broker.opens).toHaveLength(0);
+    expect(h.metrics.counts.authFailures).toBeGreaterThanOrEqual(1);
+  }, 30_000);
+
+  it("refuses an expired certificate", async () => {
+    const h = await openHarness();
+    await mintClientCert(h.ca, {
+      validAfter: new Date(Date.now() - 7_200_000),
+      validBefore: new Date(Date.now() - 3_600_000),
+    });
+    const answer = await runCli("ssh", [
+      ...clientOpts(),
+      "-o",
+      "NumberOfPasswordPrompts=0",
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "echo should-never-run",
+    ]);
+    expect(answer.code).not.toBe(0);
+    expect(answer.stdout).not.toContain("should-never-run");
+    expect(h.controlPlane.opens).toHaveLength(0);
+  }, 30_000);
+
+  it("refuses the certified principal under the wrong username", async () => {
+    const h = await openHarness();
+    await mintClientCert(h.ca);
+    const answer = await runCli("ssh", [
+      ...clientOpts(),
+      "-o",
+      "NumberOfPasswordPrompts=0",
+      "-p",
+      String(h.port),
+      "agent-2@127.0.0.1",
+      "echo should-never-run",
+    ]);
+    expect(answer.code).not.toBe(0);
+    expect(h.controlPlane.opens).toHaveLength(0);
+  }, 30_000);
+
+  // A refused session-open is the most common way a real user meets this
+  // service (per-agent cap reached, access revoked, agent deleted). The
+  // reason MUST reach their terminal: severing the connection in the same
+  // tick as the notice loses it, and the client then prints a bare
+  // "Received disconnect ... :11:" with an empty description — indistinguishable
+  // from a crash or a network fault. Found on the dev live gate.
+  it("tells the client WHY session-open was refused (no PTY)", async () => {
+    const h = await openHarness({
+      openDelayMs: 250,
+      openRefusal: {
+        status: 409,
+        message: "too many concurrent sessions for this agent",
+      },
+    });
+    await mintClientCert(h.ca);
+    const answer = await runCli("ssh", [
+      // -n (stdin from /dev/null) is what every scripted caller, scp, sftp
+      // and VS Code Remote probe effectively does — and it is the case that
+      // loses the notice.
+      "-n",
+      ...clientOpts(),
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "echo should-never-run",
+    ]);
+    expect(answer.code).not.toBe(0);
+    expect(answer.stdout).not.toContain("should-never-run");
+    expect(h.controlPlane.opens).toHaveLength(1);
+    expect(h.broker.opens).toHaveLength(0);
+    expect(answer.stderr).toContain(
+      "too many concurrent sessions for this agent",
+    );
+  }, 30_000);
+
+  it("tells the client WHY session-open was refused (PTY)", async () => {
+    const h = await openHarness({
+      openDelayMs: 250,
+      openRefusal: { status: 403, message: "workspace access was revoked" },
+    });
+    await mintClientCert(h.ca);
+    const answer = await runCli("ssh", [
+      "-tt",
+      ...clientOpts(),
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "echo should-never-run",
+    ]);
+    expect(answer.code).not.toBe(0);
+    expect(answer.stdout).not.toContain("should-never-run");
+    expect(`${answer.stdout}${answer.stderr}`).toContain(
+      "workspace access was revoked",
+    );
+  }, 30_000);
+
+  // The heartbeat status law, end to end: infrastructure noise between the
+  // terminator and the control plane (a WAF 403 on the public path, an
+  // api-server deploy window) must NOT read as a revocation. Below the strike
+  // ceiling the session rides it out; sustained, it closes with the honest
+  // "control plane unreachable" — never the "your access was revoked" lie.
+  it("rides out transient heartbeat 403s below the strike ceiling", async () => {
+    const h = await openHarness({
+      wakingAnswers: 0,
+      // Two blocked beats (the attach beat + one interval), then clean —
+      // one short of HEARTBEAT_STRIKES.
+      heartbeatStatuses: [403, 403],
+    });
+    await mintClientCert(h.ca);
+    const answer = await runCli("ssh", [
+      "-tt",
+      ...clientOpts(),
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "sleep 3.5 && echo rode-it-out",
+    ]);
+    expect(answer.code).toBe(0);
+    expect(answer.stdout).toContain("rode-it-out");
+    expect(answer.stdout).not.toContain("your access was revoked");
+    await vi.waitFor(() => {
+      expect(h.controlPlane.closes).toEqual([
+        { sessionId: SESSION_ID, reason: "client_disconnect" },
+      ]);
+    });
+  }, 30_000);
+
+  it("closes as control-plane-unreachable (never revoked) under sustained heartbeat failures", async () => {
+    const h = await openHarness({
+      wakingAnswers: 0,
+      heartbeatStatuses: Array.from({ length: 30 }, () => 403),
+    });
+    await mintClientCert(h.ca);
+    const answer = await runCli("ssh", [
+      "-tt",
+      ...clientOpts(),
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "sleep 10 && echo should-never-finish",
+    ]);
+    expect(answer.stdout).not.toContain("should-never-finish");
+    expect(answer.stdout).toContain("control plane unreachable");
+    expect(answer.stdout).not.toContain("your access was revoked");
+    await vi.waitFor(() => {
+      expect(h.controlPlane.closes).toEqual([
+        { sessionId: SESSION_ID, reason: "control_plane_unreachable" },
+      ]);
+    });
+  }, 30_000);
+
+  it("hint-free-drops connections past the pre-auth rate limit", async () => {
+    const h = await openHarness({ preauthPerIpPerMinute: 1, wakingAnswers: 0 });
+    await mintClientCert(h.ca);
+    const first = await runCli("ssh", [
+      ...clientOpts(),
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "echo first",
+    ]);
+    expect(first.code).toBe(0);
+    const second = await runCli("ssh", [
+      ...clientOpts(),
+      "-o",
+      "ConnectionAttempts=1",
+      "-p",
+      String(h.port),
+      "agent-1@127.0.0.1",
+      "echo second",
+    ]);
+    expect(second.code).not.toBe(0);
+    expect(second.stdout).not.toContain("second");
+  }, 30_000);
+
+  describe.skipIf(!localSftpServer)("sftp", () => {
+    it("round-trips a file through the raw-channel sftp relay", async () => {
+      const workDir = mkdtempSync(join(tmpdir(), "term-e2e-sftp-"));
+      const h = await openHarness({ workDir, wakingAnswers: 0 });
+      await mintClientCert(h.ca);
+
+      const localDir = mkdtempSync(join(tmpdir(), "term-e2e-local-"));
+      const uploadPath = join(localDir, "payload.bin");
+      const downloadPath = join(localDir, "roundtrip.bin");
+      const payload = Buffer.from(`sftp-e2e-${Date.now()}-${"x".repeat(4096)}`);
+      writeFileSync(uploadPath, payload);
+      const batchPath = join(localDir, "batch.txt");
+      writeFileSync(
+        batchPath,
+        `put ${uploadPath} uploaded.bin\nget uploaded.bin ${downloadPath}\n`,
+      );
+
+      const answer = await runCli("sftp", [
+        "-b",
+        batchPath,
+        ...clientOpts(),
+        "-P",
+        String(h.port),
+        "agent-1@127.0.0.1",
+      ]);
+      expect(answer.code).toBe(0);
+      // The put landed in the guest landing dir (the harness work dir) and
+      // came back byte-identical.
+      expect(readFileSync(join(workDir, "uploaded.bin"))).toEqual(payload);
+      expect(readFileSync(downloadPath)).toEqual(payload);
+    }, 30_000);
+  });
+});

--- a/apps/ssh-terminator/src/entrypoint-boot.test.ts
+++ b/apps/ssh-terminator/src/entrypoint-boot.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * THE SHIPPED BINARY ACTUALLY BOOTS.
+ *
+ * Every other suite here imports TypeScript through vitest, which resolves
+ * CommonJS/ESM interop transparently. Production runs the esbuild ESM bundle
+ * under real Node, where that interop is strict — and the gap between the two
+ * is a class of bug that passes every test, builds clean, and then
+ * crash-loops on deploy. It has happened once for real: the terminator
+ * shipped `import { Server } from "ssh2"` (ssh2 is CJS with runtime-attached
+ * exports, so Node's lexer cannot see the named export) and every pod died at
+ * process start with a SyntaxError while the whole suite stayed green.
+ *
+ * So: build for real, then start the entrypoint with an EMPTY environment.
+ * It must get far enough to refuse on its own config validation — proof the
+ * entire module graph loaded — and must never fail with a module-resolution
+ * error. Cheap (one esbuild pass, one sub-second boot) against a failure
+ * that otherwise reaches the cluster.
+ */
+
+const PACKAGE_ROOT = path.resolve(__dirname, "..");
+
+/** Failures that mean the module graph never loaded — the bug class this guards. */
+const MODULE_LOAD_FAILURES = [
+  "SyntaxError",
+  "does not provide an export",
+  "Named export",
+  "Cannot find module",
+  "ERR_MODULE_NOT_FOUND",
+  "ERR_REQUIRE_ESM",
+];
+
+beforeAll(() => {
+  // The real production build.
+  execFileSync("node", ["build.mjs"], { cwd: PACKAGE_ROOT, stdio: "pipe" });
+}, 120_000);
+
+describe("shipped entrypoint boots under real Node", () => {
+  it("dist/index.mjs loads its whole module graph and refuses on config", () => {
+    const bundle = path.join(PACKAGE_ROOT, "dist", "index.mjs");
+    expect(existsSync(bundle), `${bundle} was not built`).toBe(true);
+
+    // A COMPLETELY empty env on purpose (process.execPath is absolute, so
+    // not even PATH is needed): nothing an operator's shell happens to
+    // export can satisfy a required variable and mask a boot failure behind
+    // a service that then sits waiting on the network.
+    const result = spawnSync(process.execPath, [bundle], {
+      cwd: PACKAGE_ROOT,
+      env: {},
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+    for (const failure of MODULE_LOAD_FAILURES) {
+      expect(
+        output,
+        `dist/index.mjs failed to LOAD (${failure}) — a CJS dependency ` +
+          "imported by name, or a missing runtime dep. Production would crash-loop.",
+      ).not.toContain(failure);
+    }
+    // The positive control: reaching config validation proves every import
+    // in the graph resolved and every module body executed.
+    expect(
+      output,
+      "dist/index.mjs neither refused on config nor reported a load " +
+        "error — this guard is only meaningful if the boot path is reached.",
+    ).toContain("ConfigError");
+  }, 60_000);
+});

--- a/apps/ssh-terminator/src/errors.ts
+++ b/apps/ssh-terminator/src/errors.ts
@@ -1,0 +1,10 @@
+/** Thrown for a missing/mis-shaped boot configuration — fail at boot with a
+ * clear message, never an endless stream of hint-free 401s. The class NAME is
+ * load-bearing: the entrypoint boot test asserts the literal "ConfigError" in
+ * an empty-env boot's output. */
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}

--- a/apps/ssh-terminator/src/health.ts
+++ b/apps/ssh-terminator/src/health.ts
@@ -1,0 +1,40 @@
+import { createServer, type Server as HttpServer } from "node:http";
+
+/**
+ * The health listener the NLB target group probes (HTTP :8091). Deliberately
+ * dumb — a bare 200/503 with zero operational detail: this port is reachable
+ * from the VPC and reveals nothing about sessions, versions or config.
+ */
+
+export interface HealthServer {
+  port: number;
+  close(): Promise<void>;
+}
+
+export const startHealthServer = (options: {
+  port: number;
+  isReady: () => boolean;
+}): Promise<HealthServer> => {
+  const server: HttpServer = createServer((_request, response) => {
+    const ready = options.isReady();
+    response.writeHead(ready ? 200 : 503, { "content-type": "text/plain" });
+    response.end(ready ? "ok" : "starting");
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, () => {
+      const address = server.address();
+      const port =
+        address !== null && typeof address === "object"
+          ? address.port
+          : options.port;
+      resolve({
+        port,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+};

--- a/apps/ssh-terminator/src/index.ts
+++ b/apps/ssh-terminator/src/index.ts
@@ -1,0 +1,132 @@
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+import { createKubeBackend } from "./backend/kube";
+import { loadTerminatorConfig } from "./config";
+import { createControlPlaneClient } from "./control-plane-client";
+import { startHealthServer } from "./health";
+import { createConnectionLimits } from "./limits";
+import { logger } from "./logger";
+import { createTerminatorMetrics } from "./metrics";
+import { createTerminatorServer } from "./server";
+
+/**
+ * Terminator composition root (step 5 — the SSH front door): the platform's
+ * only public listener. Everything testable lives in server/session/relay;
+ * this file wires the real config, the three boot secrets (direct env, or
+ * Secrets Manager when an ARN is set — config presence, never edition), the
+ * kube substrate backend, CloudWatch, and the drain-on-SIGTERM contract.
+ * Zero standing K8s credential by design: the only cluster credential this
+ * process ever holds is a per-session, broker-minted, short-TTL token.
+ */
+
+const SHUTDOWN_GRACE_MS = 20_000;
+
+const config = loadTerminatorConfig(process.env);
+
+// All three boot secrets load the same way the manager's do: direct env for
+// tests/dev, Secrets Manager in cloud, fail-loud — a terminator that cannot
+// handshake, open sessions, or broker pods serves nobody.
+const secretsManager = new SecretsManagerClient({});
+const fetchSecret = async (arn: string, label: string): Promise<string> => {
+  const answer = await secretsManager.send(
+    new GetSecretValueCommand({ SecretId: arn }),
+  );
+  const value = answer.SecretString?.trim();
+  if (!value) {
+    throw new Error(`Secrets Manager returned an empty ${label} secret`);
+  }
+  return value;
+};
+
+const main = async (): Promise<void> => {
+  let ready = false;
+  const health = await startHealthServer({
+    port: config.healthPort,
+    isReady: () => ready,
+  });
+  logger.info({ port: health.port }, "terminator health listener up");
+
+  let hostKey: string;
+  let controlPlaneSecret: string;
+  let brokerSecret: string;
+  try {
+    [hostKey, controlPlaneSecret, brokerSecret] = await Promise.all([
+      config.hostKey ?? fetchSecret(config.hostKeySecretArn ?? "", "host key"),
+      config.controlPlaneToken ??
+        fetchSecret(config.controlPlaneSecretArn ?? "", "control plane"),
+      config.brokerToken ?? fetchSecret(config.brokerSecretArn ?? "", "broker"),
+    ]);
+  } catch (error) {
+    logger.error({ err: error }, "terminator secret load failed");
+    process.exit(1);
+  }
+
+  if (!config.kubeServer) {
+    logger.error(
+      "KUBERNETES_SERVICE_HOST/PORT are not set — the terminator only runs " +
+        "in-cluster (its exec dials need the API server address).",
+    );
+    process.exit(1);
+  }
+
+  const metrics = createTerminatorMetrics(config.metricNamespace);
+  const server = createTerminatorServer({
+    hostKey,
+    caPublicKey: config.caPublicKey,
+    controlPlane: createControlPlaneClient({
+      baseUrl: config.controlPlaneUrl,
+      getSecret: () => controlPlaneSecret,
+    }),
+    backend: createKubeBackend({
+      managerUrl: config.managerUrl,
+      getSecret: () => brokerSecret,
+      kube: { server: config.kubeServer, caFile: config.kubeCaFile },
+    }),
+    metrics,
+    limits: createConnectionLimits({
+      maxSessions: config.maxSessions,
+      maxSessionsPerIp: config.maxSessionsPerIp,
+      preauthPerIpPerMinute: config.preauthPerIpPerMinute,
+    }),
+    wakeWaitSeconds: config.wakeWaitSeconds,
+    preauthTimeoutSeconds: config.preauthTimeoutSeconds,
+  });
+
+  const port = await server.listen(config.port);
+  ready = true;
+  logger.info({ port }, "terminator listening");
+
+  // One flush per minute: the live-session gauge (published zero included)
+  // is the terminator's liveness heartbeat, and every counter drains here —
+  // never per event (step 6).
+  const stopMetricsPump = metrics.startPump(() => server.liveSessions());
+
+  // Drain, don't drop silently: a deploy severs live sessions (accepted and
+  // documented) — every one gets a banner, a close report, and its broker
+  // credentials deleted before the process exits.
+  let shuttingDown = false;
+  const shutdown = (signal: string): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    ready = false;
+    logger.info({ signal, sessions: server.liveSessions() }, "draining");
+    setTimeout(() => process.exit(0), SHUTDOWN_GRACE_MS).unref();
+    void server
+      .drain("the server is shutting down, reconnect shortly")
+      // The pump's stop() runs (and awaits) the FINAL flush — it must see
+      // the close counters the drain just incremented, so it runs after the
+      // drain, never before it.
+      .then(() => stopMetricsPump())
+      .then(() => health.close())
+      .finally(() => process.exit(0));
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+};
+
+void main().catch((error: unknown) => {
+  logger.error({ err: error }, "terminator boot failed");
+  process.exit(1);
+});

--- a/apps/ssh-terminator/src/limits.test.ts
+++ b/apps/ssh-terminator/src/limits.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createConnectionLimits } from "./limits";
+
+const make = (over: {
+  maxSessions?: number;
+  maxSessionsPerIp?: number;
+  preauthPerIpPerMinute?: number;
+  now?: () => number;
+}) =>
+  createConnectionLimits({
+    maxSessions: over.maxSessions ?? 100,
+    maxSessionsPerIp: over.maxSessionsPerIp ?? 10,
+    preauthPerIpPerMinute: over.preauthPerIpPerMinute ?? 60,
+    now: over.now,
+  });
+
+describe("createConnectionLimits", () => {
+  it("enforces the global concurrent cap and frees on release", () => {
+    const limits = make({ maxSessions: 2, preauthPerIpPerMinute: 1000 });
+    const a = limits.admit("1.1.1.1");
+    const b = limits.admit("2.2.2.2");
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(limits.admit("3.3.3.3")).toBeNull();
+    a?.();
+    expect(limits.admit("3.3.3.3")).not.toBeNull();
+  });
+
+  it("enforces the per-IP concurrent cap independently of other IPs", () => {
+    const limits = make({ maxSessionsPerIp: 2, preauthPerIpPerMinute: 1000 });
+    expect(limits.admit("9.9.9.9")).not.toBeNull();
+    expect(limits.admit("9.9.9.9")).not.toBeNull();
+    expect(limits.admit("9.9.9.9")).toBeNull();
+    expect(limits.admit("8.8.8.8")).not.toBeNull();
+  });
+
+  it("release is idempotent — a double release cannot free a stranger's slot", () => {
+    const limits = make({ maxSessions: 1, preauthPerIpPerMinute: 1000 });
+    const release = limits.admit("1.1.1.1");
+    release?.();
+    release?.();
+    expect(limits.admit("2.2.2.2")).not.toBeNull();
+    expect(limits.admit("3.3.3.3")).toBeNull();
+  });
+
+  it("rate-limits attempts per IP with a refilling token bucket", () => {
+    let at = 0;
+    const limits = make({ preauthPerIpPerMinute: 6, now: () => at });
+    // Burst to the full bucket, releasing each so only the RATE gates.
+    for (let i = 0; i < 6; i += 1) {
+      const release = limits.admit("5.5.5.5");
+      expect(release).not.toBeNull();
+      release?.();
+    }
+    expect(limits.admit("5.5.5.5")).toBeNull();
+    // 6/min = one token per 10s.
+    at += 10_000;
+    const release = limits.admit("5.5.5.5");
+    expect(release).not.toBeNull();
+    release?.();
+    expect(limits.admit("5.5.5.5")).toBeNull();
+    // The bucket refills to capacity but never beyond it.
+    at += 600_000;
+    for (let i = 0; i < 6; i += 1) {
+      const again = limits.admit("5.5.5.5");
+      expect(again).not.toBeNull();
+      again?.();
+    }
+    expect(limits.admit("5.5.5.5")).toBeNull();
+  });
+
+  it("one IP burning its bucket does not affect another", () => {
+    const at = 0;
+    const limits = make({ preauthPerIpPerMinute: 2, now: () => at });
+    limits.admit("1.1.1.1")?.();
+    limits.admit("1.1.1.1")?.();
+    expect(limits.admit("1.1.1.1")).toBeNull();
+    expect(limits.admit("2.2.2.2")).not.toBeNull();
+  });
+});

--- a/apps/ssh-terminator/src/limits.ts
+++ b/apps/ssh-terminator/src/limits.ts
@@ -1,0 +1,85 @@
+/**
+ * Pre-auth hardening for the public SSH listener. The NLB is pure L4 — it
+ * adds zero flood protection — so these caps ARE the defense: a global
+ * concurrent ceiling, a per-IP concurrent ceiling, and a per-IP token bucket
+ * on connection attempts. Refusals are hint-free by contract (the caller
+ * just ends the socket); the pre-auth TIMEOUT lives with the server, which
+ * owns the sockets.
+ */
+
+export interface ConnectionLimits {
+  /**
+   * Admit one connection from `ip`. Returns a release handle (call exactly
+   * once, when the connection closes) or null when refused.
+   */
+  admit(ip: string): (() => void) | null;
+}
+
+export interface ConnectionLimitsOptions {
+  maxSessions: number;
+  maxSessionsPerIp: number;
+  preauthPerIpPerMinute: number;
+  /** Injectable clock (ms) for tests. */
+  now?: () => number;
+}
+
+interface IpState {
+  live: number;
+  tokens: number;
+  refilledAt: number;
+}
+
+export const createConnectionLimits = (
+  options: ConnectionLimitsOptions,
+): ConnectionLimits => {
+  const now = options.now ?? Date.now;
+  const capacity = options.preauthPerIpPerMinute;
+  const perMs = capacity / 60_000;
+  const byIp = new Map<string, IpState>();
+  let liveTotal = 0;
+
+  const refill = (state: IpState, at: number): void => {
+    state.tokens = Math.min(
+      capacity,
+      state.tokens + (at - state.refilledAt) * perMs,
+    );
+    state.refilledAt = at;
+  };
+
+  // Bound the map: an idle entry (no live connections, bucket refilled to
+  // full) carries no state worth keeping — prune opportunistically so a
+  // scanning botnet cannot grow the map without bound.
+  const prune = (at: number): void => {
+    for (const [ip, state] of byIp) {
+      refill(state, at);
+      if (state.live === 0 && state.tokens >= capacity) byIp.delete(ip);
+    }
+  };
+
+  return {
+    admit(ip) {
+      const at = now();
+      if (liveTotal >= options.maxSessions) return null;
+      if (byIp.size > 4096) prune(at);
+      let state = byIp.get(ip);
+      if (!state) {
+        state = { live: 0, tokens: capacity, refilledAt: at };
+        byIp.set(ip, state);
+      }
+      refill(state, at);
+      if (state.live >= options.maxSessionsPerIp) return null;
+      if (state.tokens < 1) return null;
+      state.tokens -= 1;
+      state.live += 1;
+      liveTotal += 1;
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        liveTotal -= 1;
+        const current = byIp.get(ip);
+        if (current) current.live -= 1;
+      };
+    },
+  };
+};

--- a/apps/ssh-terminator/src/local-exec-backend.ts
+++ b/apps/ssh-terminator/src/local-exec-backend.ts
@@ -1,0 +1,53 @@
+import { spawn } from "node:child_process";
+import type { ExecBackend } from "./backend/types";
+
+/**
+ * Test twin of the Kubernetes exec backend: runs the relay's command as a
+ * local child process. The real guest command is wrapped in the identity
+ * drop (`env … setpriv … -- sh -c <script>`) which cannot run on a dev
+ * machine, so by default everything through the `--` fence is stripped and
+ * the trailing `sh -c <script>` runs locally — the e2e suite additionally
+ * rewrites guest-only paths in the script via `mapCommand`.
+ */
+
+export interface LocalExecBackendOptions {
+  mapCommand?: (command: string[]) => string[];
+}
+
+const stripIdentityWrapper = (command: string[]): string[] => {
+  const fence = command.lastIndexOf("--");
+  return fence >= 0 ? command.slice(fence + 1) : command;
+};
+
+export const createLocalExecBackend = <T>(
+  options: LocalExecBackendOptions = {},
+): ExecBackend<T> => ({
+  exec(_target, command, io) {
+    const argv = (options.mapCommand ?? stripIdentityWrapper)(command);
+    const program = argv[0];
+    if (!program) {
+      return Promise.reject(new Error("empty exec command"));
+    }
+    const child = spawn(program, argv.slice(1), {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    io.stdin.pipe(child.stdin);
+    child.stdout.on("data", (chunk: Buffer) => {
+      io.stdout.write(chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      // With a TTY the real backend merges stderr into the main stream.
+      (io.stderr ?? io.stdout).write(chunk);
+    });
+
+    const exited = new Promise<number>((resolve, reject) => {
+      child.once("error", (error) => reject(error));
+      child.once("exit", (code, signal) => {
+        resolve(code ?? (signal ? 1 : 0));
+      });
+    });
+
+    return Promise.resolve({ exited });
+  },
+});

--- a/apps/ssh-terminator/src/logger.ts
+++ b/apps/ssh-terminator/src/logger.ts
@@ -1,0 +1,8 @@
+import pino from "pino";
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+  ...(process.env.NODE_ENV === "production"
+    ? {}
+    : { transport: { target: "pino-pretty" } }),
+});

--- a/apps/ssh-terminator/src/metric-namespace.ts
+++ b/apps/ssh-terminator/src/metric-namespace.ts
@@ -1,0 +1,37 @@
+import { ConfigError } from "./errors";
+
+/** The sandbox platform's base CloudWatch namespace — duplicated privately
+ * from the manager's constants (the runner/supervisor precedent): local/test
+ * fallback only, never published to in cloud mode. */
+const BASE_METRIC_NAMESPACE = "OneCLI/SandboxPlatform";
+
+/**
+ * Resolve the CloudWatch namespace this process publishes to (step 6) —
+ * the terminator's copy of the sandbox platform's one namespace law.
+ *
+ * Per-env in cloud (`OneCLI/SandboxPlatform/<env>`): dev and prod share one
+ * AWS account, so the base namespace would merge their dimensionless series
+ * and both envs' alarms would watch the blend. Cloud mode must name it
+ * explicitly — the PutMetricData IAM condition is exact-match, so a silent
+ * fallback to the base would publish into AccessDenied: total metric loss
+ * with fire-and-forget emitters and NOT_BREACHING alarms (nothing would
+ * ever turn red). Local/test falls back to the base constant.
+ *
+ * `cloudMode` is this process's own "we run deployed" signal (a Secrets
+ * Manager ARN being present), passed in by its config seam.
+ */
+export const resolveMetricNamespace = (
+  raw: string | undefined,
+  cloudMode: boolean,
+): string => {
+  const trimmed = raw?.trim();
+  if (trimmed) return trimmed;
+  if (cloudMode) {
+    throw new ConfigError(
+      "SANDBOX_METRIC_NAMESPACE is required in cloud mode — the metrics " +
+        "IAM grant is namespace-conditioned per env, and a silent fallback " +
+        "to the shared base namespace would publish into AccessDenied.",
+    );
+  }
+  return BASE_METRIC_NAMESPACE;
+};

--- a/apps/ssh-terminator/src/metrics.test.ts
+++ b/apps/ssh-terminator/src/metrics.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMock = vi.hoisted(() => vi.fn());
+vi.mock("@aws-sdk/client-cloudwatch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@aws-sdk/client-cloudwatch")>();
+  return {
+    ...actual,
+    CloudWatchClient: class {
+      send = sendMock;
+    },
+  };
+});
+
+import { createTerminatorMetrics } from "./metrics";
+
+interface SentCall {
+  input: {
+    Namespace: string;
+    MetricData: Array<{
+      MetricName: string;
+      Value?: number;
+      Values?: number[];
+      Counts?: number[];
+    }>;
+  };
+}
+
+const sentData = (call: number): SentCall["input"] =>
+  (sendMock.mock.calls[call]?.[0] as SentCall).input;
+
+const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("terminator metrics (step 6 — drained, never per-event)", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({});
+  });
+
+  it("accumulates events into ONE publish per flush — an auth flood is one API call, not one per attempt", async () => {
+    const metrics = createTerminatorMetrics("OneCLI/SandboxPlatform/dev");
+    for (let i = 0; i < 500; i += 1) metrics.authFailure();
+    metrics.sessionOpened();
+    metrics.preauthRefusal();
+    expect(sendMock).not.toHaveBeenCalled();
+
+    metrics.flush(3);
+    await flushAsync();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const data = sentData(0);
+    expect(data.Namespace).toBe("OneCLI/SandboxPlatform/dev");
+    const byName = new Map(data.MetricData.map((d) => [d.MetricName, d]));
+    expect(byName.get("SshSessionsLive")?.Value).toBe(3);
+    expect(byName.get("SshAuthFailures")?.Value).toBe(500);
+    expect(byName.get("SshSessionsOpened")?.Value).toBe(1);
+    expect(byName.get("SshPreauthRefusals")?.Value).toBe(1);
+    // Zero counters are omitted; the live gauge is the always-on heartbeat.
+    expect(byName.has("SshSessionsClosed")).toBe(false);
+  });
+
+  it("publishes the live gauge every flush, zero included — the terminator-silent liveness series", async () => {
+    const metrics = createTerminatorMetrics("ns");
+    metrics.flush(0);
+    await flushAsync();
+    expect(sentData(0).MetricData).toEqual([
+      expect.objectContaining({ MetricName: "SshSessionsLive", Value: 0 }),
+    ]);
+  });
+
+  it("restores the counters when the publish fails — a flaky CloudWatch must not under-count failures", async () => {
+    const metrics = createTerminatorMetrics("ns");
+    sendMock.mockRejectedValueOnce(new Error("throttled"));
+    metrics.authFailure();
+    metrics.authFailure();
+    metrics.flush(1);
+    await flushAsync();
+
+    metrics.flush(1);
+    await flushAsync();
+    const byName = new Map(
+      sentData(1).MetricData.map((d) => [d.MetricName, d]),
+    );
+    expect(byName.get("SshAuthFailures")?.Value).toBe(2);
+  });
+
+  it("wake waits ride one Values/Counts array datum (raw values — percentiles keep working), bounded at 150", async () => {
+    const metrics = createTerminatorMetrics("ns");
+    for (let i = 0; i < 160; i += 1) metrics.wakeWaitSeconds(i);
+    metrics.flush(0);
+    await flushAsync();
+    const datum = sentData(0).MetricData.find(
+      (d) => d.MetricName === "SshWakeWaitSeconds",
+    );
+    expect(datum?.Values).toHaveLength(150);
+    expect(datum?.Counts).toHaveLength(150);
+    // Drop-oldest: the first 10 samples are gone.
+    expect(datum?.Values?.[0]).toBe(10);
+  });
+
+  it("the pump flushes every 60s and once more on stop — the AWAITED rollout-drain flush", async () => {
+    vi.useFakeTimers();
+    try {
+      const metrics = createTerminatorMetrics("ns");
+      const stop = metrics.startPump(() => 7);
+      vi.advanceTimersByTime(120_000);
+      expect(sendMock).toHaveBeenCalledTimes(2);
+      // stop() runs the FINAL flush and returns its settled promise — the
+      // shutdown path awaits it so the drain's counters land pre-exit.
+      metrics.sessionClosed();
+      await stop();
+      expect(sendMock).toHaveBeenCalledTimes(3);
+      const byName = new Map(
+        sentData(2).MetricData.map((d) => [d.MetricName, d]),
+      );
+      expect(byName.get("SshSessionsClosed")?.Value).toBe(1);
+      vi.advanceTimersByTime(120_000);
+      expect(sendMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/ssh-terminator/src/metrics.ts
+++ b/apps/ssh-terminator/src/metrics.ts
@@ -1,0 +1,189 @@
+import {
+  CloudWatchClient,
+  type MetricDatum,
+  PutMetricDataCommand,
+  StandardUnit,
+} from "@aws-sdk/client-cloudwatch";
+import { logger } from "./logger";
+
+const log = logger.child({ component: "terminator-metrics" });
+
+/**
+ * The terminator's session metrics, in the per-env platform namespace.
+ * DRAINED, never per-event (changed at step 6): the SSH listener is the
+ * platform's only internet-facing unauthenticated port, and a per-event
+ * PutMetricData turns an auth-failure flood into a metered-API amplification
+ * that throttles away exactly the datapoints the ssh-auth-failures alarm
+ * needs. Counters accumulate in-process and one flush per pump tick
+ * publishes everything; a failed publish restores the counters (parkd's
+ * drain law — a flaky CloudWatch must not under-count failures exactly when
+ * observability matters). Wake-wait samples ride one Values/Counts array
+ * datum (raw values, so percentile stats keep working); sample loss on a
+ * failed publish is accepted — latency telemetry, never correctness state.
+ */
+
+/** PutMetricData caps Values at 150 entries per datum; drop-oldest past it. */
+const WAKE_WAIT_BUFFER_CAP = 150;
+
+export interface TerminatorMetrics {
+  sessionOpened(): void;
+  sessionClosed(): void;
+  authFailure(): void;
+  /** Pre-auth admission refusals (global cap / per-IP cap / token bucket). */
+  preauthRefusal(): void;
+  wakeWaitSeconds(seconds: number): void;
+  /**
+   * Drain-and-publish one PutMetricData call. `liveSessions` is sampled at
+   * flush time and published every tick, zero included — the dimensionless
+   * series doubles as the terminator's liveness heartbeat (prod-only
+   * terminator-silent alarm). The pump's ticks fire-and-forget the returned
+   * promise; the shutdown path AWAITS it so the drain's final counters land
+   * before the process exits. Always resolves (a failed publish restores the
+   * counters and logs — it never throws).
+   */
+  flush(liveSessions: number): Promise<void>;
+  /**
+   * One flush per minute (parkd's cadence — the terminator-silent liveness
+   * alarm reads the SshSessionsLive series this keeps continuous). The
+   * returned stop clears the timer and runs (and returns) the FINAL flush,
+   * so a rollout's drain-window counters are never lost with the process —
+   * the shutdown path awaits it after server.drain().
+   */
+  startPump(liveSessions: () => number): () => Promise<void>;
+}
+
+export const createTerminatorMetrics = (
+  namespace: string,
+): TerminatorMetrics => {
+  const cloudwatch = new CloudWatchClient({});
+  let opened = 0;
+  let closed = 0;
+  let authFailures = 0;
+  let preauthRefusals = 0;
+  let wakeWaits: number[] = [];
+
+  const metrics: TerminatorMetrics = {
+    startPump: (liveSessions) => {
+      const timer = setInterval(() => {
+        void metrics.flush(liveSessions());
+      }, 60_000);
+      timer.unref();
+      return () => {
+        clearInterval(timer);
+        return metrics.flush(liveSessions());
+      };
+    },
+    sessionOpened: () => {
+      opened += 1;
+    },
+    sessionClosed: () => {
+      closed += 1;
+    },
+    authFailure: () => {
+      authFailures += 1;
+    },
+    preauthRefusal: () => {
+      preauthRefusals += 1;
+    },
+    wakeWaitSeconds: (seconds) => {
+      if (wakeWaits.length >= WAKE_WAIT_BUFFER_CAP) wakeWaits.shift();
+      wakeWaits.push(seconds);
+    },
+    flush: (liveSessions) => {
+      const drained = { opened, closed, authFailures, preauthRefusals };
+      const waits = wakeWaits;
+      opened = 0;
+      closed = 0;
+      authFailures = 0;
+      preauthRefusals = 0;
+      wakeWaits = [];
+
+      const counter = (name: string, value: number): MetricDatum[] =>
+        value > 0
+          ? [{ MetricName: name, Value: value, Unit: StandardUnit.Count }]
+          : [];
+      const data: MetricDatum[] = [
+        {
+          // Per-REPLICA gauge (the admission cap in limits.ts is
+          // per-process): alarms read Maximum; a fleet total needs the
+          // SEARCH-sum form, never a plain Sum of the 60s samples.
+          MetricName: "SshSessionsLive",
+          Value: liveSessions,
+          Unit: StandardUnit.Count,
+        },
+        ...counter("SshSessionsOpened", drained.opened),
+        ...counter("SshSessionsClosed", drained.closed),
+        ...counter("SshAuthFailures", drained.authFailures),
+        ...counter("SshPreauthRefusals", drained.preauthRefusals),
+        ...(waits.length > 0
+          ? [
+              {
+                MetricName: "SshWakeWaitSeconds",
+                Values: waits,
+                Counts: waits.map(() => 1),
+                Unit: StandardUnit.Seconds,
+              },
+            ]
+          : []),
+      ];
+      return cloudwatch
+        .send(
+          new PutMetricDataCommand({ Namespace: namespace, MetricData: data }),
+        )
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          // Restore the counters so a flaky CloudWatch cannot under-count;
+          // wake-wait samples are accepted loss (telemetry, bounded buffer).
+          opened += drained.opened;
+          closed += drained.closed;
+          authFailures += drained.authFailures;
+          preauthRefusals += drained.preauthRefusals;
+          log.warn({ err: error }, "metrics publish failed");
+        });
+    },
+  };
+  return metrics;
+};
+
+/** Test twin — records instead of publishing. */
+export interface FakeTerminatorMetrics extends TerminatorMetrics {
+  counts: {
+    opened: number;
+    closed: number;
+    authFailures: number;
+    preauthRefusals: number;
+  };
+  wakeWaits: number[];
+  flushes: number[];
+}
+
+export const createFakeTerminatorMetrics = (): FakeTerminatorMetrics => {
+  const counts = { opened: 0, closed: 0, authFailures: 0, preauthRefusals: 0 };
+  const wakeWaits: number[] = [];
+  const flushes: number[] = [];
+  return {
+    counts,
+    wakeWaits,
+    flushes,
+    sessionOpened: () => {
+      counts.opened += 1;
+    },
+    sessionClosed: () => {
+      counts.closed += 1;
+    },
+    authFailure: () => {
+      counts.authFailures += 1;
+    },
+    preauthRefusal: () => {
+      counts.preauthRefusals += 1;
+    },
+    wakeWaitSeconds: (seconds) => {
+      wakeWaits.push(seconds);
+    },
+    flush: (liveSessions) => {
+      flushes.push(liveSessions);
+      return Promise.resolve();
+    },
+    startPump: () => () => Promise.resolve(),
+  };
+};

--- a/apps/ssh-terminator/src/relay.test.ts
+++ b/apps/ssh-terminator/src/relay.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { buildGuestCommand } from "./relay";
+
+describe("buildGuestCommand", () => {
+  it("wraps a shell in the identity drop, landing in /workspace", () => {
+    expect(buildGuestCommand({ kind: "shell" })).toEqual([
+      "env",
+      "HOME=/workspace/.home",
+      "USER=node",
+      "LOGNAME=node",
+      "setpriv",
+      "--reuid",
+      "node",
+      "--regid",
+      "node",
+      "--init-groups",
+      "--",
+      "sh",
+      "-c",
+      "mkdir -p /workspace/.home 2>/dev/null || true; cd /workspace 2>/dev/null || cd /home/node; exec bash -l",
+    ]);
+  });
+
+  it("heals a missing durable home on every request kind, soft-failing", () => {
+    // A RUNNING pre-change sandbox predates the entrypoint that creates
+    // /workspace/.home; the relay's mkdir token heals it per-session. It
+    // must be present on every kind AND `|| true`-terminated — a hard
+    // failure here would kill the session over a cosmetic dir.
+    for (const request of [
+      { kind: "shell" } as const,
+      { kind: "exec", command: "ls" } as const,
+      { kind: "sftp" } as const,
+    ]) {
+      const script = buildGuestCommand(request).at(-1);
+      expect(script).toContain(
+        "mkdir -p /workspace/.home 2>/dev/null || true; ",
+      );
+    }
+  });
+
+  it("never uses --reset-env (it would strip the gateway proxy env)", () => {
+    for (const request of [
+      { kind: "shell" } as const,
+      { kind: "exec", command: "ls" } as const,
+      { kind: "sftp" } as const,
+    ]) {
+      expect(buildGuestCommand(request)).not.toContain("--reset-env");
+    }
+  });
+
+  it("runs exec commands through a login shell (OpenSSH semantics)", () => {
+    const command = buildGuestCommand({ kind: "exec", command: "echo hi" });
+    expect(command[command.length - 1]).toBe(
+      "mkdir -p /workspace/.home 2>/dev/null || true; cd /workspace 2>/dev/null || cd /home/node; exec sh -lc 'echo hi'",
+    );
+  });
+
+  it("single-quote-escapes hostile exec commands", () => {
+    const command = buildGuestCommand({
+      kind: "exec",
+      command: `echo 'a'; rm -rf "$HOME"`,
+    });
+    expect(command[command.length - 1]).toBe(
+      `mkdir -p /workspace/.home 2>/dev/null || true; ` +
+        `cd /workspace 2>/dev/null || cd /home/node; ` +
+        `exec sh -lc 'echo '\\''a'\\''; rm -rf "$HOME"'`,
+    );
+  });
+
+  it("routes the sftp subsystem to the in-guest sftp-server", () => {
+    const command = buildGuestCommand({ kind: "sftp" });
+    expect(command[command.length - 1]).toBe(
+      "mkdir -p /workspace/.home 2>/dev/null || true; cd /workspace 2>/dev/null || cd /home/node; exec /usr/lib/openssh/sftp-server",
+    );
+  });
+});

--- a/apps/ssh-terminator/src/relay.ts
+++ b/apps/ssh-terminator/src/relay.ts
@@ -1,0 +1,161 @@
+import { PassThrough } from "node:stream";
+import type { ServerChannel } from "ssh2";
+import type { ExecBackend, ExecHandle } from "./backend/types";
+
+/**
+ * The relay: bridge one ssh2 channel to one exec stream. Command
+ * construction and stream wiring live here; WHAT may be relayed was already
+ * decided upstream (cert + control plane + resolver).
+ */
+
+/**
+ * The guest's durable-home contract, duplicated privately (the
+ * runner/supervisor precedent): byte-equal with the agent image
+ * (docker/agent.Dockerfile, agent-entrypoint.sh) and pinned against
+ * apps/sandbox-manager/src/constants.ts by the infra contract test
+ * (sandbox-manager-contract.test.ts) — change them ONLY in lockstep.
+ */
+export const HOME_MOUNT = "/workspace";
+export const AGENT_POSIX_HOME = "/workspace/.home";
+
+export type RelayRequest =
+  | { kind: "shell" }
+  | { kind: "exec"; command: string }
+  | { kind: "sftp" };
+
+/** POSIX single-quote: close, escaped quote, reopen (boot-script.ts's sq). */
+const sq = (value: string): string => `'${value.replaceAll("'", `'\\''`)}'`;
+
+/** Where the in-guest OpenSSH sftp-server lives (agent image, Debian path). */
+const SFTP_SERVER_PATH = "/usr/lib/openssh/sftp-server";
+
+/**
+ * Build the in-guest command. `pods/exec` lands as in-container root with
+ * root's identity env (HOME=/root, CWD=/app — the boot script's exports are
+ * invisible to exec'd processes), which would break VS Code Remote and
+ * default scp/sftp paths, so every session wraps in the same identity drop
+ * the boot phase uses: explicit identity env, then setpriv to uid-1000
+ * "node", landing in /workspace (the durable home; ~ is /workspace/.home on
+ * the same volume, so dotfiles — and ~/.vscode-server — survive park/wake).
+ *
+ * Two pinned constraints, both load-bearing:
+ * - NEVER `--reset-env`: it would strip the spawn env, the gateway proxy
+ *   credential included, killing all in-guest egress.
+ * - The drop is UX/consistency, NOT a security boundary — the customer owns
+ *   their guest kernel (privileged container in their own microVM) and can
+ *   re-escalate; the real boundaries stay Kata isolation and the gateway
+ *   network fence.
+ */
+export const buildGuestCommand = (request: RelayRequest): string[] => {
+  const target =
+    request.kind === "shell"
+      ? "bash -l"
+      : request.kind === "sftp"
+        ? SFTP_SERVER_PATH
+        : // OpenSSH semantics: the command string runs through a shell (this
+          // also covers legacy `scp -O`, which arrives as `exec scp -t …`).
+          `sh -lc ${sq(request.command)}`;
+  return [
+    "env",
+    `HOME=${AGENT_POSIX_HOME}`,
+    "USER=node",
+    "LOGNAME=node",
+    "setpriv",
+    "--reuid",
+    "node",
+    "--regid",
+    "node",
+    "--init-groups",
+    "--",
+    "sh",
+    "-c",
+    // mkdir: a RUNNING pre-change sandbox predates the entrypoint that
+    // creates the durable home — one idempotent token heals it for this
+    // session, post-drop as node (root never mkdirs the tenant mount).
+    // Harmless when it exists; 2>/dev/null + || true keep sftp's
+    // byte-exact pipe clean and the session alive on any failure.
+    `mkdir -p ${AGENT_POSIX_HOME} 2>/dev/null || true; cd ${HOME_MOUNT} 2>/dev/null || cd /home/node; exec ${target}`,
+  ];
+};
+
+export interface TerminalSizeSource {
+  current(): { cols: number; rows: number } | null;
+  /** Subscribe to window-change events; returns an unsubscribe. */
+  onChange(
+    listener: (size: { cols: number; rows: number }) => void,
+  ): () => void;
+}
+
+export interface RunRelayOptions<T> {
+  backend: ExecBackend<T>;
+  target: T;
+  request: RelayRequest;
+  channel: ServerChannel;
+  /** Non-null when the client allocated a PTY on this ssh2 session. */
+  size: TerminalSizeSource;
+  /** Idle-timeout feed: fired on payload bytes in either direction. */
+  onActivity(): void;
+  /** Fired once the exec stream is established (the user reached the box). */
+  onAttached?(): void;
+}
+
+/**
+ * Run one channel to completion. Resolves with the guest exit code after the
+ * exit status has been sent; rejects (ExecDisconnectedError et al.) when the
+ * transport dies first — the caller closes the whole session honestly as
+ * `relay_error`.
+ */
+export const runRelay = async <T>(
+  options: RunRelayOptions<T>,
+): Promise<number> => {
+  const { channel, request } = options;
+  const pty = options.size.current();
+  // The API server refuses stderr alongside tty (the TTY stream carries
+  // both); sftp is a byte-exact protocol pipe, never a TTY.
+  const tty = pty !== null && request.kind !== "sftp";
+
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  let stderr: PassThrough | null = null;
+  if (!tty) {
+    stderr = new PassThrough();
+  }
+
+  const handle: ExecHandle = await options.backend.exec(
+    options.target,
+    buildGuestCommand(request),
+    { stdout, stderr, stdin },
+    tty,
+  );
+  options.onAttached?.();
+
+  // The channel is wired only AFTER the exec stream is established. A failed
+  // dial (the caller's pre-attach re-resolve retries runRelay on the SAME
+  // channel) must not leave bytes stranded in a dead PassThrough or a stale
+  // pipe holding backpressure. Bytes the client sends during the dial (sftp's
+  // INIT packet, typed-ahead keystrokes) buffer in the paused channel — no
+  // 'data' listener or pipe lands on it until here — and flush on pipe().
+  channel.pipe(stdin);
+  channel.on("data", () => options.onActivity());
+  stdout.on("data", () => options.onActivity());
+  stdout.pipe(channel, { end: false });
+  if (stderr) {
+    stderr.pipe(channel.stderr, { end: false });
+  }
+
+  let unsubscribe: () => void = () => undefined;
+  if (handle.resize && pty) {
+    const resize = handle.resize;
+    resize(pty.cols, pty.rows);
+    unsubscribe = options.size.onChange((size) => resize(size.cols, size.rows));
+  }
+
+  try {
+    const code = await handle.exited;
+    channel.exit(code);
+    channel.end();
+    return code;
+  } finally {
+    unsubscribe();
+  }
+};

--- a/apps/ssh-terminator/src/server.ts
+++ b/apps/ssh-terminator/src/server.ts
@@ -1,0 +1,480 @@
+import type { AddressInfo } from "node:net";
+// ssh2 is CommonJS with its exports attached at runtime, so Node's
+// CJS-interop lexer cannot see them statically: a NAMED value import
+// (`import { Server } from "ssh2"`) type-checks and bundles fine, then dies
+// at process start with "does not provide an export named 'Server'" — a
+// failure only the built bundle on real Node reproduces (vitest resolves the
+// interop transparently). Take the default export and destructure at runtime;
+// the type-only imports below are erased at build and stay named.
+import ssh2, {
+  type ClientInfo,
+  type Connection,
+  type PseudoTtyInfo,
+  type ServerChannel,
+  type Session,
+  type WindowChangeInfo,
+} from "ssh2";
+
+const { Server } = ssh2;
+import { authenticate, certificateLineOf } from "./auth";
+import { ResolverRefusedError, type TerminatorBackend } from "./backend/types";
+import {
+  SessionOpenRefusedError,
+  type ControlPlaneClient,
+} from "./control-plane-client";
+import type { ConnectionLimits } from "./limits";
+import { logger } from "./logger";
+import type { TerminatorMetrics } from "./metrics";
+import { runRelay, type RelayRequest, type TerminalSizeSource } from "./relay";
+import {
+  CLOSE_BROKER_REFUSED,
+  CLOSE_CLIENT_DISCONNECT,
+  CLOSE_RELAY_ERROR,
+  CLOSE_SHUTDOWN,
+  CLOSE_WAKE_TIMEOUT,
+  SessionClosedError,
+  WakeTimeoutError,
+  createConnectionSession,
+  type ConnectionSession,
+} from "./session";
+
+const log = logger.child({ component: "terminator-server" });
+
+/**
+ * The ssh2 server: pre-auth limits, certificate auth, then per-connection
+ * session lifecycle and channel relays. Everything stateful is injected —
+ * the e2e suite runs this exact server against fake planes and a local exec
+ * backend with the real OpenSSH client dialing in.
+ */
+
+/** ssh2 transport keepalives — the NLB idles flows out around 350s, and the
+ * exec side is separately pinged by the backend. */
+const KEEPALIVE_INTERVAL_MS = 15_000;
+const KEEPALIVE_COUNT_MAX = 6;
+
+/**
+ * Auth attempts one TCP connection may make before it is dropped. ssh2 fires
+ * the auth handler per PROTOCOL event, not per key: a normal OpenSSH client
+ * with a loaded agent burns one `none` probe plus TWO events per candidate
+ * key (publickey query, then the signed attempt), so a ~10-key agent is
+ * ~21 events of legitimate traffic. 24 clears that with headroom; anything
+ * past it is a probe, and ssh2 itself enforces no cap (step 6 — the
+ * auth-failure amplification path).
+ */
+const MAX_AUTH_ATTEMPTS_PER_CONNECTION = 24;
+
+/**
+ * How long a refused channel gets to put its reason on the wire before the
+ * transport is severed anyway.
+ *
+ * Load-bearing: writing the reason and calling `connection.end()` in the SAME
+ * tick loses it. OpenSSH then receives the extended data, the channel close
+ * and the DISCONNECT in one read batch and exits on the disconnect without
+ * flushing what it buffered — so `ssh <agent> <cmd>`, `scp`, `sftp` and VS
+ * Code Remote all reported a bare "Received disconnect … :11:" with an empty
+ * description while an interactive shell (which drains differently) showed the
+ * reason fine. Measured on the dev live gate, packet-traced with `ssh -vvv`
+ * ("rcvd ext data 59" arriving, never printed). Draining the channel first
+ * puts the DISCONNECT in a later batch, so the reason survives.
+ */
+const REFUSAL_DRAIN_TIMEOUT_MS = 2_000;
+
+export interface TerminatorServerDeps<T> {
+  /** Host private key (OpenSSH/PEM format string). */
+  hostKey: string;
+  /** Raw 32-byte CA public key. */
+  caPublicKey: Buffer;
+  controlPlane: ControlPlaneClient;
+  /** The substrate: resolver + exec backend, one target vocabulary. */
+  backend: TerminatorBackend<T>;
+  metrics: TerminatorMetrics;
+  limits: ConnectionLimits;
+  wakeWaitSeconds: number;
+  preauthTimeoutSeconds: number;
+  /** Test knobs. */
+  wakePollMs?: number;
+  now?: () => Date;
+}
+
+export interface TerminatorServer {
+  /** Resolves with the bound port (pass 0 for an ephemeral one). */
+  listen(port: number, host?: string): Promise<number>;
+  liveSessions(): number;
+  /**
+   * Stop accepting, banner + close every live session (reported as
+   * `terminator_shutdown`), sever all connections.
+   */
+  drain(banner: string): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface SizeTracker {
+  setPty(info: PseudoTtyInfo): void;
+  change(info: WindowChangeInfo): void;
+  source: TerminalSizeSource;
+}
+
+const createSizeTracker = (): SizeTracker => {
+  let current: { cols: number; rows: number } | null = null;
+  const listeners = new Set<(size: { cols: number; rows: number }) => void>();
+  return {
+    setPty(info) {
+      current = { cols: info.cols, rows: info.rows };
+    },
+    change(info) {
+      current = { cols: info.cols, rows: info.rows };
+      for (const listener of listeners) listener(current);
+    },
+    source: {
+      current: () => current,
+      onChange(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    },
+  };
+};
+
+export const createTerminatorServer = <T>(
+  deps: TerminatorServerDeps<T>,
+): TerminatorServer => {
+  const preauthTimeoutMs = deps.preauthTimeoutSeconds * 1000;
+  const connections = new Set<Connection>();
+  const sessions = new Set<ConnectionSession<T>>();
+
+  /** Resolves when `settle` fires or the bound elapses — never rejects, so a
+   * stalled peer cannot pin a refused connection open. */
+  const within = (
+    settle: (done: () => void) => void,
+    timeoutMs: number,
+  ): Promise<void> =>
+    new Promise<void>((resolve) => {
+      let finished = false;
+      const finish = (): void => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(finish, timeoutMs);
+      timer.unref();
+      settle(finish);
+    });
+
+  /** A short human line; PTY channels get it inline, exec/sftp on stderr.
+   * Resolves once the bytes have reached the socket (or the write threw). */
+  const writeNotice = (
+    channel: ServerChannel,
+    hasPty: boolean,
+    message: string,
+  ): Promise<void> =>
+    within((done) => {
+      try {
+        if (hasPty) channel.write(`\r\n${message}\r\n`, () => done());
+        else channel.stderr.write(`${message}\n`, () => done());
+      } catch {
+        // A dead channel gets no notice; the close path is unaffected.
+        done();
+      }
+    }, REFUSAL_DRAIN_TIMEOUT_MS);
+
+  /**
+   * Refuse this channel with a reason the client actually SEES: flush the
+   * notice, report a non-zero exit so scripted callers get a status, close
+   * the channel, and only then sever the transport (see
+   * REFUSAL_DRAIN_TIMEOUT_MS for why the ordering is the whole point).
+   */
+  const refuseChannel = async (
+    connection: Connection,
+    channel: ServerChannel,
+    hasPty: boolean,
+    message: string,
+  ): Promise<void> => {
+    await writeNotice(channel, hasPty, message);
+    const drained = within(
+      (done) => channel.once("close", done),
+      REFUSAL_DRAIN_TIMEOUT_MS,
+    );
+    try {
+      channel.exit(1);
+      channel.end();
+    } catch {
+      // Already gone — fall through to ending the connection.
+    }
+    await drained;
+    connection.end();
+  };
+
+  const runChannel = async (
+    connection: Connection,
+    session: ConnectionSession<T>,
+    channel: ServerChannel,
+    request: RelayRequest,
+    size: SizeTracker,
+  ): Promise<void> => {
+    const hasPty = size.source.current() !== null;
+    const unregister = session.registerChannel(channel, hasPty);
+    try {
+      try {
+        await session.open();
+      } catch (error) {
+        // No control-plane session exists — nothing to report, fail closed.
+        // Logged: a refused open is the single most likely thing a customer
+        // asks about ("it just disconnects"), and without this line there is
+        // no server-side trace of it at all.
+        if (error instanceof SessionOpenRefusedError) {
+          log.info(
+            { status: error.status, agentId: session.agentId },
+            "session-open refused by the control plane",
+          );
+        } else {
+          log.warn({ err: error }, "session-open failed");
+        }
+        const message =
+          error instanceof SessionOpenRefusedError
+            ? `access denied: ${error.message}`
+            : "onecli: could not establish a session, try again shortly";
+        await refuseChannel(connection, channel, hasPty, message);
+        return;
+      }
+      let attached = false;
+      const dial = async (): Promise<void> => {
+        const target = await session.ensureTarget((line) => {
+          if (hasPty) channel.write(`${line}\r\n`);
+        });
+        await runRelay({
+          backend: deps.backend.exec,
+          target,
+          request,
+          channel,
+          size: size.source,
+          onActivity: () => session.touch(),
+          onAttached: () => {
+            attached = true;
+            session.markAttached();
+          },
+        });
+      };
+      try {
+        await dial();
+      } catch (error) {
+        // A PRE-attach dial failure means the cached exec credential is
+        // stale — the GC reaped this session's trio (its 2h age cap, or the
+        // pinned pod churned) and the API server refused the upgrade.
+        // Invalidate and re-resolve exactly once: resolveSession recreates a
+        // missing trio, so the honest fix is a fresh dial, not an error.
+        // Post-attach failures and the classified errors keep their arms.
+        if (
+          attached ||
+          session.isClosed ||
+          error instanceof SessionClosedError ||
+          error instanceof WakeTimeoutError ||
+          error instanceof ResolverRefusedError
+        ) {
+          throw error;
+        }
+        log.warn(
+          { err: error },
+          "exec dial failed before attach; re-resolving the target once",
+        );
+        session.invalidateTarget();
+        await dial();
+      }
+    } catch (error) {
+      if (session.isClosed || error instanceof SessionClosedError) return;
+      // Every notice below is AWAITED before the session close severs the
+      // connection — same ordering rule as refuseChannel.
+      if (error instanceof WakeTimeoutError) {
+        await writeNotice(channel, hasPty, "your agent did not wake in time");
+        await session.close(CLOSE_WAKE_TIMEOUT);
+        return;
+      }
+      if (error instanceof ResolverRefusedError) {
+        log.warn({ code: error.code }, "resolver refused the session");
+        await writeNotice(channel, hasPty, "onecli: session refused");
+        await session.close(CLOSE_BROKER_REFUSED);
+        return;
+      }
+      log.warn({ err: error }, "relay failed");
+      await writeNotice(
+        channel,
+        hasPty,
+        "onecli: connection to your agent lost",
+      );
+      await session.close(CLOSE_RELAY_ERROR);
+    } finally {
+      unregister();
+    }
+  };
+
+  const handleSshSession = (
+    connection: Connection,
+    session: ConnectionSession<T>,
+    sshSession: Session,
+  ): void => {
+    const size = createSizeTracker();
+    // ssh2 hands accept as undefined when the client wants no reply — the
+    // types miss that, hence the typeof guards.
+    sshSession.on("pty", (accept, _reject, info) => {
+      size.setPty(info);
+      if (typeof accept === "function") accept();
+    });
+    sshSession.on("window-change", (accept, _reject, info) => {
+      size.change(info);
+      if (typeof accept === "function") accept();
+    });
+    sshSession.on("shell", (accept) => {
+      void runChannel(connection, session, accept(), { kind: "shell" }, size);
+    });
+    sshSession.on("exec", (accept, _reject, info) => {
+      void runChannel(
+        connection,
+        session,
+        accept(),
+        { kind: "exec", command: info.command },
+        size,
+      );
+    });
+    // Deliberately NO 'sftp' listener: without one ssh2 routes the sftp
+    // subsystem here and accept() yields a RAW channel (its SFTP class never
+    // engages), which is exactly what the byte-pipe relay needs.
+    sshSession.on("subsystem", (accept, reject, info) => {
+      if (info.name === "sftp") {
+        void runChannel(connection, session, accept(), { kind: "sftp" }, size);
+        return;
+      }
+      reject();
+    });
+  };
+
+  const handleConnection = (client: Connection, info: ClientInfo): void => {
+    const release = deps.limits.admit(info.ip);
+    if (!release) {
+      // Hint-free by design: capped or rate-limited callers learn nothing.
+      // Counted (drained, step 6): a DoS and a capped developer are
+      // otherwise identical to nothing happening.
+      deps.metrics.preauthRefusal();
+      client.end();
+      return;
+    }
+    connections.add(client);
+    let session: ConnectionSession<T> | null = null;
+    let authed = false;
+    let authAttempts = 0;
+
+    const preauthTimer = setTimeout(() => {
+      if (!authed) client.end();
+    }, preauthTimeoutMs);
+    preauthTimer.unref();
+
+    client.on("error", (error: Error) => {
+      log.debug({ err: error, ip: info.ip }, "connection error");
+    });
+
+    client.on("authentication", (ctx) => {
+      // ssh2 enforces no attempt cap of its own: one admitted connection
+      // could otherwise spam auth attempts for the whole pre-auth window,
+      // each one a counted failure (step-6 review — the amplification path).
+      authAttempts += 1;
+      if (authAttempts > MAX_AUTH_ATTEMPTS_PER_CONNECTION) {
+        client.end();
+        return;
+      }
+      const clock = deps.now;
+      const outcome = authenticate(ctx, {
+        caPublicKey: deps.caPublicKey,
+        now: clock?.(),
+      });
+      if (outcome.state === "rejected" && outcome.counted) {
+        deps.metrics.authFailure();
+      }
+      if (outcome.state === "authenticated") {
+        authed = true;
+        session = createConnectionSession(
+          {
+            controlPlane: deps.controlPlane,
+            resolver: deps.backend.resolver,
+            metrics: deps.metrics,
+            wakeWaitSeconds: deps.wakeWaitSeconds,
+            wakePollMs: deps.wakePollMs,
+            now: clock ? () => clock().getTime() : undefined,
+          },
+          {
+            certificate: certificateLineOf(outcome.certificate),
+            sourceIp: info.ip,
+            agentId: outcome.username,
+            endConnection: () => client.end(),
+          },
+        );
+        sessions.add(session);
+      }
+    });
+
+    client.on("session", (accept, reject) => {
+      const live = session;
+      if (!live) {
+        reject();
+        return;
+      }
+      handleSshSession(client, live, accept());
+    });
+
+    client.on("close", () => {
+      clearTimeout(preauthTimer);
+      release();
+      connections.delete(client);
+      const live = session;
+      if (live) {
+        sessions.delete(live);
+        void live.close(CLOSE_CLIENT_DISCONNECT);
+      }
+    });
+  };
+
+  const server = new Server(
+    {
+      hostKeys: [deps.hostKey],
+      keepaliveInterval: KEEPALIVE_INTERVAL_MS,
+      keepaliveCountMax: KEEPALIVE_COUNT_MAX,
+    },
+    handleConnection,
+  );
+
+  return {
+    listen(port, host = "0.0.0.0") {
+      return new Promise<number>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(port, host, () => {
+          const address: AddressInfo | string | null = server.address();
+          if (address === null || typeof address === "string") {
+            reject(new Error("listener bound without a TCP address"));
+            return;
+          }
+          resolve(address.port);
+        });
+      });
+    },
+
+    liveSessions() {
+      return sessions.size;
+    },
+
+    async drain(banner) {
+      await new Promise<void>((resolve) => {
+        // close() stops the listener; existing connections drain below.
+        server.close(() => resolve());
+        // With zero connections close() calls back immediately; with some it
+        // waits for them — resolve as soon as the listener is down instead.
+        setImmediate(resolve);
+      });
+      await Promise.allSettled(
+        [...sessions].map((session) => session.close(CLOSE_SHUTDOWN, banner)),
+      );
+      for (const client of connections) client.end();
+    },
+
+    async close() {
+      await this.drain("the server is shutting down, reconnect shortly");
+    },
+  };
+};

--- a/apps/ssh-terminator/src/session.test.ts
+++ b/apps/ssh-terminator/src/session.test.ts
@@ -1,0 +1,439 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ResolverRefusedError,
+  ResolverUnreachableError,
+  type Resolver,
+  type ResolverAnswer,
+} from "./backend/types";
+import {
+  ControlPlaneUnreachableError,
+  type ControlPlaneClient,
+  type HeartbeatAnswer,
+  type OpenedSession,
+} from "./control-plane-client";
+import { createFakeTerminatorMetrics } from "./metrics";
+import {
+  CLOSE_CONTROL_PLANE_UNREACHABLE,
+  CLOSE_IDLE_TIMEOUT,
+  CLOSE_MAX_SESSION,
+  WakeTimeoutError,
+  createConnectionSession,
+  type ConnectionSessionDeps,
+} from "./session";
+
+const POLICY = {
+  maxSessionSeconds: 100,
+  idleTimeoutSeconds: 50,
+  heartbeatSeconds: 5,
+};
+
+/** Headroom past a policy boundary for the 1s policy tick to observe it. */
+const POLICY_SLACK_MS = 2_000;
+
+interface FakeControlPlane extends ControlPlaneClient {
+  opens: Array<{ certificate: string; sourceIp: string }>;
+  heartbeats: boolean[];
+  closes: Array<{ sessionId: string; reason: string }>;
+  openBehavior: () => Promise<OpenedSession>;
+  heartbeatBehavior: () => Promise<HeartbeatAnswer>;
+}
+
+const makeControlPlane = (): FakeControlPlane => {
+  const fake: FakeControlPlane = {
+    opens: [],
+    heartbeats: [],
+    closes: [],
+    openBehavior: () =>
+      Promise.resolve({
+        sessionId: "sess-1",
+        grant: "grant-1",
+        policy: POLICY,
+      }),
+    heartbeatBehavior: () => Promise.resolve({ revoked: false }),
+    openSession(input) {
+      fake.opens.push(input);
+      return fake.openBehavior();
+    },
+    heartbeat(_sessionId, attached) {
+      fake.heartbeats.push(attached);
+      return fake.heartbeatBehavior();
+    },
+    close(sessionId, reason) {
+      fake.closes.push({ sessionId, reason });
+      return Promise.resolve();
+    },
+  };
+  return fake;
+};
+
+/** The fake substrate's own target vocabulary — the session must thread it
+ * opaquely, which is exactly what these tests now prove. */
+interface TestTarget {
+  namespace: string;
+  pod: string;
+  container: string;
+  token: string;
+  server: string;
+  caFile: string;
+}
+
+const testTarget = (): TestTarget => ({
+  namespace: "ws-1",
+  pod: "pod-1",
+  container: "sandbox",
+  token: "tok-1",
+  server: "https://kube.test:443",
+  caFile: "/tmp/ca.crt",
+});
+
+const readyAnswer = () => ({
+  status: "ready" as const,
+  target: testTarget(),
+  expiresAt: new Date(Date.now() + 600_000),
+});
+
+interface FakeResolver extends Resolver<TestTarget> {
+  opens: Array<{ certificate: string; grant: string }>;
+  deletes: string[];
+  openBehavior: (attempt: number) => Promise<ResolverAnswer<TestTarget>>;
+}
+
+const makeResolver = (): FakeResolver => {
+  const fake: FakeResolver = {
+    opens: [],
+    deletes: [],
+    openBehavior: () => Promise.resolve(readyAnswer()),
+    open(input) {
+      fake.opens.push(input);
+      return fake.openBehavior(fake.opens.length);
+    },
+    close(sessionId) {
+      fake.deletes.push(sessionId);
+      return Promise.resolve();
+    },
+  };
+  return fake;
+};
+
+const makeChannel = (options?: { neverFlushes?: boolean }) => {
+  const channel = {
+    writes: [] as string[],
+    ended: false,
+    // Reports the write flushed, like ssh2's Duplex does. `neverFlushes`
+    // models a wedged peer: the close must still complete on its own bound.
+    write(data: string, flushed?: () => void) {
+      channel.writes.push(data);
+      if (!options?.neverFlushes) flushed?.();
+      return true;
+    },
+    end() {
+      channel.ended = true;
+    },
+  };
+  return channel;
+};
+
+const harness = (over: Partial<ConnectionSessionDeps<TestTarget>> = {}) => {
+  const controlPlane = makeControlPlane();
+  const resolver = makeResolver();
+  const metrics = createFakeTerminatorMetrics();
+  let connectionEnded = 0;
+  const session = createConnectionSession(
+    {
+      controlPlane,
+      resolver,
+      metrics,
+      wakeWaitSeconds: 60,
+      wakePollMs: 5,
+      now: () => Date.now(),
+      ...over,
+    },
+    {
+      certificate: "ssh-ed25519-cert-v01@openssh.com AAAA",
+      sourceIp: "203.0.113.7",
+      agentId: "agent-1",
+      endConnection: () => {
+        connectionEnded += 1;
+      },
+    },
+  );
+  return {
+    controlPlane,
+    resolver,
+    metrics,
+    session,
+    connectionEnded: () => connectionEnded,
+  };
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createConnectionSession — open/close contract", () => {
+  it("opens once per connection and emits SshSessionsOpened", async () => {
+    const h = harness();
+    const [a, b] = await Promise.all([h.session.open(), h.session.open()]);
+    expect(a.sessionId).toBe("sess-1");
+    expect(b).toBe(a);
+    expect(h.controlPlane.opens).toHaveLength(1);
+    expect(h.controlPlane.opens[0]?.sourceIp).toBe("203.0.113.7");
+    expect(h.metrics.counts.opened).toBe(1);
+  });
+
+  it("reports close exactly once — the first reason wins", async () => {
+    const h = harness();
+    await h.session.open();
+    await h.session.close("idle_timeout");
+    await h.session.close("revoked");
+    expect(h.controlPlane.closes).toEqual([
+      { sessionId: "sess-1", reason: "idle_timeout" },
+    ]);
+    expect(h.resolver.deletes).toEqual(["sess-1"]);
+    expect(h.metrics.counts.closed).toBe(1);
+    expect(h.connectionEnded()).toBeGreaterThan(0);
+  });
+
+  it("close banners PTY channels only, and ends every channel", async () => {
+    const h = harness();
+    await h.session.open();
+    const pty = makeChannel();
+    const plain = makeChannel();
+    h.session.registerChannel(pty, true);
+    h.session.registerChannel(plain, false);
+    await h.session.close("revoked", "your access was revoked");
+    expect(pty.writes.join("")).toContain("your access was revoked");
+    expect(plain.writes).toHaveLength(0);
+    expect(pty.ended).toBe(true);
+    expect(plain.ended).toBe(true);
+  });
+
+  // The reason is only useful if it LEAVES. Severing the transport in the same
+  // tick as the banner loses it: OpenSSH takes the DISCONNECT out of the same
+  // read batch and exits without flushing (measured on the dev live gate — a
+  // terminator pod delete dropped a live PTY session with a bare
+  // "Received disconnect … :11:" instead of the shutdown banner).
+  it("holds the connection open until the banner has flushed", async () => {
+    const h = harness();
+    await h.session.open();
+    let flush: () => void = () => undefined;
+    const pty = {
+      writes: [] as string[],
+      ended: false,
+      write(data: string, flushed?: () => void) {
+        pty.writes.push(data);
+        flush = flushed ?? (() => undefined);
+        return true;
+      },
+      end() {
+        pty.ended = true;
+      },
+    };
+    h.session.registerChannel(pty, true);
+    const closing = h.session.close("revoked", "your access was revoked");
+    // The banner is written synchronously; the transport must still be up.
+    expect(pty.writes.join("")).toContain("your access was revoked");
+    await Promise.resolve();
+    expect(h.connectionEnded()).toBe(0);
+    flush();
+    await closing;
+    expect(h.connectionEnded()).toBeGreaterThan(0);
+  });
+
+  it("severs a wedged peer on the drain bound rather than hanging", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    await h.session.open();
+    const pty = makeChannel({ neverFlushes: true });
+    h.session.registerChannel(pty, true);
+    const closing = h.session.close("revoked", "your access was revoked");
+    await Promise.resolve();
+    expect(h.connectionEnded()).toBe(0);
+    await vi.advanceTimersByTimeAsync(2_500);
+    await closing;
+    expect(h.connectionEnded()).toBeGreaterThan(0);
+  });
+
+  it("a close racing an in-flight open still reports once the row exists", async () => {
+    const h = harness();
+    let release: () => void = () => undefined;
+    h.controlPlane.openBehavior = () =>
+      new Promise((resolve) => {
+        release = () =>
+          resolve({ sessionId: "sess-9", grant: "g", policy: POLICY });
+      });
+    const opening = h.session.open();
+    const closing = h.session.close("client_disconnect");
+    release();
+    await opening;
+    await closing;
+    expect(h.controlPlane.closes).toEqual([
+      { sessionId: "sess-9", reason: "client_disconnect" },
+    ]);
+    expect(h.resolver.deletes).toEqual(["sess-9"]);
+  });
+
+  it("a refused open reports nothing (no session ever existed)", async () => {
+    const h = harness();
+    h.controlPlane.openBehavior = () =>
+      Promise.reject(new Error("access denied"));
+    await expect(h.session.open()).rejects.toThrow("access denied");
+    await h.session.close("client_disconnect");
+    expect(h.controlPlane.closes).toHaveLength(0);
+    expect(h.metrics.counts.closed).toBe(0);
+  });
+});
+
+describe("createConnectionSession — heartbeat loop", () => {
+  it("closes with the control plane's reason on revocation, bannering PTYs", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    await h.session.open();
+    const channel = makeChannel();
+    h.session.registerChannel(channel, true);
+    h.controlPlane.heartbeatBehavior = () =>
+      Promise.resolve({ revoked: true, reason: "workspace_access_revoked" });
+    await vi.advanceTimersByTimeAsync(POLICY.heartbeatSeconds * 1000 + 10);
+    expect(h.controlPlane.closes).toEqual([
+      { sessionId: "sess-1", reason: "workspace_access_revoked" },
+    ]);
+    expect(channel.writes.join("")).toContain("your access was revoked");
+  });
+
+  it("fails closed after three consecutive transport failures", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    await h.session.open();
+    h.controlPlane.heartbeatBehavior = () =>
+      Promise.reject(new ControlPlaneUnreachableError("down"));
+    await vi.advanceTimersByTimeAsync(2 * POLICY.heartbeatSeconds * 1000 + 10);
+    expect(h.controlPlane.closes).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(POLICY.heartbeatSeconds * 1000);
+    expect(h.controlPlane.closes).toEqual([
+      { sessionId: "sess-1", reason: CLOSE_CONTROL_PLANE_UNREACHABLE },
+    ]);
+  });
+
+  it("a successful heartbeat resets the strike count", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    await h.session.open();
+    let fail = true;
+    h.controlPlane.heartbeatBehavior = () =>
+      fail
+        ? Promise.reject(new ControlPlaneUnreachableError("down"))
+        : Promise.resolve({ revoked: false });
+    await vi.advanceTimersByTimeAsync(2 * POLICY.heartbeatSeconds * 1000 + 10);
+    fail = false;
+    await vi.advanceTimersByTimeAsync(POLICY.heartbeatSeconds * 1000);
+    fail = true;
+    await vi.advanceTimersByTimeAsync(2 * POLICY.heartbeatSeconds * 1000);
+    expect(h.controlPlane.closes).toHaveLength(0);
+  });
+
+  it("markAttached fires an immediate attached heartbeat", async () => {
+    const h = harness();
+    await h.session.open();
+    h.session.markAttached();
+    await vi.waitFor(() => expect(h.controlPlane.heartbeats).toContain(true));
+  });
+});
+
+describe("createConnectionSession — local policy", () => {
+  it("closes at max session duration regardless of activity", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    await h.session.open();
+    for (let i = 0; i < POLICY.maxSessionSeconds; i += 10) {
+      await vi.advanceTimersByTimeAsync(10_000);
+      h.session.touch();
+    }
+    await vi.advanceTimersByTimeAsync(POLICY_SLACK_MS);
+    const reasons = h.controlPlane.closes.map((c) => c.reason);
+    expect(reasons).toEqual([CLOSE_MAX_SESSION]);
+  });
+
+  it("closes on idle timeout, and touch() defers it", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    await h.session.open();
+    await vi.advanceTimersByTimeAsync(30_000);
+    h.session.touch();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(h.controlPlane.closes).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(
+      POLICY.idleTimeoutSeconds * 1000 + POLICY_SLACK_MS,
+    );
+    expect(h.controlPlane.closes.map((c) => c.reason)).toEqual([
+      CLOSE_IDLE_TIMEOUT,
+    ]);
+  });
+});
+
+describe("createConnectionSession — wake wait", () => {
+  it("polls the resolver through waking to ready and records the wake wait", async () => {
+    const h = harness();
+    h.resolver.openBehavior = (attempt) =>
+      Promise.resolve(attempt < 3 ? { status: "waking" } : readyAnswer());
+    const lines: string[] = [];
+    const target = await h.session.ensureTarget((line) => lines.push(line));
+    // The resolver's target round-trips untouched — the session never
+    // interprets it (the real merge coverage lives in the kube resolver's
+    // own wire test).
+    expect(target).toEqual(testTarget());
+    expect(h.resolver.opens.length).toBeGreaterThanOrEqual(3);
+    expect(h.resolver.opens[0]?.grant).toBe("grant-1");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(lines[0]).toContain("waking");
+    expect(h.metrics.wakeWaits).toHaveLength(1);
+  });
+
+  it("reuses a fresh resolved target without re-polling", async () => {
+    const h = harness();
+    await h.session.ensureTarget(() => undefined);
+    const resolverCalls = h.resolver.opens.length;
+    await h.session.ensureTarget(() => undefined);
+    expect(h.resolver.opens.length).toBe(resolverCalls);
+  });
+
+  it("re-resolves when the cached target is near expiry", async () => {
+    const h = harness();
+    h.resolver.openBehavior = () =>
+      Promise.resolve({
+        ...readyAnswer(),
+        expiresAt: new Date(Date.now() + 1_000),
+      });
+    await h.session.ensureTarget(() => undefined);
+    const resolverCalls = h.resolver.opens.length;
+    await h.session.ensureTarget(() => undefined);
+    expect(h.resolver.opens.length).toBeGreaterThan(resolverCalls);
+  });
+
+  it("times out honestly when the sandbox never wakes", async () => {
+    const h = harness({ wakeWaitSeconds: 0.05 });
+    h.resolver.openBehavior = () => Promise.resolve({ status: "waking" });
+    await expect(h.session.ensureTarget(() => undefined)).rejects.toThrow(
+      WakeTimeoutError,
+    );
+  });
+
+  it("propagates deterministic resolver refusals immediately", async () => {
+    const h = harness();
+    h.resolver.openBehavior = () =>
+      Promise.reject(new ResolverRefusedError("grant_refused", "no"));
+    await expect(h.session.ensureTarget(() => undefined)).rejects.toThrow(
+      ResolverRefusedError,
+    );
+    expect(h.resolver.opens).toHaveLength(1);
+  });
+
+  it("rides out transient resolver unreachability inside the window", async () => {
+    const h = harness();
+    h.resolver.openBehavior = (attempt) =>
+      attempt === 1
+        ? Promise.reject(new ResolverUnreachableError("blip"))
+        : Promise.resolve(readyAnswer());
+    const target = await h.session.ensureTarget(() => undefined);
+    expect(target.pod).toBe("pod-1");
+  });
+});

--- a/apps/ssh-terminator/src/session.ts
+++ b/apps/ssh-terminator/src/session.ts
@@ -1,0 +1,419 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import {
+  ResolverRefusedError,
+  ResolverUnreachableError,
+  type Resolver,
+} from "./backend/types";
+import {
+  ControlPlaneUnreachableError,
+  type ControlPlaneClient,
+  type OpenedSession,
+} from "./control-plane-client";
+import { logger } from "./logger";
+import type { TerminatorMetrics } from "./metrics";
+
+const log = logger.child({ component: "ssh-session" });
+
+/**
+ * One authenticated SSH connection's control-plane session: open-once,
+ * heartbeat loop, local policy enforcement (max duration + idle), wake-wait
+ * resolving, and the close-exactly-once contract — every exit path reports
+ * the close to the control plane AND closes the resolver's session (both
+ * best-effort; a crash-orphaned row is closed by the control-plane sweep).
+ */
+
+/** Close reasons this daemon originates (the revocation reason may also come
+ * verbatim from the control plane's heartbeat answer). */
+export const CLOSE_CLIENT_DISCONNECT = "client_disconnect";
+export const CLOSE_REVOKED = "revoked";
+export const CLOSE_CONTROL_PLANE_UNREACHABLE = "control_plane_unreachable";
+export const CLOSE_MAX_SESSION = "max_session";
+export const CLOSE_IDLE_TIMEOUT = "idle_timeout";
+export const CLOSE_WAKE_TIMEOUT = "wake_timeout";
+export const CLOSE_RELAY_ERROR = "relay_error";
+export const CLOSE_BROKER_REFUSED = "broker_refused";
+export const CLOSE_SHUTDOWN = "terminator_shutdown";
+
+/** Consecutive heartbeat transport failures tolerated before failing closed
+ * (the lease expires server-side anyway — holding on longer is dishonest). */
+const HEARTBEAT_STRIKES = 3;
+
+/** Cadence of the local idle/max-duration policy check. */
+const POLICY_TICK_MS = 1_000;
+
+/** A cached exec target this close to expiry is re-resolved, not reused. */
+const TOKEN_REUSE_MARGIN_MS = 30_000;
+
+const PROGRESS_THROTTLE_MS = 10_000;
+
+/**
+ * How long a closing session waits for its banner to reach the socket before
+ * severing the transport anyway.
+ *
+ * Same ordering rule as the terminator server's refusal path: writing the
+ * banner and calling `endConnection()` in the SAME tick loses it — OpenSSH
+ * takes the DISCONNECT out of the same read batch and exits without flushing.
+ * Measured on the dev live gate: deleting the terminator pod dropped a live
+ * PTY session in 0.8s but printed a bare "Received disconnect … :11:" instead
+ * of "the server is shutting down, reconnect shortly". Revocation, max
+ * duration and idle timeout all ride the same path, so all four reasons were
+ * invisible.
+ */
+const BANNER_DRAIN_TIMEOUT_MS = 2_000;
+
+/** Resolves when the write reports flushed, or when the bound elapses. */
+const flushed = (write: (done: () => void) => void): Promise<void> =>
+  new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(finish, BANNER_DRAIN_TIMEOUT_MS);
+    timer.unref();
+    try {
+      write(finish);
+    } catch {
+      finish();
+    }
+  });
+
+export class WakeTimeoutError extends Error {
+  constructor() {
+    super("sandbox did not wake in time");
+    this.name = "WakeTimeoutError";
+  }
+}
+
+export class SessionClosedError extends Error {
+  constructor() {
+    super("session already closed");
+    this.name = "SessionClosedError";
+  }
+}
+
+export interface ConnectionSessionDeps<T> {
+  controlPlane: ControlPlaneClient;
+  resolver: Resolver<T>;
+  metrics: TerminatorMetrics;
+  wakeWaitSeconds: number;
+  /** Resolver poll cadence; test knob (production default 2s). */
+  wakePollMs?: number;
+  now?: () => number;
+}
+
+export interface ConnectionSessionInput {
+  /** The certificate line, reconstructed from the verified auth blob. */
+  certificate: string;
+  sourceIp: string;
+  agentId: string;
+  /** Severs the underlying ssh2 connection (client.end()). */
+  endConnection(): void;
+}
+
+/** What the session needs from a registered channel (structurally satisfied
+ * by ssh2's ServerChannel; minimal so tests can hand in plain fakes).
+ * The write callback is load-bearing, not decoration — see
+ * BANNER_DRAIN_TIMEOUT_MS. */
+export interface NotifiableChannel {
+  write(data: string, flushed?: () => void): boolean;
+  end(): void;
+}
+
+export interface ConnectionSession<T> {
+  /** Open the control-plane session (memoized — one per connection). */
+  open(): Promise<OpenedSession>;
+  /**
+   * Resolve the exec target, waking the sandbox if needed. `onWaking`
+   * receives throttled human-readable progress lines.
+   */
+  ensureTarget(onWaking: (line: string) => void): Promise<T>;
+  /**
+   * Drop the cached exec target so the next ensureTarget re-resolves. The
+   * cache holds a target for up to ~570s with no failure-driven refresh —
+   * a reaped session trio or a re-pinned pod makes it stale mid-session,
+   * and the dial-retry path (server.ts) is what heals that (step 6).
+   */
+  invalidateTarget(): void;
+  registerChannel(channel: NotifiableChannel, hasPty: boolean): () => void;
+  /** Idle-timeout feed. */
+  touch(): void;
+  /** First relay established — heartbeats now report attached. */
+  markAttached(): void;
+  /** Idempotent; the first reason wins. Resolves once reports finished. */
+  close(reason: string, banner?: string): Promise<void>;
+  readonly isClosed: boolean;
+  /** The certified principal — for logging a refusal, which has no session id. */
+  readonly agentId: string;
+}
+
+export const createConnectionSession = <T>(
+  deps: ConnectionSessionDeps<T>,
+  input: ConnectionSessionInput,
+): ConnectionSession<T> => {
+  const now = deps.now ?? Date.now;
+  const wakePollMs = deps.wakePollMs ?? 2_000;
+
+  let openPromise: Promise<OpenedSession> | null = null;
+  let closed = false;
+  let closeReported: Promise<void> = Promise.resolve();
+  let attached = false;
+  let lastActivityAt = now();
+  let openedAt = 0;
+  let policyTimer: NodeJS.Timeout | null = null;
+  let heartbeatTimer: NodeJS.Timeout | null = null;
+  let heartbeatInFlight = false;
+  let heartbeatStrikes = 0;
+  const channels = new Set<{ channel: NotifiableChannel; hasPty: boolean }>();
+
+  let cachedTarget: { target: T; expiresAt: Date } | null = null;
+  let wakeInFlight: Promise<T> | null = null;
+  let wakeCompleted = false;
+
+  const session: ConnectionSession<T> = {
+    get isClosed() {
+      return closed;
+    },
+
+    agentId: input.agentId,
+
+    open() {
+      if (closed) return Promise.reject(new SessionClosedError());
+      if (openPromise) return openPromise;
+      openPromise = (async () => {
+        const opened = await deps.controlPlane.openSession({
+          certificate: input.certificate,
+          sourceIp: input.sourceIp,
+        });
+        deps.metrics.sessionOpened();
+        log.info(
+          { sessionId: opened.sessionId, agentId: input.agentId },
+          "ssh session opened",
+        );
+        openedAt = now();
+        lastActivityAt = openedAt;
+        // A close that raced this open already captured the promise and will
+        // report once it resolves — just never start loops on a closed
+        // session.
+        if (!closed) {
+          startPolicyLoop(opened);
+          startHeartbeatLoop(opened);
+        }
+        return opened;
+      })();
+      openPromise.catch(() => {
+        // A refused open leaves no session to close later; clear so a
+        // subsequent channel on the same connection may retry.
+        openPromise = null;
+      });
+      return openPromise;
+    },
+
+    async ensureTarget(onWaking) {
+      const opened = await session.open();
+      if (
+        cachedTarget &&
+        cachedTarget.expiresAt.getTime() - now() > TOKEN_REUSE_MARGIN_MS
+      ) {
+        return cachedTarget.target;
+      }
+      if (!wakeInFlight) {
+        wakeInFlight = pollResolver(opened, onWaking).finally(() => {
+          wakeInFlight = null;
+        });
+      }
+      return wakeInFlight;
+    },
+
+    invalidateTarget() {
+      cachedTarget = null;
+    },
+
+    registerChannel(channel, hasPty) {
+      const entry = { channel, hasPty };
+      channels.add(entry);
+      return () => channels.delete(entry);
+    },
+
+    touch() {
+      lastActivityAt = now();
+    },
+
+    markAttached() {
+      if (attached) return;
+      attached = true;
+      // Immediate heartbeat so attachedAt is stamped promptly (and short
+      // sessions still record their attach).
+      void runHeartbeat();
+    },
+
+    close(reason, banner) {
+      if (closed) return closeReported;
+      closed = true;
+      if (policyTimer) clearInterval(policyTimer);
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      const flushes: Array<Promise<void>> = [];
+      for (const { channel, hasPty } of channels) {
+        try {
+          if (banner && hasPty) {
+            flushes.push(
+              flushed((done) => channel.write(`\r\n${banner}\r\n`, done)),
+            );
+          }
+          channel.end();
+        } catch {
+          // A torn channel changes nothing about the close contract.
+        }
+      }
+      channels.clear();
+      // Report immediately (the control plane should learn now), but sever the
+      // transport only once the banner has left, so the client renders the
+      // reason instead of a bare disconnect. Bounded, so a stalled peer cannot
+      // keep a closed session's socket alive. The returned promise covers BOTH
+      // so callers that sever afterwards — drain() — cannot outrun the flush.
+      const reporting = reportClose(reason);
+      const severing =
+        flushes.length === 0
+          ? Promise.resolve()
+          : Promise.all(flushes).then(() => undefined);
+      closeReported = Promise.all([
+        reporting,
+        severing.then(() => input.endConnection()),
+      ]).then(() => undefined);
+      return closeReported;
+    },
+  };
+
+  const reportClose = (reason: string): Promise<void> => {
+    const pending = openPromise;
+    return (async () => {
+      let opened: OpenedSession | null = null;
+      try {
+        opened = pending ? await pending : null;
+      } catch {
+        opened = null;
+      }
+      if (!opened) return;
+      log.info(
+        { sessionId: opened.sessionId, agentId: input.agentId, reason },
+        "ssh session closed",
+      );
+      deps.metrics.sessionClosed();
+      await Promise.allSettled([
+        deps.controlPlane.close(opened.sessionId, reason).catch((error) => {
+          log.warn(
+            { sessionId: opened.sessionId, err: error },
+            "close report failed",
+          );
+        }),
+        deps.resolver.close(opened.sessionId).catch((error) => {
+          log.warn(
+            { sessionId: opened.sessionId, err: error },
+            "resolver session delete failed",
+          );
+        }),
+      ]);
+    })();
+  };
+
+  const startPolicyLoop = (opened: OpenedSession): void => {
+    policyTimer = setInterval(() => {
+      const at = now();
+      if (at - openedAt >= opened.policy.maxSessionSeconds * 1000) {
+        void session.close(
+          CLOSE_MAX_SESSION,
+          "session closed: maximum duration reached",
+        );
+        return;
+      }
+      if (at - lastActivityAt >= opened.policy.idleTimeoutSeconds * 1000) {
+        void session.close(CLOSE_IDLE_TIMEOUT, "session closed: idle timeout");
+      }
+    }, POLICY_TICK_MS);
+    policyTimer.unref();
+  };
+
+  const runHeartbeat = async (): Promise<void> => {
+    if (closed || heartbeatInFlight || !openPromise) return;
+    heartbeatInFlight = true;
+    try {
+      const opened = await openPromise;
+      const answer = await deps.controlPlane.heartbeat(
+        opened.sessionId,
+        attached,
+      );
+      heartbeatStrikes = 0;
+      if (answer.revoked) {
+        void session.close(
+          answer.reason ?? CLOSE_REVOKED,
+          "your access was revoked",
+        );
+      }
+    } catch (error) {
+      if (error instanceof ControlPlaneUnreachableError) {
+        heartbeatStrikes += 1;
+        if (heartbeatStrikes >= HEARTBEAT_STRIKES) {
+          // Fail closed: the lease is expiring server-side anyway, and a
+          // relay that cannot re-check access must not keep relaying.
+          void session.close(
+            CLOSE_CONTROL_PLANE_UNREACHABLE,
+            "session closed: control plane unreachable",
+          );
+        }
+      } else {
+        log.warn({ err: error }, "heartbeat failed");
+      }
+    } finally {
+      heartbeatInFlight = false;
+    }
+  };
+
+  const startHeartbeatLoop = (opened: OpenedSession): void => {
+    heartbeatTimer = setInterval(() => {
+      void runHeartbeat();
+    }, opened.policy.heartbeatSeconds * 1000);
+    heartbeatTimer.unref();
+  };
+
+  const pollResolver = async (
+    opened: OpenedSession,
+    onWaking: (line: string) => void,
+  ): Promise<T> => {
+    const startedAt = now();
+    const deadline = startedAt + deps.wakeWaitSeconds * 1000;
+    let lastProgressAt = 0;
+    for (;;) {
+      if (closed) throw new SessionClosedError();
+      let waking = false;
+      try {
+        const answer = await deps.resolver.open({
+          certificate: input.certificate,
+          grant: opened.grant,
+        });
+        if (answer.status === "ready") {
+          if (!wakeCompleted) {
+            wakeCompleted = true;
+            deps.metrics.wakeWaitSeconds((now() - startedAt) / 1000);
+          }
+          cachedTarget = { target: answer.target, expiresAt: answer.expiresAt };
+          return answer.target;
+        }
+        waking = true;
+      } catch (error) {
+        if (error instanceof ResolverRefusedError) throw error;
+        if (!(error instanceof ResolverUnreachableError)) throw error;
+        // Transient: ride it out inside the wake window, like a wake poll.
+      }
+      if (waking && now() - lastProgressAt >= PROGRESS_THROTTLE_MS) {
+        lastProgressAt = now();
+        onWaking("⏳ waking your agent…");
+      }
+      if (now() + wakePollMs > deadline) throw new WakeTimeoutError();
+      await sleep(wakePollMs);
+    }
+  };
+
+  return session;
+};

--- a/apps/ssh-terminator/src/test-fixtures.ts
+++ b/apps/ssh-terminator/src/test-fixtures.ts
@@ -1,0 +1,67 @@
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+import {
+  buildUserCertificate,
+  ed25519SignerFromPrivateKeyPem,
+  spkiToEd25519Raw,
+  type BuildUserCertificateOptions,
+  type BuiltCertificate,
+  type Ed25519Signer,
+} from "@onecli/ssh-cert";
+
+/** Shared cert-minting helpers for the terminator's test suites. */
+
+export interface TestCa {
+  signer: Ed25519Signer;
+  /** Raw 32-byte public key — the trust anchor under test. */
+  publicKey: Buffer;
+}
+
+export const createTestCa = (): TestCa => {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" });
+  const signer = ed25519SignerFromPrivateKeyPem(
+    typeof pem === "string" ? pem : pem.toString("utf8"),
+  );
+  return { signer, publicKey: signer.publicKey };
+};
+
+export interface TestUserKey {
+  /** Raw 32-byte public key. */
+  publicKey: Buffer;
+  /** Pure-ed25519 signature over the exact input (possession proofs). */
+  sign(data: Buffer): Buffer;
+}
+
+export const createTestUserKey = (): TestUserKey => {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  return {
+    publicKey: spkiToEd25519Raw(Buffer.from(spki)),
+    sign: (data) => cryptoSign(null, data, privateKey),
+  };
+};
+
+export const mintTestCertificate = (
+  ca: TestCa,
+  user: TestUserKey,
+  overrides: Partial<BuildUserCertificateOptions> = {},
+): Promise<BuiltCertificate> =>
+  buildUserCertificate(
+    {
+      userPublicKey: user.publicKey,
+      keyId: JSON.stringify({
+        u: "user-1",
+        e: "u@example.com",
+        a: "agent-1",
+        w: "ws-1",
+      }),
+      principal: "agent-1",
+      validAfter: new Date(Date.now() - 60_000),
+      validBefore: new Date(Date.now() + 600_000),
+      sandboxId: "sbx-1",
+      workspaceId: "ws-1",
+      userId: "user-1",
+      ...overrides,
+    },
+    ca.signer,
+  );

--- a/apps/ssh-terminator/tsconfig.json
+++ b/apps/ssh-terminator/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@onecli/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,6 +55,7 @@ apps/
   gateway/            # Rust gateway (credential injection, port 10255)
   runner/             # Hosted-agents daemon: starts/parks/reaps sandboxes
   sandbox-supervisor/ # Runs inside each agent sandbox
+  ssh-terminator/     # SSH front door: terminates ssh, bridges into sandboxes
   channel-adapter/    # Slack channels daemon
   gateway-e2e/        # Gateway end-to-end suite
   hosted-e2e/         # Hosted-agent end-to-end suite

--- a/packages/agent-protocol/src/failure-codes.ts
+++ b/packages/agent-protocol/src/failure-codes.ts
@@ -30,11 +30,20 @@
  *   the raw provider response on every chat surface — the raw text stays
  *   operator material (the control plane's server log and the stored
  *   transcript events).
+ * - `harness_busy`: the harness refused to take the turn's message because
+ *   its session was still executing an earlier, platform-abandoned run — and
+ *   the adapter's self-heal (cancel the orphan, resend with backoff) could
+ *   not free it. Minted by the ADAPTER on its terminal error event (the
+ *   vendor's refusal wording never crosses the adapter boundary) and carried
+ *   to `turn.result.errorCode` by the supervisor. The raw refusal rides
+ *   beside it as `error` so an old control plane that ignores the code still
+ *   stores visible text instead of a silent NULL.
  */
 export const TURN_FAILURE_CODES = {
   agentRestarted: "agent_restarted",
   agentStartFailed: "agent_start_failed",
   modelProviderError: "model_provider_error",
+  harnessBusy: "harness_busy",
 } as const;
 export type TurnFailureCode =
   (typeof TURN_FAILURE_CODES)[keyof typeof TURN_FAILURE_CODES];

--- a/packages/api/src/services/conversation.pg.test.ts
+++ b/packages/api/src/services/conversation.pg.test.ts
@@ -7,6 +7,7 @@ import {
   AGENT_RESTARTED_MESSAGE,
   AGENT_START_FAILED_MESSAGE,
   AT_CAPACITY_MESSAGE,
+  HARNESS_BUSY_MESSAGE,
   IMAGE_UNAVAILABLE_MESSAGE,
   MODEL_PROVIDER_ERROR_MESSAGE,
   TURN_STALLED_MESSAGE,
@@ -1300,6 +1301,42 @@ describe.skipIf(!PROOF_URL)("finishTurn and the cold-death revival", () => {
     expect(row?.error).toBe(MODEL_PROVIDER_ERROR_MESSAGE);
     expect(row?.errorCode).toBe("model_provider_error");
     expect(row?.error).not.toContain("rate_limit_error");
+  });
+
+  it("closes a harness_busy failure with the canonical copy, never the vendor wording", async () => {
+    // The adapter's busy self-heal exhausted: the wire carries the code plus
+    // the raw refusal (the version-skew guard for OLD control planes) — this
+    // control plane knows the code, so the row gets the canonical sentence
+    // and the raw text stays operator material.
+    const { conversationId, sandboxId } = await seedTalkable("fin-busy");
+    const turn = await turns.createTurn(
+      WORKSPACE,
+      conversationId,
+      "first",
+      WEB_A,
+    );
+    await dueWork.claimDueWork(RUNNER_A, 5);
+    await turns.applyTurnEvents(
+      reporter(RUNNER_A, sandboxId),
+      conversationId,
+      turn.id,
+      [{ type: "turn.started" }],
+    );
+
+    await turns.finishTurn({
+      reporter: reporter(RUNNER_A, sandboxId),
+      conversationId,
+      turnId: turn.id,
+      status: "failed",
+      error: "Already processing a message",
+      errorCode: "harness_busy",
+    });
+
+    const row = await db.turn.findUnique({ where: { id: turn.id } });
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toBe(HARNESS_BUSY_MESSAGE);
+    expect(row?.errorCode).toBe("harness_busy");
+    expect(row?.error).not.toContain("Already processing");
   });
 });
 

--- a/packages/api/src/validations/conversation.ts
+++ b/packages/api/src/validations/conversation.ts
@@ -97,6 +97,7 @@ export const LIFECYCLE_TURN_ERROR_CODES = [
   "agent_restarted",
   "agent_start_failed",
   "at_capacity",
+  "harness_busy",
   "image_unavailable",
   "turn_stalled",
   "turn_time_limit",
@@ -186,6 +187,30 @@ export const IMAGE_UNAVAILABLE_MESSAGE =
 export const MODEL_PROVIDER_ERROR_MESSAGE =
   "The agent's model provider rejected the request. This is usually a usage limit or an expired key. Check the connected model key, or connect a different one, then send your message again.";
 
+/** The harness refused the message because its session was still executing
+ * earlier, platform-abandoned work and the adapter's self-heal (cancel +
+ * resend with backoff) could not free it. Genuinely temporary: the blocked
+ * run either finishes or dies, so a resend is the honest recovery. */
+export const HARNESS_BUSY_MESSAGE =
+  "The agent was still busy with earlier work and couldn't take this message. Send it again in a moment.";
+
+/** The Slack mirror's last-resort line for a FAILED turn that produced no
+ * answer text and no error anywhere — silence would read as the agent
+ * ignoring the person (the seen-reaction is already stripped by the time the
+ * mirror decides). Same doctrine as the family above. */
+export const TURN_FAILED_SILENT_MESSAGE =
+  "Something went wrong and this message didn't get an answer. Send it again.";
+
+/** The Slack mirror's marker under a FAILED turn's partial answer — the text
+ * above it is real but incomplete, and must not read as a normal reply. */
+export const TURN_FAILED_PARTIAL_MESSAGE =
+  "The agent stopped partway through this answer. Send it again.";
+
+/** The Slack mirror's closure line for an aborted turn with nothing to show —
+ * the web's word for the same moment (turn-block's aborted arm), kept
+ * byte-identical by convention. */
+export const TURN_STOPPED_MESSAGE = "Stopped.";
+
 /**
  * The server-side allowlist: a WIRE failure code (supervisor/runner-supplied,
  * an open string there) → the canonical {code, message} pair written to the
@@ -210,6 +235,10 @@ export const TURN_FAILURE_COPY: Partial<
   model_provider_error: {
     code: "model_provider_error",
     message: MODEL_PROVIDER_ERROR_MESSAGE,
+  },
+  harness_busy: {
+    code: "harness_busy",
+    message: HARNESS_BUSY_MESSAGE,
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,52 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@30.0.1(@noble/hashes@2.3.0))(lightningcss@1.31.1)(tsx@4.23.12)(yaml@2.8.2)
 
+  apps/ssh-terminator:
+    dependencies:
+      '@aws-sdk/client-cloudwatch':
+        specifier: ^3.1014.0
+        version: 3.1117.0
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.1014.0
+        version: 3.1041.0
+      '@kubernetes/client-node':
+        specifier: 2.0.0
+        version: 2.0.0
+      '@onecli/ssh-cert':
+        specifier: workspace:*
+        version: link:../../packages/ssh-cert
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
+    devDependencies:
+      '@onecli/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@onecli/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.19.11
+      '@types/ssh2':
+        specifier: ^1.15.5
+        version: 1.15.5
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.2
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@30.0.1(@noble/hashes@2.3.0))(lightningcss@1.31.1)(tsx@4.23.12)(yaml@2.8.2)
+
   apps/web:
     dependencies:
       '@aws-amplify/adapter-nextjs':
@@ -812,6 +858,10 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-cloudwatch@3.1117.0':
+    resolution: {integrity: sha512-x9QsSoQjPe5kXx3gR4wpwu3zuzIaDpUchbzHFlh0EMRTnT1k4D4ZBIyxSxLAk3sIeZ+3whMojRmZWDeYyP++tw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cognito-identity-provider@3.1085.0':
     resolution: {integrity: sha512-RGBrP5cGlitR/oc77t1ZG1lK/EjKIxwsc6zOp4l6bo5Xlo5M48xYNzNeQ9DLX6+Eyptw41NN6KSo+GOejKDjBA==}
     engines: {node: '>=20.0.0'}
@@ -848,100 +898,104 @@ packages:
     resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.21':
-    resolution: {integrity: sha512-BkAfKq8Bd4shCtec1usNz//urPJF/SZy14qJyxkSaRJQ/Vv1gVh0VZSTmS7aE6aLMELkFV5wHHrS9ZcdG8Kxsg==}
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.34':
-    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+  '@aws-sdk/credential-provider-env@3.972.21':
+    resolution: {integrity: sha512-BkAfKq8Bd4shCtec1usNz//urPJF/SZy14qJyxkSaRJQ/Vv1gVh0VZSTmS7aE6aLMELkFV5wHHrS9ZcdG8Kxsg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.57':
     resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.23':
-    resolution: {integrity: sha512-4XZ3+Gu5DY8/n8zQFHBgcKTF7hWQl42G6CY9xfXVo2d25FM/lYkpmuzhYopYoPL1ITWkJ2OSBQfYEu5JRfHOhA==}
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.36':
-    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+  '@aws-sdk/credential-provider-http@3.972.23':
+    resolution: {integrity: sha512-4XZ3+Gu5DY8/n8zQFHBgcKTF7hWQl42G6CY9xfXVo2d25FM/lYkpmuzhYopYoPL1ITWkJ2OSBQfYEu5JRfHOhA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.59':
     resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.23':
-    resolution: {integrity: sha512-PZLSmU0JFpNCDFReidBezsgL5ji9jOBry8CnZdw4Jj6d0K2z3Ftnp44NXgADqYx5BLMu/ZHujfeJReaDoV+IwQ==}
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.38':
-    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+  '@aws-sdk/credential-provider-ini@3.972.23':
+    resolution: {integrity: sha512-PZLSmU0JFpNCDFReidBezsgL5ji9jOBry8CnZdw4Jj6d0K2z3Ftnp44NXgADqYx5BLMu/ZHujfeJReaDoV+IwQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.973.1':
     resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.23':
-    resolution: {integrity: sha512-OmE/pSkbMM3dCj1HdOnZ5kXnKK+R/Yz+kbBugraBecp0pGAs21eEURfQRz+1N2gzIHLVyGIP1MEjk/uSrFsngg==}
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.38':
-    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+  '@aws-sdk/credential-provider-login@3.972.23':
+    resolution: {integrity: sha512-OmE/pSkbMM3dCj1HdOnZ5kXnKK+R/Yz+kbBugraBecp0pGAs21eEURfQRz+1N2gzIHLVyGIP1MEjk/uSrFsngg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.63':
     resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.24':
-    resolution: {integrity: sha512-9Jwi7aps3AfUicJyF5udYadPypPpCwUZ6BSKr/QjRbVCpRVS1wc+1Q6AEZ/qz8J4JraeRd247pSzyMQSIHVebw==}
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.39':
-    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+  '@aws-sdk/credential-provider-node@3.972.24':
+    resolution: {integrity: sha512-9Jwi7aps3AfUicJyF5udYadPypPpCwUZ6BSKr/QjRbVCpRVS1wc+1Q6AEZ/qz8J4JraeRd247pSzyMQSIHVebw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.66':
     resolution: {integrity: sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.21':
-    resolution: {integrity: sha512-nRxbeOJ1E1gVA0lNQezuMVndx+ZcuyaW/RB05pUsznN5BxykSlH6KkZ/7Ca/ubJf3i5N3p0gwNO5zgPSCzj+ww==}
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.34':
-    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+  '@aws-sdk/credential-provider-process@3.972.21':
+    resolution: {integrity: sha512-nRxbeOJ1E1gVA0lNQezuMVndx+ZcuyaW/RB05pUsznN5BxykSlH6KkZ/7Ca/ubJf3i5N3p0gwNO5zgPSCzj+ww==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.57':
     resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.23':
-    resolution: {integrity: sha512-APUccADuYPLL0f2htpM8Z4czabSmHOdo4r41W6lKEZdy++cNJ42Radqy6x4TopENzr3hR6WYMyhiuiqtbf/nAA==}
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.38':
-    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+  '@aws-sdk/credential-provider-sso@3.972.23':
+    resolution: {integrity: sha512-APUccADuYPLL0f2htpM8Z4czabSmHOdo4r41W6lKEZdy++cNJ42Radqy6x4TopENzr3hR6WYMyhiuiqtbf/nAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.973.1':
     resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.23':
     resolution: {integrity: sha512-H5JNqtIwOu/feInmMMWcK0dL5r897ReEn7n2m16Dd0DPD9gA2Hg8Cq4UDzZ/9OzaLh/uqBM6seixz0U6Fi2Eag==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.38':
-    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-web-identity@3.972.63':
     resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.10':
@@ -980,10 +1034,6 @@ packages:
     resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.37':
-    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/middleware-user-agent@3.972.13':
     resolution: {integrity: sha512-p1kVYbzBxRmhuOHoL/ANJPCedqUxnVgkEjxPoxt5pQv/yzppHM7aBWciYEE9TZY59M421D3GjLfZIZBoEFboVQ==}
     engines: {node: '>=20.0.0'}
@@ -1004,8 +1054,8 @@ packages:
     resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.6':
-    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.13':
@@ -1020,24 +1070,24 @@ packages:
     resolution: {integrity: sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.25':
-    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/signature-v4-multi-region@3.996.39':
     resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1014.0':
     resolution: {integrity: sha512-gHTHNUoaOGNrSWkl32A7wFsU78jlNTlqMccLu0byUk5CysYYXaxNMIonIVr4YcykC7vgtDS5ABuz83giy6fzJA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1041.0':
-    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/token-providers@3.1083.0':
     resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.1':
@@ -1060,16 +1110,12 @@ packages:
     resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-arn-parser@3.972.3':
-    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.982.0':
     resolution: {integrity: sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-endpoints@3.996.1':
-    resolution: {integrity: sha512-7cJyd+M5i0IoqWkJa1KFx8KNCGIx+Ywu+lT53KpqX7ReVwz03DCKUqvZ/y65vdKwo9w9/HptSAeLDluO5MpGIg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.5':
@@ -1130,6 +1176,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.34':
     resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -1780,6 +1830,21 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@kubernetes/client-node@2.0.0':
+    resolution: {integrity: sha512-Jx2cRxEVb4XkDNiR/cg8SX9dH6ZHdMhKmZdQcfhn2vdBWHdb2ldwM0P3I0dK4msYhFmC6TCODsNHH144IpA06w==}
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -2950,8 +3015,8 @@ packages:
     resolution: {integrity: sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.2.10':
-    resolution: {integrity: sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==}
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.12':
@@ -2964,6 +3029,10 @@ packages:
 
   '@smithy/credential-provider-imds@4.4.8':
     resolution: {integrity: sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.10':
@@ -2998,6 +3067,10 @@ packages:
     resolution: {integrity: sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-node@4.2.10':
     resolution: {integrity: sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==}
     engines: {node: '>=18.0.0'}
@@ -3030,16 +3103,16 @@ packages:
     resolution: {integrity: sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==}
     engines: {node: '>=16.0.0'}
 
-  '@smithy/is-array-buffer@4.2.1':
-    resolution: {integrity: sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/is-array-buffer@4.2.2':
     resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/md5-js@2.0.7':
     resolution: {integrity: sha512-2i2BpXF9pI5D1xekqUsgQ/ohv5+H//G9FlawJrkOJskV18PgJ8LiNbLiskMeYt07yAsSTZR7qtlcAaa/GQLWww==}
+
+  '@smithy/middleware-compression@4.6.2':
+    resolution: {integrity: sha512-Q9d+luiRjyHT6kCL/9NyGpdZJgodh4vtvfHC6H8SqoVKrV2k9RoyI9/IloVfdCYks3/2DIi7BsYYLcda5KZS0A==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-content-length@4.2.10':
     resolution: {integrity: sha512-TQZ9kX5c6XbjhaEBpvhSvMEZ0klBs1CFtOdPFwATZSbC9UeQfKHPLPN9Y+I6wZGMOavlYTOlHEPDrt42PMSH9w==}
@@ -3113,6 +3186,10 @@ packages:
     resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.5.0':
     resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
     engines: {node: '>=18.0.0'}
@@ -3157,20 +3234,12 @@ packages:
     resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-parser@4.2.10':
-    resolution: {integrity: sha512-4Mh18J26+ao1oX5wXJfWlTT+Q1OpDR8ssiC9PDOuEgVBGloqg18Fw7h5Ct8DyT9NBYwJgtJ2nLjKKFU6RP1G1Q==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/querystring-parser@4.2.12':
     resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-parser@4.2.14':
     resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/service-error-classification@4.2.10':
-    resolution: {integrity: sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/service-error-classification@4.2.12':
@@ -3205,6 +3274,10 @@ packages:
     resolution: {integrity: sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.0':
     resolution: {integrity: sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==}
     engines: {node: '>=18.0.0'}
@@ -3235,6 +3308,10 @@ packages:
 
   '@smithy/types@4.16.1':
     resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.10':
@@ -3284,10 +3361,6 @@ packages:
   '@smithy/util-buffer-from@3.0.0':
     resolution: {integrity: sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==}
     engines: {node: '>=16.0.0'}
-
-  '@smithy/util-buffer-from@4.2.1':
-    resolution: {integrity: sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==}
-    engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@4.2.2':
     resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
@@ -3600,6 +3673,9 @@ packages:
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -3612,8 +3688,14 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  '@types/node@26.3.0':
+    resolution: {integrity: sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==}
 
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
@@ -3625,6 +3707,12 @@ packages:
 
   '@types/react@19.2.2':
     resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
+
+  '@types/stream-buffers@3.0.8':
+    resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -3847,6 +3935,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
 
@@ -3926,6 +4018,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -3936,6 +4031,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -3960,6 +4058,14 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -3970,6 +4076,43 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.8.1:
+    resolution: {integrity: sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.5.2:
+    resolution: {integrity: sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3977,6 +4120,9 @@ packages:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-auth@1.6.26:
     resolution: {integrity: sha512-nhXWrDDj+EnZsHq1j0z1c6DowOMFZWZHe6LCaXbBfLIgHHZm6dyazBQcbRspM4spUIcUt250Mc1BFOSuP7eniQ==}
@@ -4076,6 +4222,10 @@ packages:
 
   buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4188,6 +4338,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -4234,6 +4388,10 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -4328,6 +4486,10 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -4639,6 +4801,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.1.1:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
@@ -4676,6 +4841,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -4738,6 +4906,9 @@ packages:
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -4768,6 +4939,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -4893,6 +5068,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -4911,6 +5090,10 @@ packages:
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
+
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -5131,6 +5314,11 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -5141,6 +5329,9 @@ packages:
 
   jose@6.2.0:
     resolution: {integrity: sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==}
+
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -5160,6 +5351,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js-yaml@5.4.0:
+    resolution: {integrity: sha512-jE7vUJIebKzYQI5xu4co5CRBDlDEYnHrdzsxs4O2giCz4v2SbVMYKpmt1D9L38OKQAeCWmrOTRiCV93u0UkaJA==}
+    hasBin: true
+
   jsdom@30.0.1:
     resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -5168,6 +5363,10 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5196,6 +5395,11 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   jsx-ast-utils@3.3.5:
@@ -5510,8 +5714,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -5538,6 +5750,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5607,6 +5822,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  oauth4webapi@3.8.7:
+    resolution: {integrity: sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5656,6 +5874,9 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openid-client@6.8.5:
+    resolution: {integrity: sha512-jNGC/5wnTYwCcEUe2ss0IRUmVRQcgxM0A1nLb3eX/9llqNbMWOQd2xd+qDAgfVCpA5Qh96Y1cdnkfbva6+bSdA==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -6063,6 +6284,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
+
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -6205,6 +6429,18 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@10.1.0:
+    resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
+    engines: {node: '>= 20'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -6225,6 +6461,10 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -6244,6 +6484,13 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -6372,6 +6619,18 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
+  tar-stream@3.2.1:
+    resolution: {integrity: sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
@@ -6485,6 +6744,9 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6529,8 +6791,14 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@8.10.0:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
@@ -6978,7 +7246,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       tslib: 2.8.1
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -6986,7 +7254,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -6994,7 +7262,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -7005,6 +7273,18 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.2
       '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudwatch@3.1117.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/middleware-compression': 4.6.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/client-cognito-identity-provider@3.1085.0':
@@ -7022,20 +7302,20 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
       '@aws-sdk/middleware-host-header': 3.972.4
       '@aws-sdk/middleware-logger': 3.972.4
       '@aws-sdk/middleware-recursion-detection': 3.972.4
       '@aws-sdk/middleware-user-agent': 3.972.13
       '@aws-sdk/region-config-resolver': 3.972.4
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-endpoints': 3.982.0
       '@aws-sdk/util-user-agent-browser': 3.972.4
       '@aws-sdk/util-user-agent-node': 3.972.12
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
       '@smithy/middleware-content-length': 4.2.10
@@ -7044,10 +7324,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.11
       '@smithy/middleware-stack': 4.2.10
       '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.9.5
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.10
       '@smithy/util-base64': 4.3.1
       '@smithy/util-body-length-browser': 4.2.1
@@ -7066,23 +7346,23 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
       '@aws-sdk/middleware-host-header': 3.972.4
       '@aws-sdk/middleware-logger': 3.972.4
       '@aws-sdk/middleware-recursion-detection': 3.972.4
       '@aws-sdk/middleware-user-agent': 3.972.13
       '@aws-sdk/region-config-resolver': 3.972.4
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-endpoints': 3.982.0
       '@aws-sdk/util-user-agent-browser': 3.972.4
       '@aws-sdk/util-user-agent-node': 3.972.12
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.29.3
       '@smithy/eventstream-serde-browser': 4.2.10
       '@smithy/eventstream-serde-config-resolver': 4.3.10
       '@smithy/eventstream-serde-node': 4.2.10
-      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/fetch-http-handler': 5.6.5
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
       '@smithy/middleware-content-length': 4.2.10
@@ -7091,10 +7371,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.11
       '@smithy/middleware-stack': 4.2.10
       '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.9.5
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.10
       '@smithy/util-base64': 4.3.1
       '@smithy/util-body-length-browser': 4.2.1
@@ -7158,20 +7438,20 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
       '@aws-sdk/middleware-host-header': 3.972.4
       '@aws-sdk/middleware-logger': 3.972.4
       '@aws-sdk/middleware-recursion-detection': 3.972.4
       '@aws-sdk/middleware-user-agent': 3.972.13
       '@aws-sdk/region-config-resolver': 3.972.4
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-endpoints': 3.982.0
       '@aws-sdk/util-user-agent-browser': 3.972.4
       '@aws-sdk/util-user-agent-node': 3.972.12
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
       '@smithy/middleware-content-length': 4.2.10
@@ -7180,10 +7460,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.11
       '@smithy/middleware-stack': 4.2.10
       '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.9.5
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.10
       '@smithy/util-base64': 4.3.1
       '@smithy/util-body-length-browser': 4.2.1
@@ -7202,20 +7482,20 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
       '@aws-sdk/middleware-host-header': 3.972.10
       '@aws-sdk/middleware-logger': 3.972.10
       '@aws-sdk/middleware-recursion-detection': 3.972.11
       '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
       '@aws-sdk/util-user-agent-node': 3.973.24
       '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
       '@smithy/hash-node': 4.2.14
       '@smithy/invalid-dependency': 4.2.14
       '@smithy/middleware-content-length': 4.2.14
@@ -7224,10 +7504,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.9.5
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -7286,19 +7566,22 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.21':
     dependencies:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.34':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -7308,6 +7591,14 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.23':
@@ -7323,19 +7614,6 @@ snapshots:
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.36':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.25
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-http@3.972.59':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -7344,6 +7622,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.5
       '@smithy/node-http-handler': 4.9.5
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.23':
@@ -7365,25 +7653,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-env': 3.972.34
-      '@aws-sdk/credential-provider-http': 3.972.36
-      '@aws-sdk/credential-provider-login': 3.972.38
-      '@aws-sdk/credential-provider-process': 3.972.34
-      '@aws-sdk/credential-provider-sso': 3.972.38
-      '@aws-sdk/credential-provider-web-identity': 3.972.38
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-ini@3.973.1':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -7400,28 +7669,31 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/core': 3.975.1
       '@aws-sdk/nested-clients': 3.996.13
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7433,6 +7705,15 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.24':
@@ -7452,23 +7733,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.39':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.34
-      '@aws-sdk/credential-provider-http': 3.972.36
-      '@aws-sdk/credential-provider-ini': 3.972.38
-      '@aws-sdk/credential-provider-process': 3.972.34
-      '@aws-sdk/credential-provider-sso': 3.972.38
-      '@aws-sdk/credential-provider-web-identity': 3.972.38
-      '@aws-sdk/types': 3.973.8
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-node@3.972.66':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.57
@@ -7483,6 +7747,20 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.21':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -7492,21 +7770,20 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.34':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.972.57':
     dependencies:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.23':
@@ -7522,19 +7799,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-sso@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/token-providers': 3.1041.0
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-sso@3.973.1':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -7543,6 +7807,16 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.23':
@@ -7557,18 +7831,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-web-identity@3.972.63':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -7576,6 +7838,15 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.10':
@@ -7587,9 +7858,9 @@ snapshots:
 
   '@aws-sdk/middleware-host-header@3.972.4':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.8':
@@ -7607,8 +7878,8 @@ snapshots:
 
   '@aws-sdk/middleware-logger@3.972.4':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.8':
@@ -7627,10 +7898,10 @@ snapshots:
 
   '@aws-sdk/middleware-recursion-detection@3.972.4':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@aws/lambda-invoke-store': 0.2.3
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.14.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.8':
@@ -7641,31 +7912,14 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.37':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.23.17
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-user-agent@3.972.13':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.1
-      '@smithy/core': 3.23.17
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.14.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.29.3
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.24':
@@ -7694,19 +7948,19 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/core': 3.975.1
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
       '@aws-sdk/middleware-recursion-detection': 3.972.8
       '@aws-sdk/middleware-user-agent': 3.972.24
       '@aws-sdk/region-config-resolver': 3.972.9
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
       '@aws-sdk/util-user-agent-node': 3.973.10
       '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
       '@smithy/hash-node': 4.2.12
       '@smithy/invalid-dependency': 4.2.12
       '@smithy/middleware-content-length': 4.2.12
@@ -7715,10 +7969,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.15
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.9.5
       '@smithy/protocol-http': 5.3.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -7744,49 +7998,16 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.6':
+  '@aws-sdk/nested-clients@3.997.44':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.25
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.7
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/util-utf8': 4.2.2
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
@@ -7798,10 +8019,10 @@ snapshots:
 
   '@aws-sdk/region-config-resolver@3.972.4':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/config-resolver': 4.4.9
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.972.9':
@@ -7812,15 +8033,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.25':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.37
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.39':
     dependencies:
       '@aws-sdk/types': 3.974.0
@@ -7828,26 +8040,21 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1014.0':
     dependencies:
-      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/core': 3.975.1
       '@aws-sdk/nested-clients': 3.996.13
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.974.0
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/token-providers@3.1041.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7861,14 +8068,23 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.1':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.2':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.6':
@@ -7886,24 +8102,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-arn-parser@3.972.3':
+  '@aws-sdk/types@3.974.5':
     dependencies:
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.982.0':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.10
-      '@smithy/util-endpoints': 3.3.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.996.1':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.10
-      '@smithy/util-endpoints': 3.3.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/types': 4.16.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.5':
@@ -7935,8 +8144,8 @@ snapshots:
 
   '@aws-sdk/util-user-agent-browser@3.972.4':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/types': 4.16.1
       bowser: 2.14.1
       tslib: 2.8.1
 
@@ -7949,10 +8158,10 @@ snapshots:
 
   '@aws-sdk/util-user-agent-node@3.972.12':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.13
-      '@aws-sdk/types': 3.973.8
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/types': 4.14.1
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.974.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.973.10':
@@ -7989,6 +8198,11 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.34':
     dependencies:
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -8523,6 +8737,40 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@kubernetes/client-node@2.0.0':
+    dependencies:
+      '@types/js-yaml': 4.0.9
+      '@types/node': 26.3.0
+      '@types/stream-buffers': 3.0.8
+      form-data: 4.0.6
+      hpagent: 1.2.0
+      isomorphic-ws: 5.0.0(ws@8.21.3)
+      js-yaml: 5.4.0
+      jsonpath-plus: 10.4.0
+      openid-client: 6.8.5
+      rfc4648: 1.5.4
+      socks: 2.8.9
+      socks-proxy-agent: 10.1.0
+      stream-buffers: 3.0.3
+      tar-fs: 3.1.3
+      undici: 8.10.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
     dependencies:
@@ -9629,7 +9877,7 @@ snapshots:
 
   '@smithy/abort-controller@4.2.10':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/abort-controller@4.2.12':
@@ -9657,11 +9905,11 @@ snapshots:
 
   '@smithy/config-resolver@4.4.9':
     dependencies:
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/types': 4.14.1
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.16.1
       '@smithy/util-config-provider': 4.2.1
-      '@smithy/util-endpoints': 3.3.1
-      '@smithy/util-middleware': 4.2.10
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/core@3.23.12':
@@ -9695,12 +9943,9 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.10':
+  '@smithy/core@3.33.3':
     dependencies:
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/property-provider': 4.2.10
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.10
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.2.12':
@@ -9725,34 +9970,40 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/eventstream-codec@4.2.10':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/util-hex-encoding': 4.2.1
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.2.10':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.10
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-config-resolver@4.3.10':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-node@4.2.10':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.10
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-universal@4.2.10':
     dependencies:
       '@smithy/eventstream-codec': 4.2.10
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.15':
@@ -9777,11 +10028,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/hash-node@4.2.10':
     dependencies:
-      '@smithy/types': 4.14.1
-      '@smithy/util-buffer-from': 4.2.1
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/types': 4.16.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/hash-node@4.2.12':
@@ -9793,14 +10050,14 @@ snapshots:
 
   '@smithy/hash-node@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.10':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.12':
@@ -9821,10 +10078,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/is-array-buffer@4.2.1':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/is-array-buffer@4.2.2':
     dependencies:
       tslib: 2.8.1
@@ -9835,10 +10088,17 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@smithy/middleware-compression@4.6.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      fflate: 0.8.3
+      tslib: 2.8.1
+
   '@smithy/middleware-content-length@4.2.10':
     dependencies:
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.14.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.12':
@@ -9855,13 +10115,13 @@ snapshots:
 
   '@smithy/middleware-endpoint@4.4.20':
     dependencies:
-      '@smithy/core': 3.23.17
-      '@smithy/middleware-serde': 4.2.11
-      '@smithy/node-config-provider': 4.3.10
+      '@smithy/core': 3.29.3
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
       '@smithy/shared-ini-file-loader': 4.4.5
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.10
-      '@smithy/util-middleware': 4.2.10
+      '@smithy/types': 4.16.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/middleware-endpoint@4.4.27':
@@ -9888,13 +10148,13 @@ snapshots:
 
   '@smithy/middleware-retry@4.4.37':
     dependencies:
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/service-error-classification': 4.2.10
-      '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.14.1
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-retry': 4.2.10
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.16.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
       '@smithy/uuid': 1.1.1
       tslib: 2.8.1
 
@@ -9925,8 +10185,8 @@ snapshots:
 
   '@smithy/middleware-serde@4.2.11':
     dependencies:
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.14.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.15':
@@ -9945,7 +10205,7 @@ snapshots:
 
   '@smithy/middleware-stack@4.2.10':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.12':
@@ -9962,7 +10222,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.12':
@@ -9977,6 +10237,12 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.5.0':
@@ -10002,7 +10268,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.10':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/property-provider@4.2.12':
@@ -10017,7 +10283,7 @@ snapshots:
 
   '@smithy/protocol-http@5.3.10':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.12':
@@ -10042,11 +10308,6 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/querystring-parser@4.2.10':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@smithy/querystring-parser@4.2.12':
     dependencies:
       '@smithy/types': 4.14.1
@@ -10056,10 +10317,6 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-
-  '@smithy/service-error-classification@4.2.10':
-    dependencies:
-      '@smithy/types': 4.14.1
 
   '@smithy/service-error-classification@4.2.12':
     dependencies:
@@ -10071,7 +10328,7 @@ snapshots:
 
   '@smithy/shared-ini-file-loader@4.4.5':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.7':
@@ -10112,13 +10369,19 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.0':
     dependencies:
-      '@smithy/core': 3.23.17
-      '@smithy/middleware-endpoint': 4.4.20
-      '@smithy/middleware-stack': 4.2.10
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.14.1
+      '@smithy/core': 3.29.3
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.16.1
       '@smithy/util-stream': 4.5.15
       tslib: 2.8.1
 
@@ -10162,10 +10425,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/url-parser@4.2.10':
     dependencies:
-      '@smithy/querystring-parser': 4.2.10
-      '@smithy/types': 4.14.1
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/url-parser@4.2.12':
@@ -10177,7 +10444,7 @@ snapshots:
   '@smithy/url-parser@4.2.14':
     dependencies:
       '@smithy/querystring-parser': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/util-base64@3.0.0':
@@ -10188,8 +10455,8 @@ snapshots:
 
   '@smithy/util-base64@4.3.1':
     dependencies:
-      '@smithy/util-buffer-from': 4.2.1
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.2':
@@ -10224,11 +10491,6 @@ snapshots:
       '@smithy/is-array-buffer': 3.0.0
       tslib: 2.8.1
 
-  '@smithy/util-buffer-from@4.2.1':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.1
-      tslib: 2.8.1
-
   '@smithy/util-buffer-from@4.2.2':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
@@ -10245,8 +10507,8 @@ snapshots:
   '@smithy/util-defaults-mode-browser@4.3.36':
     dependencies:
       '@smithy/property-provider': 4.2.10
-      '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.14.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.43':
@@ -10265,12 +10527,12 @@ snapshots:
 
   '@smithy/util-defaults-mode-node@4.2.39':
     dependencies:
-      '@smithy/config-resolver': 4.4.9
-      '@smithy/credential-provider-imds': 4.2.10
-      '@smithy/node-config-provider': 4.3.10
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.10
-      '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.14.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.47':
@@ -10295,8 +10557,8 @@ snapshots:
 
   '@smithy/util-endpoints@3.3.1':
     dependencies:
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/types': 4.14.1
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.3.3':
@@ -10325,7 +10587,7 @@ snapshots:
 
   '@smithy/util-middleware@4.2.10':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/util-middleware@4.2.12':
@@ -10340,8 +10602,8 @@ snapshots:
 
   '@smithy/util-retry@4.2.10':
     dependencies:
-      '@smithy/service-error-classification': 4.2.10
-      '@smithy/types': 4.14.1
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/util-retry@4.2.12':
@@ -10353,18 +10615,18 @@ snapshots:
   '@smithy/util-retry@4.3.8':
     dependencies:
       '@smithy/service-error-classification': 4.3.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.15':
     dependencies:
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.1
-      '@smithy/util-buffer-from': 4.2.1
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.1
-      '@smithy/util-utf8': 4.2.1
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.20':
@@ -10410,7 +10672,7 @@ snapshots:
 
   '@smithy/util-utf8@4.2.1':
     dependencies:
-      '@smithy/util-buffer-from': 4.2.1
+      '@smithy/util-buffer-from': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-utf8@4.2.2':
@@ -10421,7 +10683,7 @@ snapshots:
   '@smithy/util-waiter@4.2.10':
     dependencies:
       '@smithy/abort-controller': 4.2.10
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.1':
@@ -10604,6 +10866,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -10614,9 +10878,17 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@26.3.0':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/qrcode@1.5.6':
     dependencies:
@@ -10629,6 +10901,14 @@ snapshots:
   '@types/react@19.2.2':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
+
+  '@types/stream-buffers@3.0.8':
+    dependencies:
+      '@types/node': 22.19.11
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -10860,6 +11140,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@9.0.0: {}
+
   ajv-formats@3.0.1:
     dependencies:
       ajv: 8.20.0
@@ -10973,11 +11255,17 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -11005,15 +11293,50 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
+  bare-events@2.9.1: {}
+
+  bare-fs@4.8.1:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.5.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.5.2:
+    dependencies:
+      bare-path: 3.1.1
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   better-auth@1.6.26(@opentelemetry/api@1.9.1)(@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.2))(typescript@5.9.2))(next@16.1.0(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@6.19.2(typescript@5.9.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@30.0.1(@noble/hashes@2.3.0))(lightningcss@1.31.1)(tsx@4.23.12)(yaml@2.8.2)):
     dependencies:
@@ -11100,6 +11423,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
       isarray: 1.0.0
+
+  buildcheck@0.0.7:
+    optional: true
 
   bytes@3.1.2: {}
 
@@ -11211,6 +11537,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@14.0.3: {}
@@ -11239,6 +11569,12 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -11323,6 +11659,8 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.4: {}
+
+  delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
 
@@ -11773,6 +12111,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
@@ -11833,6 +12177,8 @@ snapshots:
   fast-copy@4.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -11898,6 +12244,8 @@ snapshots:
 
   fflate@0.4.8: {}
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -11937,6 +12285,14 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -12052,6 +12408,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -12085,6 +12445,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   hono@4.12.18: {}
+
+  hpagent@1.2.0: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.3.0):
     dependencies:
@@ -12301,6 +12663,10 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-ws@5.0.0(ws@8.21.3):
+    dependencies:
+      ws: 8.21.3
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -12314,6 +12680,8 @@ snapshots:
 
   jose@6.2.0: {}
 
+  jose@6.2.10: {}
+
   joycon@3.1.1: {}
 
   js-cookie@3.0.5: {}
@@ -12323,6 +12691,10 @@ snapshots:
   js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.4.0:
     dependencies:
       argparse: 2.0.1
 
@@ -12352,6 +12724,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  jsep@1.4.0: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -12369,6 +12743,12 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -12872,7 +13252,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -12893,6 +13279,9 @@ snapshots:
   minimist@1.2.8: {}
 
   ms@2.1.3: {}
+
+  nan@2.28.0:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -12953,6 +13342,8 @@ snapshots:
       pathe: 2.0.3
       tinyexec: 1.0.2
 
+  oauth4webapi@3.8.7: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -13010,6 +13401,11 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openid-client@6.8.5:
+    dependencies:
+      jose: 6.2.10
+      oauth4webapi: 3.8.7
 
   optionator@0.9.4:
     dependencies:
@@ -13481,6 +13877,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rfc4648@1.5.4: {}
+
   rfdc@1.4.1: {}
 
   rollup@4.62.2:
@@ -13717,6 +14115,21 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@10.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.5.0
+      smart-buffer: 4.2.0
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -13732,6 +14145,14 @@ snapshots:
 
   split2@4.2.0: {}
 
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -13746,6 +14167,17 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-buffers@3.0.3: {}
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   string-argv@0.3.2: {}
 
@@ -13880,6 +14312,42 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.1
+    optionalDependencies:
+      bare-fs: 4.8.1
+      bare-path: 3.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.2.1:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
@@ -13973,6 +14441,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -14038,7 +14508,11 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
+
+  undici-types@8.3.0: {}
 
   undici@8.10.0: {}
 


### PR DESCRIPTION
## What

Three changes riding one sync window (58 files).

### Per-conversation jcode sessions + busy self-heal
Each conversation now gets its own jcode session instead of sharing one per sandbox. Previously a second conversation could attach to a busy session and poison a live turn: two 30s control-op timeouts surfaced as false "model isn't available" notices, the busy refusal's broadcast error frame failed the live turn early with an empty error, and every follow-up died silently while the finished answer was discarded.

- `apps/sandbox-supervisor`: session-per-conversation in the supervisor and process manager, busy self-heal, defensive abort delivery
- `apps/channel-adapter`: the mirror never swallows a failure silently
- Env-gated live regression suites replaying the incident against the real jcode binary (`jcode-incident.live.test.ts`, gated on `JCODE_LIVE_TEST`) and the full local stack (`apps/hosted-e2e/tests/live-jcode-incident.test.ts`, double env-gated) — neither runs in CI

### Agent report-back contract
A turn-ending prompt law in the jcode harness plus a supervisor turn-end watch as the safety net, so agents report what happened instead of ending turns silently. New failure codes in `@onecli/agent-protocol` and conversation validations in `@onecli/api`.

### Standalone ssh-terminator app
The SSH front door daemon (certificate auth + session lifecycle) extracted into its own workspace package at `apps/ssh-terminator`, with a pluggable substrate backend (kube today), its own build, tests, limits, and metrics. Groundwork for self-host SSH support.

## Notes

- New workspace package → lockfile regenerated with `pnpm install`
- CI picks the new package up via the existing workspace-wide lint/build/test filters; no `ci.yml` changes needed
- Root `package.json` intentionally not synced: the diff nets to the carved fields (`name`, `generate:catalog`) plus the version, where this repo is ahead (2.2.2)