### PR TITLE
fix(cli-auth): dynamically resolve apiHost for self-hosted instances

### DIFF
--- a/apps/web/src/lib/actions/secrets.ts
+++ b/apps/web/src/lib/actions/secrets.ts
@@ -4,6 +4,8 @@ import { db } from "@onecli/db";
 import { resolveWorkspaceContext } from "@/lib/actions/resolve-user";
 import type { ResolveOptions } from "@/lib/actions/resolve-user";
 import { apiOrigin, appOrigin } from "@onecli/api/lib/public-origins";
+import { originFromHeaders } from "@onecli/api/lib/app-origin";
+import { headers } from "next/headers";
 import {
   listSecrets,
   createSecret as createSecretService,
@@ -76,10 +78,13 @@ export const getInstallInfo = async (options?: ResolveOptions) => {
     });
   }
 
+  const headerList = await headers();
+  const requestOrigin = originFromHeaders(headerList);
+
   return {
     apiKey: keyResult.apiKey,
-    appUrl: appOrigin(),
-    apiUrl: apiOrigin(),
+    appUrl: appOrigin(requestOrigin),
+    apiUrl: apiOrigin(requestOrigin),
   };
 };
 

--- a/packages/api/src/lib/public-origins.test.ts
+++ b/packages/api/src/lib/public-origins.test.ts
@@ -437,15 +437,21 @@ describe("env wrapper and facades", () => {
     expect(configuredApiUrl()).toBeUndefined();
   });
 
-  // The required subtlety: a configured external URL makes the API origin
-  // *derived-but-configured*, pinning OAuth redirect URIs and cookie-domain
-  // inputs without a separate API_URL line.
-  it("configuredApiUrl answers the derived origin when only the external URL is set", () => {
+  // Dynamic requestOrigin fallback
+  it("uses requestOrigin fallback for resolveOriginsFromEnv when no env is set", () => {
     clearAll();
-    process.env.ONECLI_EXTERNAL_URL = "http://192.0.2.10:10254";
-    expect(configuredApiUrl()).toBe("http://192.0.2.10:10256");
-    process.env.ONECLI_EXTERNAL_URL = "https://onecli.acme.com";
-    expect(configuredApiUrl()).toBe("https://onecli.acme.com");
+    const r = resolveOriginsFromEnv("http://192.168.1.100:10254");
+    expect(r.app).toBe("http://192.168.1.100:10254");
+    expect(r.api).toBe("http://192.168.1.100:10256");
+    expect(r.gateway).toBe("http://192.168.1.100:10255");
+  });
+
+  it("ignores requestOrigin fallback when ONECLI_EXTERNAL_URL is set", () => {
+    clearAll();
+    process.env.ONECLI_EXTERNAL_URL = "http://configured.host:10254";
+    const r = resolveOriginsFromEnv("http://fallback.host:10254");
+    expect(r.app).toBe("http://configured.host:10254");
+    expect(r.api).toBe("http://configured.host:10256");
   });
 });
 

--- a/packages/api/src/lib/public-origins.ts
+++ b/packages/api/src/lib/public-origins.ts
@@ -544,21 +544,35 @@ const readEnvBag = (): PublicOriginsEnvBag => ({
   gatewayBaseUrl: process.env.GATEWAY_BASE_URL,
 });
 
-export const resolveOriginsFromEnv = (): ResolvedPublicOrigins =>
-  resolvePublicOrigins(readEnvBag());
+export const resolveOriginsFromEnv = (
+  requestOrigin?: string,
+): ResolvedPublicOrigins => {
+  const env = readEnvBag();
+  if (
+    requestOrigin &&
+    !firstConfigured(env.externalUrl) &&
+    !firstConfigured(env.appUrl, env.nextPublicAppUrl)
+  ) {
+    env.externalUrl = requestOrigin;
+  }
+  return resolvePublicOrigins(env);
+};
 
 /** The dashboard origin — where a browser opens OneCLI. */
-export const appOrigin = (): string => resolveOriginsFromEnv().app;
+export const appOrigin = (requestOrigin?: string): string =>
+  resolveOriginsFromEnv(requestOrigin).app;
 
 /** The api-server origin — OAuth redirect base, CLI api-host, /v1 calls. */
-export const apiOrigin = (): string => resolveOriginsFromEnv().api;
+export const apiOrigin = (requestOrigin?: string): string =>
+  resolveOriginsFromEnv(requestOrigin).api;
 
 /** The gateway HTTP origin (approvals, vault status) — NOT the CONNECT proxy. */
-export const gatewayHttpOrigin = (): string => resolveOriginsFromEnv().gateway;
+export const gatewayHttpOrigin = (requestOrigin?: string): string =>
+  resolveOriginsFromEnv(requestOrigin).gateway;
 
 /** Scheme-less host:port agent containers use as their CONNECT proxy target. */
-export const agentProxyAddress = (): string =>
-  resolveOriginsFromEnv().agentProxyAddress;
+export const agentProxyAddress = (requestOrigin?: string): string =>
+  resolveOriginsFromEnv(requestOrigin).agentProxyAddress;
 
 /**
  * The public app URL the operator explicitly configured, or `undefined` when
@@ -569,8 +583,10 @@ export const agentProxyAddress = (): string =>
  * seed counts as configured — it replaced a compose-seeded `APP_URL` that was
  * configured too.
  */
-export const configuredAppUrl = (): string | undefined => {
-  const resolved = resolveOriginsFromEnv();
+export const configuredAppUrl = (
+  requestOrigin?: string,
+): string | undefined => {
+  const resolved = resolveOriginsFromEnv(requestOrigin);
   return resolved.externalConfigured ? resolved.app : undefined;
 };
 
@@ -581,7 +597,9 @@ export const configuredAppUrl = (): string | undefined => {
  * origin the request arrived on. A configured external URL answering here is
  * what pins OAuth redirect URIs without a separate `API_URL` line.
  */
-export const configuredApiUrl = (): string | undefined => {
-  const resolved = resolveOriginsFromEnv();
+export const configuredApiUrl = (
+  requestOrigin?: string,
+): string | undefined => {
+  const resolved = resolveOriginsFromEnv(requestOrigin);
   return resolved.sources.api.source === "default" ? undefined : resolved.api;
 };


### PR DESCRIPTION
Fixes #496. Dynamically resolves apiHost/appUrl in getInstallInfo from the browser's request headers on self-hosted instances when no external URL is configured.