### PR TITLE
fix: nonce-based CSP, enterprise-default E2E suites, chat-first onboarding

### DIFF
--- a/.github/workflows/ci-cache-seed.yml
+++ b/.github/workflows/ci-cache-seed.yml
@@ -2,7 +2,7 @@ name: CI cache seed
 
 # ci.yml runs only on pull_request, and GitHub scopes PR-written caches to
 # the writing PR's merge ref — so nothing ever seeds a cache a NEW PR can
-# restore, and every fresh PR's rust + hosted-e2e lanes recompile the
+# restore, and every fresh PR's unit-rust + e2e lanes recompile the
 # gateway from zero (~14 min each, measured). Base- and default-branch
 # caches are readable by every PR, so this workflow does one warm build per
 # merge and the PR lanes restore from it: the rust caches via the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,15 @@ name: CI
 # dev repo, but each repo owns its own CI. Job shapes deliberately mirror the
 # upstream ci.yml that runs on the SAME tree, so a change that is green
 # upstream stays green here.
+#
+# The test topology is deliberate: many fast UNIT checks (pure logic plus
+# integration-grade suites against throwaway Postgres containers) and exactly
+# ONE end-to-end check, which runs the ENTERPRISE edition — an entitled
+# self-host (EDITION=onprem + ENTERPRISE_ENABLED=true) with the licensed
+# Redis-backed HA stores and real Postgres. Cloud-only wire behavior keeps a
+# thin per-test cloud arm inside that same check (see
+# apps/gateway-e2e/README.md); the TS↔Rust KMS envelope contract is pinned at
+# unit level on both sides (kms-crypto.contract.test.ts / kms_crypto.rs).
 
 on:
   pull_request:
@@ -29,205 +38,6 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
-  rust:
-    name: Rust
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Check for changes
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            rust:
-              - 'apps/gateway/**'
-              # The black-box E2E suite lives outside apps/gateway, so without
-              # this its own changes would never run it.
-              - 'apps/gateway-e2e/**'
-              # The gateway's DB integration tests read these tables via raw SQL
-              # (not compile-checked), so a schema change must re-run them to
-              # catch drift.
-              - 'packages/db/prisma/**'
-              # The gateway enforce tests read fixtures written by this seeder;
-              # a change to it must re-run them.
-              - 'packages/api/src/ee/testing/**'
-              # The E2E suite is the only guard on the TS↔Rust KMS envelope
-              # contract: TypeScript writes the ciphertext, the Rust gateway
-              # decrypts it. A change to the encryptor must re-run it.
-              - 'packages/api/src/ee/kms-crypto.ts'
-              # The session-cookie E2E is the only guard on the TS↔Rust cookie
-              # contract: TypeScript issues the cookie, the Rust gateway
-              # validates it. A change to either must re-run it.
-              - 'packages/api/src/lib/better-auth.ts'
-              - 'packages/api/src/lib/better-auth-contract.ts'
-              # The golden corpus + TS evaluator are byte-shared with two Rust
-              # consumers (corpus_test.rs, oss_parity_test.rs); a corpus-only
-              # change must re-run them or the count pins detonate on the next
-              # unrelated rust-touching PR.
-              - 'packages/api/src/services/policy-translation/**'
-              - '.github/workflows/ci.yml'
-
-      - name: Setup Node.js
-        if: steps.changes.outputs.rust == 'true'
-        uses: ./.github/actions/setup-node
-
-      - name: Setup Rust
-        if: steps.changes.outputs.rust == 'true'
-        uses: dtolnay/rust-toolchain@stable
-
-      # `shared-key` puts every lane in one cache family: this job writes it,
-      # the hosted-e2e job restores it, and the optional ci-cache-seed
-      # workflow (see the commented block at the bottom of this file) keeps it
-      # warm across PRs. Without a main-branch seeder, the first run of each
-      # PR compiles the gateway cold (~14 min).
-      - name: Cache Rust
-        if: steps.changes.outputs.rust == 'true'
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/gateway -> target
-          shared-key: gateway-debug
-
-      - name: Clippy
-        if: steps.changes.outputs.rust == 'true'
-        run: pnpm --filter @onecli/gateway check-types
-
-      - name: Format
-        if: steps.changes.outputs.rust == 'true'
-        run: pnpm --filter @onecli/gateway lint
-
-      # The cloud edition's workspace-key usage recheck (db.rs `user_can_manage_workspace`)
-      # is exercised by DB integration tests that need a real Postgres.
-      - name: Start Postgres for gateway DB tests
-        if: steps.changes.outputs.rust == 'true'
-        run: |
-          # max_connections is raised for the E2E suite below: every test there
-          # holds its own gateway pool (up to 5) plus a Prisma client.
-          docker run -d --name gw-test-db \
-            -e POSTGRES_USER=ci -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=onecli \
-            -p 5434:5432 postgres:18-alpine -c max_connections=200
-          # Start the two E2E containers here rather than at their readiness
-          # steps further down. `docker run -d` still blocks on the image pull,
-          # so the pull itself does NOT overlap the cargo build — what this buys
-          # is having Redis and MiniStack finish *initialising* while the test
-          # lanes run, so their readiness probes below return immediately.
-          docker run -d --name gw-test-redis -p 6379:6379 redis:7-alpine
-          docker run -d --name gw-test-kms -p 4566:4566 \
-            ministackorg/ministack@sha256:c3c2e86f19ff8024aca7488fd0827e2d66117effca0b0c9553088d68d9556a86
-          # Probe over TCP (-h localhost), not the container's Unix socket: the
-          # image reports socket-ready during its init phase, before the TCP
-          # listener and the onecli DB exist — which would flake migrate deploy.
-          for _ in $(seq 30); do
-            docker exec gw-test-db pg_isready -h localhost -U ci -d onecli && break
-            sleep 1
-          done
-          pnpm --filter @onecli/db exec prisma migrate deploy
-          # The E2E suite clones a private database per test from this template,
-          # so migrations run once rather than per test. Provisioned here, next
-          # to the migrate above, so a broken migration fails the job in seconds
-          # instead of after the ~15-minute cargo test matrix.
-          docker exec gw-test-db psql -U ci -d onecli -v ON_ERROR_STOP=1 \
-            -c 'CREATE DATABASE onecli_e2e_template'
-          DATABASE_URL=postgresql://ci:ci@127.0.0.1:5434/onecli_e2e_template \
-            pnpm --filter @onecli/db exec prisma migrate deploy
-        env:
-          DATABASE_URL: postgresql://ci:ci@localhost:5434/onecli
-
-      # Seed the fixtures the EE enforce tests read
-      # (apps/gateway/src/policy_engine/enforce_pg_test.rs). Type-safe via the
-      # generated @onecli/db client; runs against the same gw-test-db as the tests.
-      - name: Seed gateway enforce fixtures
-        if: steps.changes.outputs.rust == 'true'
-        run: pnpm --filter @onecli/api-server exec tsx ../../packages/api/src/ee/testing/gateway-enforce-seed.ts
-        env:
-          DATABASE_URL: postgresql://ci:ci@localhost:5434/onecli
-
-      - name: Test
-        if: steps.changes.outputs.rust == 'true'
-        run: pnpm --filter @onecli/gateway test
-        env:
-          GATEWAY_TEST_DATABASE_URL: postgresql://ci:ci@localhost:5434/onecli
-
-      # ── Black-box E2E ──────────────────────────────────────────────────────
-      # Extra steps in THIS job rather than a job of their own: they reuse the
-      # warm cargo cache, the Postgres already running above, and Node from the
-      # setup step. See apps/gateway-e2e/README.md.
-
-      # The cloud edition connects to Redis unconditionally at startup — both
-      # the cache store and the approval store require it, and the in-crate
-      # #[cfg(test)] fallback does not apply to a spawned binary.
-      - name: Wait for Redis
-        if: steps.changes.outputs.rust == 'true'
-        run: |
-          for _ in $(seq 30); do
-            docker exec gw-test-redis redis-cli ping 2>/dev/null | grep -q PONG && break
-            sleep 1
-          done
-          # Assert rather than hope: a probe that only times out would resurface
-          # later as an unrelated-looking gateway boot failure.
-          docker exec gw-test-redis redis-cli ping | grep -q PONG
-
-      # KMS emulator. MiniStack (MIT), not LocalStack — its Community edition
-      # was discontinued in March 2026 and the remaining free tier is
-      # non-commercial only. Pinned by digest: `latest` on a credential-handling
-      # emulator is both a supply-chain and a reproducibility hazard.
-      #
-      # AWS_ENDPOINT_URL_KMS is all the production code needs to reach it —
-      # packages/api/src/ee/kms-crypto.ts and apps/gateway/src/ee/crypto.rs both
-      # pick it up unmodified.
-      - name: Wait for the KMS emulator and mint a key
-        if: steps.changes.outputs.rust == 'true'
-        run: |
-          # A functional probe, not a TCP one: in the AWS SDK an unreachable
-          # endpoint and a missing credential produce indistinguishable errors,
-          # so prove KMS actually answers before anything can misattribute it.
-          for _ in $(seq 30); do
-            aws --endpoint-url "$AWS_ENDPOINT_URL_KMS" kms list-keys >/dev/null 2>&1 && break
-            sleep 1
-          done
-          aws --endpoint-url "$AWS_ENDPOINT_URL_KMS" kms list-keys >/dev/null
-          # One key per run, shared by the fixtures (which mint envelopes) and
-          # the gateway (which decrypts them).
-          ARN=$(aws --endpoint-url "$AWS_ENDPOINT_URL_KMS" kms create-key \
-                  --description 'onecli gateway E2E' \
-                  --query KeyMetadata.Arn --output text)
-          echo "KMS_KEY_ARN=$ARN" >> "$GITHUB_ENV"
-        env:
-          # 127.0.0.1, never localhost: Node 17+ resolves localhost with
-          # verbatim DNS ordering and can answer ::1 first.
-          AWS_ENDPOINT_URL_KMS: http://127.0.0.1:4566
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: test
-          AWS_SECRET_ACCESS_KEY: test
-
-      # Built as its own step so a compile failure reports as a compile
-      # failure, not an E2E failure. One edition-less binary — the runtime
-      # EDITION env selects behavior.
-      - name: Build the gateway
-        if: steps.changes.outputs.rust == 'true'
-        run: cargo build --manifest-path apps/gateway/Cargo.toml --bin onecli-gateway
-
-      # Spawns the REAL binary (EDITION=cloud in the spawn env) per test against
-      # a freshly cloned database, a real Redis and a real KMS. Runs after the
-      # in-crate lane so a failure here is never misattributed to it.
-      - name: E2E (cloud edition)
-        if: steps.changes.outputs.rust == 'true'
-        run: pnpm --filter @onecli/gateway-e2e test:e2e:no-build
-        env:
-          GATEWAY_E2E_BIN: ${{ github.workspace }}/apps/gateway/target/debug/onecli-gateway
-          E2E_ADMIN_DATABASE_URL: postgresql://ci:ci@127.0.0.1:5434/postgres
-          E2E_TEMPLATE_DB: onecli_e2e_template
-          # Deliberately scoped to this step, never job-wide: the cache store keys
-          # its in-memory test fallback on REDIS_HOST being ABSENT, so a job-wide
-          # value would silently re-point the in-crate cargo lanes at this container.
-          E2E_REDIS_HOST: 127.0.0.1
-          E2E_REDIS_PORT: "6379"
-          AWS_ENDPOINT_URL_KMS: http://127.0.0.1:4566
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: test
-          AWS_SECRET_ACCESS_KEY: test
-
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
@@ -298,8 +108,8 @@ jobs:
           docker rm -f shadow-db
           exit $EXIT_CODE
 
-  test:
-    name: Test
+  unit-ts:
+    name: Unit (TS)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -312,7 +122,9 @@ jobs:
       # gateway does — the only level at which a "which rows land in which
       # generation" bug is visible. They skip when the URL is unset, so wiring it
       # here is what makes them a permanent guard rather than a local-only one.
-      - name: Start Postgres for the policy proof suites
+      # Integration-grade, but a UNIT concern: one process, one throwaway
+      # database, no spawned binaries — not the E2E lane.
+      - name: Start Postgres for the pg proof suites
         run: |
           docker run -d --name policy-proof-db \
             -e POSTGRES_USER=ci -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=onecli \
@@ -329,8 +141,15 @@ jobs:
       # script runs the whole package (src/licensing included), so the
       # `pnpm --filter @onecli/api test:licensing` subset needs no step of its
       # own — it runs here and again in the onprem lane below.
+      #
+      # `--filter` makes this a PNPM recursive run (not turbo). Its default
+      # workspace-concurrency (4) runs 4 vitest processes × up to 4 worker
+      # forks each on ubuntu-latest's 4 vCPUs — an oversubscription that has
+      # starved timing-sensitive tests (channel-adapter's SIGTERM-drain
+      # liveness test). Two suites at a time keeps every process responsive
+      # at negligible wall-clock cost.
       - name: Test
-        run: pnpm test --filter='!@onecli/gateway'
+        run: pnpm test --filter='!@onecli/gateway' --workspace-concurrency=2
         env:
           POLICY_PROOF_DATABASE_URL: postgresql://ci:ci@localhost:5440/onecli
 
@@ -348,18 +167,9 @@ jobs:
         env:
           POLICY_PROOF_DATABASE_URL: postgresql://ci:ci@localhost:5440/onecli
 
-  # The hosted-path black-box suite: real gateway binary, real api-server
-  # child, real runner, real sandbox containers from the agent image,
-  # per-test template-clone databases. Path-filtered like the rust job — it
-  # is the most expensive lane in this file — and carries an explicit timeout
-  # (a hung container wait must never ride the 6-hour default).
-  hosted-e2e:
-    name: Hosted E2E
+  unit-rust:
+    name: Unit (Rust)
     runs-on: ubuntu-latest
-    # 30 covers the cold path (measured 21-22m with no warm cache — the norm
-    # here until the ci-cache-seed workflow below is enabled; warm runs are
-    # ~8m). A timeout kill must stay distinguishable from a hung container.
-    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -369,56 +179,170 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            hosted:
+            rust:
+              - 'apps/gateway/**'
+              # The gateway's DB integration tests read these tables via raw SQL
+              # (not compile-checked), so a schema change must re-run them to
+              # catch drift.
+              - 'packages/db/prisma/**'
+              # The gateway enforce tests read fixtures written by this seeder;
+              # a change to it must re-run them.
+              - 'packages/api/src/ee/testing/**'
+              # The Rust half of the TS↔Rust KMS envelope contract include_str!s
+              # this fixture; a change to it must re-run the contract tests.
+              - 'packages/api/src/ee/kms-envelope.fixture.json'
+              # The golden corpus + TS evaluator are byte-shared with two Rust
+              # consumers (corpus_test.rs, oss_parity_test.rs); a corpus-only
+              # change must re-run them or the count pins detonate on the next
+              # unrelated rust-touching PR.
+              - 'packages/api/src/services/policy-translation/**'
+              - '.github/workflows/ci.yml'
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.rust == 'true'
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Rust
+        if: steps.changes.outputs.rust == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      # `shared-key` joins the cache family the ci-cache-seed workflow writes
+      # on every main merge — without it Swatinem keys per-job and a fresh
+      # PR starts cold (PR-written caches are invisible to other PRs).
+      - name: Cache Rust
+        if: steps.changes.outputs.rust == 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/gateway -> target
+          shared-key: gateway-debug
+
+      - name: Clippy
+        if: steps.changes.outputs.rust == 'true'
+        run: pnpm --filter @onecli/gateway check-types
+
+      - name: Format
+        if: steps.changes.outputs.rust == 'true'
+        run: pnpm --filter @onecli/gateway lint
+
+      # The workspace-key usage recheck (db.rs `user_can_manage_workspace`) and
+      # its licensed peers are exercised by DB integration tests that need a
+      # real Postgres. Integration-grade, but a UNIT concern: in-crate cargo
+      # tests against a throwaway database — not the E2E lane.
+      - name: Start Postgres for gateway DB tests
+        if: steps.changes.outputs.rust == 'true'
+        run: |
+          docker run -d --name gw-test-db \
+            -e POSTGRES_USER=ci -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=onecli \
+            -p 5434:5432 postgres:18-alpine
+          # Probe over TCP (-h localhost), not the container's Unix socket: the
+          # image reports socket-ready during its init phase, before the TCP
+          # listener and the onecli DB exist — which would flake migrate deploy.
+          for _ in $(seq 30); do
+            docker exec gw-test-db pg_isready -h localhost -U ci -d onecli && break
+            sleep 1
+          done
+          pnpm --filter @onecli/db exec prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://ci:ci@localhost:5434/onecli
+
+      # Seed the fixtures the EE enforce tests read
+      # (apps/gateway/src/policy_engine/enforce_pg_test.rs). Type-safe via the
+      # generated @onecli/db client; runs against the same gw-test-db as the tests.
+      - name: Seed gateway enforce fixtures
+        if: steps.changes.outputs.rust == 'true'
+        run: pnpm --filter @onecli/api-server exec tsx ../../packages/api/src/ee/testing/gateway-enforce-seed.ts
+        env:
+          DATABASE_URL: postgresql://ci:ci@localhost:5434/onecli
+
+      - name: Test
+        if: steps.changes.outputs.rust == 'true'
+        run: pnpm --filter @onecli/gateway test
+        env:
+          GATEWAY_TEST_DATABASE_URL: postgresql://ci:ci@localhost:5434/onecli
+
+  # ── The ONE end-to-end check: the enterprise edition, real Postgres ────────
+  #
+  # Both black-box suites in one job against one Postgres and one Redis:
+  # gateway-e2e (the proxy wire surface — spawns the real binary per test) and
+  # hosted-e2e (the hosted-agents spine — real api-server child, real runner,
+  # real sandbox containers from the agent image). The default spawn env for
+  # every child is the enterprise edition; the unlicensed and cloud arms live
+  # INSIDE the suites as per-test env overrides, so this single check covers
+  # entitled, unlicensed, and cloud wire behavior without a second lane.
+  #
+  # Path-filtered — it is the most expensive check in this file — and
+  # explicitly timed out (a hung container wait must never ride the 6-hour
+  # default).
+  e2e:
+    name: E2E (enterprise)
+    runs-on: ubuntu-latest
+    # Covers the cold path (no seeded cache — the gateway compile dominates);
+    # warm runs land well under half of this. A timeout kill must stay
+    # distinguishable from a hung container.
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check for changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            e2e:
+              - 'apps/gateway-e2e/**'
               - 'apps/hosted-e2e/**'
+              - 'apps/gateway/**'
               - 'apps/runner/**'
               - 'apps/sandbox-supervisor/**'
-              - 'apps/gateway/**'
-              # The suite spawns apps/api-server/src/index.ts as its
-              # api-server child, so its own changes must re-run it.
+              # Both suites lean on the API package: gateway-e2e seeds through
+              # its services, and the control plane IS half of hosted-e2e's
+              # subject (dispatch, doors, fences, the spawn-env contract, which
+              # apps/api-server serves as the spawned child).
               - 'apps/api-server/**'
-              - 'packages/agent-protocol/**'
-              # The control plane IS half the suite's subject: dispatch,
-              # doors, fences, the spawn-env contract.
               - 'packages/api/**'
+              - 'packages/agent-protocol/**'
               - 'packages/db/prisma/**'
               - 'docker/agent.Dockerfile'
               - 'docker/agent-entrypoint.sh'
               - '.github/workflows/ci.yml'
 
-      - name: Setup Node
-        if: steps.changes.outputs.hosted == 'true'
+      - name: Setup Node.js
+        if: steps.changes.outputs.e2e == 'true'
         uses: ./.github/actions/setup-node
 
-      - name: Install Rust
-        if: steps.changes.outputs.hosted == 'true'
+      - name: Setup Rust
+        if: steps.changes.outputs.e2e == 'true'
         uses: dtolnay/rust-toolchain@stable
 
-      # Same shared-key as the rust job (and the optional seed workflow), so
-      # this lane restores an existing build instead of recompiling cold
-      # (~14 min, the job's dominant cost). Consume-only: the rust job and
-      # the seeder own the writes.
-      - name: Cache cargo
-        if: steps.changes.outputs.hosted == 'true'
+      # Same shared-key as the unit-rust job and the ci-cache-seed workflow,
+      # so this lane restores the seeded build instead of recompiling cold
+      # (~14 min, the job's dominant cost). Consume-only: the unit-rust job
+      # and the seeder own the writes.
+      - name: Cache Rust
+        if: steps.changes.outputs.e2e == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/gateway -> target
           shared-key: gateway-debug
           save-if: "false"
 
+      # Built as its own step so a compile failure reports as a compile
+      # failure, not an E2E failure. One edition-less binary — the runtime
+      # env in each suite's spawn selects behavior.
       - name: Build the gateway
-        if: steps.changes.outputs.hosted == 'true'
+        if: steps.changes.outputs.e2e == 'true'
         run: cargo build --manifest-path apps/gateway/Cargo.toml --bin onecli-gateway
 
       - name: Set up Docker Buildx
-        if: steps.changes.outputs.hosted == 'true'
+        if: steps.changes.outputs.e2e == 'true'
         uses: docker/setup-buildx-action@v4
 
       # The one image with a network download in its build (the vendored
       # jcode runtime) — the gha cache is what keeps warm runs inside the
       # timeout. Scope deliberately distinct from publish.yml's.
       - name: Build the agent image
-        if: steps.changes.outputs.hosted == 'true'
+        if: steps.changes.outputs.e2e == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -428,29 +352,63 @@ jobs:
           cache-from: type=gha,scope=ci-agent
           cache-to: type=gha,mode=max,scope=ci-agent
 
-      - name: Start Postgres
-        if: steps.changes.outputs.hosted == 'true'
+      # One Postgres, two template databases (one per suite — their sweeps and
+      # clone prefixes are independent), one Redis for the licensed HA stores.
+      # max_connections is raised because every gateway-e2e test holds its own
+      # gateway pool (up to 5) plus a Prisma client, across parallel forks.
+      - name: Start Postgres and Redis
+        if: steps.changes.outputs.e2e == 'true'
         run: |
-          docker run -d --name he2e-postgres \
+          docker run -d --name e2e-postgres \
             -e POSTGRES_USER=ci -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=postgres \
-            -p 5435:5432 postgres:18-alpine -c max_connections=200
-          for i in $(seq 1 30); do
-            pg_isready -h localhost -p 5435 -U ci && break
+            -p 5434:5432 postgres:18-alpine -c max_connections=200
+          docker run -d --name e2e-redis -p 6379:6379 redis:7-alpine
+          # Probe over TCP (-h localhost), not the container's Unix socket: the
+          # image reports socket-ready during its init phase, before the TCP
+          # listener exists — which would flake the CREATE DATABASE below.
+          for _ in $(seq 30); do
+            docker exec e2e-postgres pg_isready -h localhost -U ci -d postgres && break
             sleep 1
           done
-
-      - name: Migrate the template database
-        if: steps.changes.outputs.hosted == 'true'
-        run: |
-          docker exec he2e-postgres psql -U ci -d postgres -c 'CREATE DATABASE onecli_he2e_template'
-          DATABASE_URL=postgresql://ci:ci@localhost:5435/onecli_he2e_template \
+          docker exec e2e-postgres psql -U ci -d postgres -v ON_ERROR_STOP=1 \
+            -c 'CREATE DATABASE onecli_e2e_template' \
+            -c 'CREATE DATABASE onecli_he2e_template'
+          DATABASE_URL=postgresql://ci:ci@127.0.0.1:5434/onecli_e2e_template \
             pnpm --filter @onecli/db exec prisma migrate deploy
+          DATABASE_URL=postgresql://ci:ci@127.0.0.1:5434/onecli_he2e_template \
+            pnpm --filter @onecli/db exec prisma migrate deploy
+          # Assert rather than hope: a Redis probe that only times out would
+          # resurface later as an unrelated-looking gateway boot failure.
+          for _ in $(seq 30); do
+            docker exec e2e-redis redis-cli ping 2>/dev/null | grep -q PONG && break
+            sleep 1
+          done
+          docker exec e2e-redis redis-cli ping | grep -q PONG
 
-      - name: Hosted E2E (deep lane)
-        if: steps.changes.outputs.hosted == 'true'
+      # Spawns the REAL binary per test (enterprise edition in the spawn env)
+      # against a freshly cloned database and a real Redis. 127.0.0.1, never
+      # localhost: Node 17+ resolves localhost with verbatim DNS ordering and
+      # can answer ::1 first.
+      - name: Gateway E2E
+        if: steps.changes.outputs.e2e == 'true'
+        run: pnpm --filter @onecli/gateway-e2e test:e2e:no-build
+        env:
+          GATEWAY_E2E_BIN: ${{ github.workspace }}/apps/gateway/target/debug/onecli-gateway
+          E2E_ADMIN_DATABASE_URL: postgresql://ci:ci@127.0.0.1:5434/postgres
+          E2E_TEMPLATE_DB: onecli_e2e_template
+          E2E_REDIS_HOST: 127.0.0.1
+          E2E_REDIS_PORT: "6379"
+
+      # The hosted-agents spine on the same infrastructure: real api-server
+      # child, real runner, real sandbox containers. Runs after gateway-e2e so
+      # a proxy-surface failure is never misattributed to the hosted path.
+      - name: Hosted E2E
+        if: steps.changes.outputs.e2e == 'true'
         run: pnpm --filter @onecli/hosted-e2e test:e2e:no-build
         env:
-          E2E_ADMIN_DATABASE_URL: postgresql://ci:ci@localhost:5435/postgres
+          E2E_ADMIN_DATABASE_URL: postgresql://ci:ci@127.0.0.1:5434/postgres
           E2E_TEMPLATE_DB: onecli_he2e_template
           E2E_GATEWAY_BIN: ${{ github.workspace }}/apps/gateway/target/debug/onecli-gateway
           E2E_AGENT_IMAGE: onecli-agent:ci
+          E2E_REDIS_HOST: 127.0.0.1
+          E2E_REDIS_PORT: "6379"

--- a/apps/gateway-e2e/README.md
+++ b/apps/gateway-e2e/README.md
@@ -12,15 +12,32 @@ move essentially every file in it. A suite coupled to internals would break duri
 and protect nothing; a suite that only knows the wire protocol survives it and is exactly the
 regression net the restructure needs.
 
-## Why cloud edition only
+## The edition model: enterprise by default, arms per lane
 
-The suite spawns the one edition-less binary with `EDITION=cloud`. That edition uses Redis for its cache and
-approval stores and KMS for secret decryption, so the tests need both — which is also what
-makes them faithful to what actually runs in production.
+The binary is edition-less; the runtime env selects behavior. The suite's default spawn env
+is the **enterprise edition** — an entitled self-host (`EDITION=onprem` +
+`ENTERPRISE_ENABLED=true`) running the **licensed Redis-backed HA stores** (`REDIS_HOST`
+set) and the local AES crypto backend (`SECRET_ENCRYPTION_KEY`, pinned by
+`vitest.config.ts`). That is the canonical licensed deployment, and it exercises the
+entitled feature set (group principals, resource scoping, budgets, RBAC rechecks, HA
+stores) that a plain self-host never runs.
+
+Two lanes override it per test:
+
+- **The unlicensed lane** (`unlicensed.test.ts`) blanks `ENTERPRISE_ENABLED` and
+  `REDIS_HOST` and proves the decided flag-off posture from the outside — licensed features
+  get a differential twin (same seeds, opposite outcome), free surfaces get parity twins.
+- **The cloud lane** (`platform-llm.test.ts`) sets `EDITION=cloud` and covers cloud-only
+  wire behavior: the platform Anthropic trial credit and the cloud boot posture. The
+  Cognito/KMS values it sets are dummies satisfying the cloud fail-fast — never dialed
+  (sessions stay on agent tokens; the pinned `SECRET_ENCRYPTION_KEY` selects local AES by
+  config precedence). The KMS envelope FORMAT itself is unit-pinned on both sides of the
+  TS↔Rust contract (`packages/api/src/ee/kms-crypto.contract.test.ts`,
+  `apps/gateway/src/ee/kms_crypto.rs`); only the live AWS KMS call is proven by deploys.
 
 ## Running locally
 
-Three containers, then migrate, then run. Use `127.0.0.1` throughout, never `localhost`:
+Two containers, then migrate, then run. Use `127.0.0.1` throughout, never `localhost`:
 Node 17+ resolves `localhost` with `verbatim` DNS ordering and can answer `::1` first, which
 fails to connect while other clients on the same host succeed.
 
@@ -31,22 +48,16 @@ docker run -d --name gwe2e-db -p 5434:5432 \
   -e POSTGRES_USER=ci -e POSTGRES_PASSWORD=ci -e POSTGRES_DB=onecli \
   postgres:18-alpine -c max_connections=200
 
-# 2. Redis — the cloud edition connects to it unconditionally at startup.
+# 2. Redis — the enterprise lane runs the licensed Redis-backed stores.
 docker run -d --name gwe2e-redis -p 6379:6379 redis:7-alpine
 
-# 3. KMS emulator. MiniStack, not LocalStack (whose Community edition was
-#    discontinued and whose free tier is non-commercial only). Pinned by digest
-#    to match CI exactly — keep this in step with .github/workflows/ci.yml.
-docker run -d --name gwe2e-kms -p 4566:4566 \
-  ministackorg/ministack@sha256:c3c2e86f19ff8024aca7488fd0827e2d66117effca0b0c9553088d68d9556a86
-
-# 4. Create and migrate the template database the tests clone per test.
+# 3. Create and migrate the template database the tests clone per test.
 docker exec gwe2e-db psql -U ci -d onecli -c 'CREATE DATABASE onecli_e2e_template'
 DATABASE_URL=postgresql://ci:ci@127.0.0.1:5434/onecli_e2e_template \
   pnpm --filter @onecli/db exec prisma migrate deploy
 
-# 5. Run. `test:e2e` builds the gateway binary (spawned with EDITION=cloud) first; use
-#    `test:e2e:no-build` to skip that when the binary is already current.
+# 4. Run. `test:e2e` builds the gateway binary first; use `test:e2e:no-build`
+#    to skip that when the binary is already current.
 #
 #    The script is deliberately NOT called `test`: the root `pnpm test` runs
 #    `turbo run test`, and this suite must not drag containers and a cargo build
@@ -54,14 +65,10 @@ DATABASE_URL=postgresql://ci:ci@127.0.0.1:5434/onecli_e2e_template \
 export E2E_ADMIN_DATABASE_URL=postgresql://ci:ci@127.0.0.1:5434/postgres
 export E2E_TEMPLATE_DB=onecli_e2e_template
 export E2E_REDIS_HOST=127.0.0.1
-export AWS_ENDPOINT_URL_KMS=http://127.0.0.1:4566
-export AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test
-export KMS_KEY_ARN=$(aws --endpoint-url http://127.0.0.1:4566 kms create-key \
-                      --query KeyMetadata.Arn --output text)
 pnpm --filter @onecli/gateway-e2e test:e2e
 ```
 
-Teardown: `docker rm -f gwe2e-db gwe2e-redis gwe2e-kms`.
+Teardown: `docker rm -f gwe2e-db gwe2e-redis`.
 
 ## Isolation
 
@@ -118,6 +125,9 @@ Known gaps, all deliberate:
   resolution outcomes (ambiguity, not-found) are covered instead, since they answer before any
   socket opens.
 - **No approval timeout.** It is 180 seconds.
+- **No live KMS decryption.** The KMS backend is hosted-cloud plumbing; its envelope format
+  is unit-pinned cross-language (see above), and the live AWS round-trip is proven by cloud
+  deploys, not this suite.
 
 Tests that name a real provider hostname (`gmail.googleapis.com`) still make no network calls:
 they assert an arm that answers before egress. Where a test needs a host that must _never_
@@ -151,11 +161,11 @@ The gateway's captured stdout and stderr are attached to failures. It runs with
 
 The suite imports no gateway code, but it does read a few things out of the
 gateway's **structured log**: the `starting onecli-gateway` line (to confirm the
-binary really is a cloud-edition build), the `listening for connections` line's
-`addr` field (to discover the port chosen by `--port 0`), and — in
-`shutdown.test.ts` only — the `shutdown started` and `drain complete` messages,
-which pin that a signal starts a real drain rather than the process merely
-dying. It runs the child with `LOG_FORMAT=json` for exactly this reason.
+binary really booted the edition the test meant to start), the `listening for
+connections` line's `addr` field (to discover the port chosen by `--port 0`),
+and — in `shutdown.test.ts` only — the `shutdown started` and `drain complete`
+messages, which pin that a signal starts a real drain rather than the process
+merely dying. It runs the child with `LOG_FORMAT=json` for exactly this reason.
 
 That is the whole interface. Renaming any of these messages, dropping the `addr`
 field, or changing the `edition` value will break the suite in a way that looks

--- a/apps/gateway-e2e/src/binary.ts
+++ b/apps/gateway-e2e/src/binary.ts
@@ -60,8 +60,8 @@ export const gatewayBinary = (): string => {
  * the variable the gateway would silently run as the other edition — different
  * workspace resolution, different key rechecks — and the failures would look
  * like anything but the real cause, so assert the boot line reports what the
- * test meant to start (the suite default is Cloud; the unlicensed lane opts
- * into Onprem).
+ * test meant to start (the suite default is Onprem — the enterprise lane; the
+ * cloud lane opts into Cloud).
  */
 export const assertEdition = (
   bootLine: Readonly<Record<string, unknown>>,

--- a/apps/gateway-e2e/src/env.ts
+++ b/apps/gateway-e2e/src/env.ts
@@ -22,9 +22,6 @@ export interface E2EConfig {
   readonly templateDb: string;
   readonly redisHost: string;
   readonly redisPort: string;
-  readonly kmsEndpoint: string;
-  readonly kmsKeyArn: string;
-  readonly awsRegion: string;
 }
 
 const read = (name: string): string | undefined => {
@@ -38,9 +35,7 @@ const WHY: Readonly<Record<string, string>> = {
     "the maintenance connection used to clone a database per test",
   E2E_TEMPLATE_DB: "the migrated template database each test clones",
   E2E_REDIS_HOST:
-    "the cloud edition connects to Redis unconditionally at startup",
-  AWS_ENDPOINT_URL_KMS: "the KMS emulator the gateway decrypts secrets against",
-  KMS_KEY_ARN: "the key used to mint credential fixtures",
+    "the enterprise lane runs the licensed Redis-backed stores (HA is licensed)",
 };
 
 const resolve = (): E2EConfig | null => {
@@ -49,15 +44,11 @@ const resolve = (): E2EConfig | null => {
   const adminDatabaseUrl = read("E2E_ADMIN_DATABASE_URL");
   const templateDb = read("E2E_TEMPLATE_DB");
   const redisHost = read("E2E_REDIS_HOST");
-  const kmsEndpoint = read("AWS_ENDPOINT_URL_KMS");
-  const kmsKeyArn = read("KMS_KEY_ARN");
 
   const missing = Object.entries({
     E2E_ADMIN_DATABASE_URL: adminDatabaseUrl,
     E2E_TEMPLATE_DB: templateDb,
     E2E_REDIS_HOST: redisHost,
-    AWS_ENDPOINT_URL_KMS: kmsEndpoint,
-    KMS_KEY_ARN: kmsKeyArn,
   })
     .filter(([, value]) => value === undefined)
     .map(([name]) => name);
@@ -65,9 +56,7 @@ const resolve = (): E2EConfig | null => {
   if (
     adminDatabaseUrl === undefined ||
     templateDb === undefined ||
-    redisHost === undefined ||
-    kmsEndpoint === undefined ||
-    kmsKeyArn === undefined
+    redisHost === undefined
   ) {
     const first = missing[0] ?? "E2E_ADMIN_DATABASE_URL";
     if (process.env.CI !== undefined) {
@@ -87,9 +76,6 @@ const resolve = (): E2EConfig | null => {
     templateDb,
     redisHost,
     redisPort: read("E2E_REDIS_PORT") ?? "6379",
-    kmsEndpoint,
-    kmsKeyArn,
-    awsRegion: read("AWS_REGION") ?? "us-east-1",
   };
 };
 
@@ -99,4 +85,20 @@ let cached: E2EConfig | null | undefined;
 export const e2eConfig = (): E2EConfig | null => {
   if (cached === undefined) cached = resolve();
   return cached;
+};
+
+/**
+ * The shared symmetric key every process in a scenario encrypts/decrypts
+ * with — pinned by vitest.config.ts `test.env`, so the fixtures (this process)
+ * and the spawned gateway agree on it. A fixed test key, never a production
+ * value.
+ */
+export const secretEncryptionKey = (): string => {
+  const value = read("SECRET_ENCRYPTION_KEY");
+  if (value === undefined) {
+    throw new Error(
+      "SECRET_ENCRYPTION_KEY missing — vitest.config.ts pins it; run through vitest.",
+    );
+  }
+  return value;
 };

--- a/apps/gateway-e2e/src/fixtures.ts
+++ b/apps/gateway-e2e/src/fixtures.ts
@@ -1,4 +1,4 @@
-import { cryptoService } from "@onecli/api/ee/kms-crypto";
+import { cryptoService } from "@onecli/api/lib/crypto";
 import type { Prisma, PrismaClient } from "@prisma/client";
 
 import type { TestIds } from "./ids.js";
@@ -41,7 +41,8 @@ export interface InjectionSpec {
 export interface SecretSpec extends InjectionSpec {
   /** Host the credential is scoped to, e.g. `127.0.0.1`. */
   readonly hostPattern: string;
-  /** Plaintext. Stored as a REAL KMS envelope via the production crypto. */
+  /** Plaintext. Stored via the production local-AES encryptor (the enterprise
+   * self-host backend); the spawned gateway decrypts it with the same key. */
   readonly value: string;
   /**
    * Omitted means `"*"` — every path. `/a/*` is boundary-aware (matches `/a`
@@ -151,10 +152,10 @@ export interface RuleSpec {
 /**
  * A connected OAuth app.
  *
- * The credentials are a real KMS envelope but are never decrypted by the tests
- * that use this: they assert on resolution outcomes (ambiguity, not-found)
- * which are decided by grouping connections on `provider` and `id`, before any
- * credential is touched.
+ * The credentials are a real AES ciphertext but are never decrypted by the
+ * tests that use this: they assert on resolution outcomes (ambiguity,
+ * not-found) which are decided by grouping connections on `provider` and
+ * `id`, before any credential is touched.
  */
 export interface AppConnectionSpec {
   readonly provider: string;
@@ -407,9 +408,9 @@ export const addSecret = async (
       workspaceId: scope === "workspace" ? ids.workspace : null,
       organizationId: ids.org,
       valueSource: "inline",
-      // The production encryptor, against the same KMS the gateway decrypts
-      // with. This is what makes the TS→Rust envelope contract a real
-      // assertion rather than Rust agreeing with itself.
+      // The production encryptor, against the same AES key the gateway
+      // decrypts with. This is what makes the TS→Rust 3-part format contract
+      // a real assertion rather than Rust agreeing with itself.
       encryptedValue: await cryptoService.encrypt(secret.value),
       hostPattern: secret.hostPattern,
       pathPattern: secret.pathPattern ?? null,

--- a/apps/gateway-e2e/src/gateway.ts
+++ b/apps/gateway-e2e/src/gateway.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { assertEdition, gatewayBinary } from "./binary.js";
-import type { E2EConfig } from "./env.js";
+import { secretEncryptionKey, type E2EConfig } from "./env.js";
 
 /** How a gateway process ended, as observed from outside. */
 export interface GatewayExit {
@@ -69,8 +69,8 @@ export interface GatewayOptions {
   readonly dataDir?: string;
   /** Additional or overriding environment for this instance. */
   readonly env?: Readonly<Record<string, string>>;
-  /** The edition the boot line must report (default Cloud — the suite's
-   * standard lane; the unlicensed lane starts Onprem gateways). */
+  /** The edition the boot line must report (default Onprem — the suite's
+   * standard enterprise lane; the cloud lane starts Cloud gateways). */
   readonly expectedEdition?: "Cloud" | "Onprem";
 }
 
@@ -212,32 +212,31 @@ export const startGateway = async (
     opts.dataDir ?? mkdtempSync(join(tmpdir(), "onecli-gateway-e2e-"));
 
   // An explicit environment, never a `process.env` spread: a developer's local
-  // REDIS_PASSWORD, AWS_PROFILE or DATABASE_URL would otherwise silently change
-  // what is under test.
+  // REDIS_PASSWORD or DATABASE_URL would otherwise silently change what is
+  // under test.
   const env: Record<string, string> = {
     PATH: process.env.PATH ?? "",
     HOME: process.env.HOME ?? "",
-    // The binary is edition-less; the suite defaults to the cloud edition, so
-    // the runtime switch must reach the child (assertEdition guards it did —
-    // the unlicensed lane overrides EDITION and expects Onprem).
-    EDITION: "cloud",
-    // Cloud boots fail fast without a Cognito pool configured. The suite never
-    // authenticates Cognito sessions (agent tokens + API keys only), so the
-    // value is used lazily at most to build a JWKS URL that is never fetched.
-    COGNITO_USER_POOL_ID: "us-east-1_e2e",
+    // The binary is edition-less; the suite defaults to the ENTERPRISE
+    // edition — an entitled self-host (`EDITION=onprem` +
+    // `ENTERPRISE_ENABLED=true`), the canonical licensed deployment — so the
+    // runtime switch must reach the child (assertEdition guards it did; the
+    // unlicensed and cloud lanes override per test).
+    EDITION: "onprem",
+    ENTERPRISE_ENABLED: "true",
     DATABASE_URL: databaseUrl,
+    // The licensed HA stores: multi-instance operation is an entitled
+    // feature, and this lane is entitled — so it runs the Redis-backed cache
+    // and approval stores, not the in-memory fallback. (The unlicensed lane
+    // overrides REDIS_HOST to empty and runs in-memory.)
     REDIS_HOST: config.redisHost,
     REDIS_PORT: config.redisPort,
-    // The cloud default is rediss://; a plain container speaks TCP.
+    // The self-host default is plain TCP; a plain container speaks TCP.
     REDIS_TLS: "false",
-    AWS_ENDPOINT_URL_KMS: config.kmsEndpoint,
-    AWS_REGION: config.awsRegion,
-    AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ?? "test",
-    AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ?? "test",
-    // Without this the SDK's credential chain can stall for seconds looking for
-    // instance metadata that will never answer.
-    AWS_EC2_METADATA_DISABLED: "true",
-    KMS_KEY_ARN: config.kmsKeyArn,
+    // Local AES-256-GCM — the self-host crypto backend. The fixtures encrypt
+    // with the same key (vitest pins it), which is what keeps the TS→Rust
+    // 3-part format a real cross-language assertion.
+    SECRET_ENCRYPTION_KEY: secretEncryptionKey(),
     // Host-scoped, matched against the port-stripped host — narrower than the
     // global GATEWAY_DANGER_ACCEPT_INVALID_CERTS, so only the stub is exempt.
     GATEWAY_SKIP_VERIFY_HOSTS: "127.0.0.1",
@@ -322,7 +321,7 @@ export const startGateway = async (
       "gateway never logged its startup line, so its edition could not be verified",
     );
   }
-  assertEdition(startLine, opts.expectedEdition ?? "Cloud");
+  assertEdition(startLine, opts.expectedEdition ?? "Onprem");
 
   const addr = bootLine["addr"];
   if (typeof addr !== "string") {

--- a/apps/gateway-e2e/tests/inject.test.ts
+++ b/apps/gateway-e2e/tests/inject.test.ts
@@ -26,7 +26,7 @@ describe("credential injection", () => {
       expect(res.status).toBe(200);
       const [seen] = await upstream.waitForRequests(1);
       // The whole product in one assertion: a credential the client never had
-      // arrived at the upstream, decrypted from a real KMS envelope.
+      // arrived at the upstream, decrypted from a real stored ciphertext.
       expect(seen?.header("x-test-key")).toBe(SECRET);
     },
   );

--- a/apps/gateway-e2e/tests/platform-llm.test.ts
+++ b/apps/gateway-e2e/tests/platform-llm.test.ts
@@ -6,6 +6,14 @@ import { throughProxy } from "../src/proxy.js";
 /**
  * The platform Anthropic trial credit (`ee/platform_llm.rs`), black-box.
  *
+ * THE cloud arm of the suite: the trial credit is cloud-only wire behavior
+ * (`parse` returns None off-cloud), so these scenarios override the harness's
+ * enterprise default with `EDITION=cloud` — which also pins the cloud boot
+ * posture end to end (the fail-fast wants Cognito/Redis/KMS configured; the
+ * dummies below satisfy it, and neither is ever dialed: sessions stay on
+ * agent tokens, and the harness's SECRET_ENCRYPTION_KEY selects the local
+ * AES crypto backend by config precedence).
+ *
  * The binary runs with `PLATFORM_ANTHROPIC_API_KEY` set and the injection
  * host overridden to the local stub (`PLATFORM_ANTHROPIC_API_HOST` —
  * production resolves api.anthropic.com). What these prove end to end:
@@ -23,17 +31,30 @@ import { throughProxy } from "../src/proxy.js";
 
 const PLATFORM_KEY = "sk-ant-api03-platform-e2e";
 
+/** The cloud spawn env, layered per scenario (some drop the platform key). */
+const CLOUD_ENV = {
+  EDITION: "cloud",
+  COGNITO_USER_POOL_ID: "us-east-1_e2e",
+  KMS_KEY_ARN: "arn:aws:kms:us-east-1:000000000000:key/e2e-never-dialed",
+} as const;
+
+const CLOUD = { env: CLOUD_ENV, expectedEdition: "Cloud" } as const;
+
 const platformEnv = {
+  ...CLOUD_ENV,
   PLATFORM_ANTHROPIC_API_KEY: PLATFORM_KEY,
   // The e2e upstreams live on 127.0.0.1; production leaves this unset.
   PLATFORM_ANTHROPIC_API_HOST: "127.0.0.1",
 } as const;
 
-describe("platform trial credit", () => {
+describe("platform trial credit (cloud edition)", () => {
   scenario("injects the platform key for a keyless org", async (cx) => {
     const upstream = await cx.upstream();
     await cx.seed(); // no secrets, no grants — a brand-new user's world
-    const gw = await cx.startGateway({ env: platformEnv });
+    const gw = await cx.startGateway({
+      env: platformEnv,
+      expectedEdition: "Cloud",
+    });
 
     const res = await throughProxy(gw.origin, {
       url: upstream.url("/v1/messages"),
@@ -52,7 +73,7 @@ describe("platform trial credit", () => {
   scenario("does not inject without the env key", async (cx) => {
     const upstream = await cx.upstream();
     await cx.seed();
-    const gw = await cx.startGateway(); // no PLATFORM_ANTHROPIC_API_KEY
+    const gw = await cx.startGateway(CLOUD); // no PLATFORM_ANTHROPIC_API_KEY
 
     await throughProxy(gw.origin, {
       url: upstream.url("/v1/messages"),
@@ -72,7 +93,8 @@ describe("platform trial credit", () => {
       const upstream = await cx.upstream();
       await cx.seed();
       const gw = await cx.startGateway({
-        env: { PLATFORM_ANTHROPIC_API_KEY: PLATFORM_KEY },
+        env: { ...CLOUD_ENV, PLATFORM_ANTHROPIC_API_KEY: PLATFORM_KEY },
+        expectedEdition: "Cloud",
       });
 
       await throughProxy(gw.origin, {
@@ -97,7 +119,10 @@ describe("platform trial credit", () => {
           { type: "openai", hostPattern: "api.openai.com", value: "sk-own" },
         ],
       });
-      const gw = await cx.startGateway({ env: platformEnv });
+      const gw = await cx.startGateway({
+        env: platformEnv,
+        expectedEdition: "Cloud",
+      });
 
       await throughProxy(gw.origin, {
         url: upstream.url("/v1/messages"),
@@ -128,7 +153,10 @@ describe("platform trial credit", () => {
           spentNanos: 5_000_000_000n,
         },
       });
-      const gw = await cx.startGateway({ env: platformEnv });
+      const gw = await cx.startGateway({
+        env: platformEnv,
+        expectedEdition: "Cloud",
+      });
 
       const res = await throughProxy(gw.origin, {
         url: upstream.url("/v1/messages"),
@@ -182,7 +210,10 @@ describe("platform trial credit", () => {
           spentNanos: 5_000_000_000n,
         },
       });
-      const gw = await cx.startGateway({ env: platformEnv });
+      const gw = await cx.startGateway({
+        env: platformEnv,
+        expectedEdition: "Cloud",
+      });
 
       const res = await throughProxy(gw.origin, {
         url: upstream.url("/v1/messages"),

--- a/apps/gateway-e2e/tests/session-cookie.test.ts
+++ b/apps/gateway-e2e/tests/session-cookie.test.ts
@@ -24,16 +24,13 @@ import type { Cx } from "../src/scenario.js";
 const SECRET = "e2e-better-auth-secret-e2e-better-auth-secret";
 const PASSWORD = "correct horse battery staple";
 
-/** The gateway serves session cookies only on a self-hosted deployment. */
+/** The gateway serves session cookies only on a self-hosted deployment.
+ * The harness default IS the self-host edition now; what these scenarios add
+ * is the shared cookie secret (and in-memory stores — the session arm needs
+ * no Redis, and one lane deliberately proves it without). */
 const ONPREM_SESSION = {
   expectedEdition: "Onprem",
   env: {
-    EDITION: "onprem",
-    // The edition routes sessions to the cookie arm; the empty pool id only
-    // mirrors a real self-host env (the stray-pool-id scenario keeps it set).
-    COGNITO_USER_POOL_ID: "",
-    // Multi-instance operation is licensed; the unlicensed boot must run on
-    // the in-memory stores.
     REDIS_HOST: "",
     // The same secret the cookie is signed with: one shared value is the
     // whole basis for the gateway trusting a cookie it did not issue.
@@ -107,14 +104,14 @@ describe("self-hosted session cookies at the gateway", () => {
     async (cx) => {
       await cx.seed({ withApiKey: true });
 
-      // EDITION=onprem with the harness default COGNITO_USER_POOL_ID kept: a
-      // shared self-host .env can carry a pool id it never uses, and the
-      // session cookie must still validate. The selector is the edition, not
-      // config presence; before the edition gate this request 401'd.
+      // EDITION=onprem with a STRAY COGNITO_USER_POOL_ID set: a shared
+      // self-host .env can carry a pool id it never uses, and the session
+      // cookie must still validate. The selector is the edition, not config
+      // presence; before the edition gate this request 401'd.
       const gw = await cx.startGateway({
         expectedEdition: "Onprem",
         env: {
-          EDITION: "onprem",
+          COGNITO_USER_POOL_ID: "us-east-1_e2e",
           REDIS_HOST: "",
           BETTER_AUTH_SECRET: SECRET,
         },
@@ -200,8 +197,6 @@ describe("self-hosted session cookies at the gateway", () => {
     const gw = await cx.startGateway({
       expectedEdition: "Onprem",
       env: {
-        EDITION: "onprem",
-        COGNITO_USER_POOL_ID: "",
         REDIS_HOST: "",
         BETTER_AUTH_SECRET: "",
       },

--- a/apps/gateway-e2e/tests/unlicensed.test.ts
+++ b/apps/gateway-e2e/tests/unlicensed.test.ts
@@ -12,20 +12,20 @@ import { scenario } from "../src/scenario.js";
 // outcome); org credentials are FREE, so their scenarios are parity twins —
 // the license flag must change nothing.
 
-/** Unlicensed onprem: overrides the harness's cloud spawn env. */
+/** Unlicensed onprem: overrides the harness's enterprise spawn env. */
 const UNLICENSED = {
   env: {
-    EDITION: "onprem",
-    // The scenarios authenticate with agent tokens and `oc_` API keys only;
-    // the edition keeps sessions on the cookie arm regardless of this var.
-    COGNITO_USER_POOL_ID: "",
+    // The harness default is the ENTITLED self-host; blank the flag (the
+    // parser treats a blank exactly like unset) to boot unlicensed.
+    ENTERPRISE_ENABLED: "",
     // HA is licensed (#7): the unlicensed boot must run the in-memory stores.
     REDIS_HOST: "",
   },
   expectedEdition: "Onprem" as const,
 };
 
-/** The same deployment with the license flag on — the unlock differential. */
+/** The same deployment with the license flag on — the unlock differential.
+ * REDIS_HOST stays blank so the pair differs ONLY in the flag. */
 const LICENSED = {
   env: { ...UNLICENSED.env, ENTERPRISE_ENABLED: "true" },
   expectedEdition: "Onprem" as const,

--- a/apps/gateway-e2e/tests/websocket.test.ts
+++ b/apps/gateway-e2e/tests/websocket.test.ts
@@ -443,7 +443,7 @@ describe("websocket sessions", () => {
     expect(ws.status).toBe(101);
     const [seen] = await upstream.waitForUpgrades(1);
     // The product, on this leg: a credential the client never held arrives
-    // upstream, decrypted from a real KMS envelope.
+    // upstream, decrypted from a real stored ciphertext.
     expect(seen?.header("x-test-key")).toBe(SECRET);
     // The path rewrite applies to the handshake target too. Asserting the URL
     // catches a regression that sends the original path — invisible to the

--- a/apps/gateway-e2e/vitest.config.ts
+++ b/apps/gateway-e2e/vitest.config.ts
@@ -16,5 +16,12 @@ export default defineConfig({
     // Diagnostics matter more than brevity here: when a black-box test fails you
     // are looking at captured child-process output, not a stack trace.
     printConsoleTrace: false,
+    env: {
+      // The one symmetric secret every process in a scenario must share: the
+      // fixtures encrypt with it (via @onecli/api's local-AES service, which
+      // reads it at module load) and the spawned gateway decrypts with it. A
+      // fixed test key, never a production value.
+      SECRET_ENCRYPTION_KEY: "3q2+7wEhI0VniavN7xEjRWeJq83vESNFZ4mrze8RI0U=",
+    },
   },
 });

--- a/apps/gateway/src/ee/kms_crypto.rs
+++ b/apps/gateway/src/ee/kms_crypto.rs
@@ -176,4 +176,100 @@ mod tests {
         let decrypted = aes_gcm_decrypt(&data_key, &iv, &auth_tag, &ciphertext).expect("decrypt");
         assert_eq!(decrypted, plaintext);
     }
+
+    // ── The TS↔Rust envelope contract, against the committed fixture ────────
+    //
+    // TypeScript writes the envelope (packages/api/src/ee/kms-crypto.ts), this
+    // module opens it — and neither can import the other, so the contract is a
+    // committed fixture both sides must open. The TS twin is
+    // `kms-crypto.contract.test.ts`; `include_str!` shares the bytes exactly
+    // like the policy corpus does. This pair replaced the E2E-against-a-KMS-
+    // emulator guard when the E2E lane moved to the enterprise edition.
+
+    /// The corpus-test pattern: four `..` from apps/gateway/src/ee/ reach the
+    /// repo root.
+    const FIXTURE: &str = include_str!("../../../../packages/api/src/ee/kms-envelope.fixture.json");
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct EnvelopeFixture {
+        data_key_b64: String,
+        encrypted_data_key_b64: String,
+        encryption_context_key: String,
+        encryption_context_value: String,
+        plaintext: String,
+        envelope: String,
+    }
+
+    fn fixture() -> EnvelopeFixture {
+        serde_json::from_str(FIXTURE).expect("parse kms-envelope.fixture.json")
+    }
+
+    /// The decrypt path AFTER KMS: split, validate, open with the data key —
+    /// the exact primitives `KmsEnvelopeCrypto::decrypt` applies once the
+    /// KMS call has recovered the key.
+    fn open_fixture_envelope(envelope: &str, data_key: &[u8]) -> Result<String> {
+        let parts: Vec<&str> = envelope.split(':').collect();
+        assert_eq!(parts.len(), 4, "the envelope must have 4 parts");
+        let b64 = &base64::engine::general_purpose::STANDARD;
+        let iv = b64.decode(parts[1]).context("invalid IV base64")?;
+        let auth_tag = b64.decode(parts[2]).context("invalid auth tag base64")?;
+        let ciphertext = b64.decode(parts[3]).context("invalid ciphertext base64")?;
+        check_iv_and_tag(&iv, &auth_tag)?;
+        aes_gcm_decrypt(data_key, &iv, &auth_tag, &ciphertext)
+    }
+
+    #[test]
+    fn opens_the_envelope_typescript_wrote() {
+        let f = fixture();
+        let b64 = &base64::engine::general_purpose::STANDARD;
+        let data_key = b64.decode(&f.data_key_b64).expect("decode data key");
+        assert_eq!(data_key.len(), 32);
+
+        let decrypted =
+            open_fixture_envelope(&f.envelope, &data_key).expect("open the TS-written envelope");
+        assert_eq!(decrypted, f.plaintext);
+
+        // The first part is the (opaque) KMS-encrypted data key, byte-exact.
+        let first = f.envelope.split(':').next().expect("first part");
+        assert_eq!(first, f.encrypted_data_key_b64);
+    }
+
+    #[test]
+    fn encryption_context_matches_the_fixture_pin() {
+        // Both sides must send the same encryption context or KMS refuses the
+        // decrypt. The fixture pins it; this module hardcodes it.
+        let f = fixture();
+        assert_eq!(ENCRYPTION_CONTEXT_KEY, f.encryption_context_key);
+        assert_eq!(ENCRYPTION_CONTEXT_VALUE, f.encryption_context_value);
+    }
+
+    #[test]
+    fn a_wrong_key_fails_to_open_the_fixture() {
+        // Positive control: proves the contract test would detonate on drift
+        // rather than pass vacuously.
+        let f = fixture();
+        let rng = SystemRandom::new();
+        let mut wrong_key = [0u8; 32];
+        rng.fill(&mut wrong_key).expect("generate key");
+        assert!(open_fixture_envelope(&f.envelope, &wrong_key).is_err());
+    }
+
+    #[test]
+    fn own_encrypt_writes_an_envelope_the_fixture_algorithm_opens() {
+        // Round-trip through the production assembly with the FIXTURE's data
+        // key: what this module writes, the fixture algorithm (and therefore
+        // the TS side) opens.
+        let f = fixture();
+        let b64 = &base64::engine::general_purpose::STANDARD;
+        let data_key = b64.decode(&f.data_key_b64).expect("decode data key");
+        let encrypted_data_key = b64
+            .decode(&f.encrypted_data_key_b64)
+            .expect("decode encrypted data key");
+
+        let envelope =
+            kms_envelope_encrypt(&data_key, &encrypted_data_key, &f.plaintext).expect("encrypt");
+        let decrypted = open_fixture_envelope(&envelope, &data_key).expect("open own envelope");
+        assert_eq!(decrypted, f.plaintext);
+    }
 }

--- a/apps/hosted-e2e/README.md
+++ b/apps/hosted-e2e/README.md
@@ -7,9 +7,13 @@ silently rotted).
 
 Per test (`pnpm --filter @onecli/hosted-e2e test:e2e`): a private Postgres
 database cloned from a migrated template, a spawned **gateway binary**
-(onprem edition — no Redis, no KMS, local AES), a spawned **api-server**
-child, an **in-process runner** with the real Docker backend, and **real
-sandbox containers** from the agent image running the fake harness. Covers
+(the enterprise edition — an entitled self-host, `EDITION=onprem` +
+`ENTERPRISE_ENABLED=true`, local AES; give it the licensed Redis-backed HA
+stores by setting `E2E_REDIS_HOST`, as CI does — without it the entitled
+in-memory stores run, also a legitimate licensed configuration), a spawned
+**api-server** child (same edition), an **in-process runner** with the real
+Docker backend, and **real sandbox containers** from the agent image running
+the fake harness. Covers
 the spine (spawn → turn → platform tool call → gateway injection → approval
 hold → sleep → wake → cron fire) plus the hardening legs: multi-tenant
 isolation, kill-mid-turn recovery, runner restart, memory write-back

--- a/apps/hosted-e2e/src/api-server.ts
+++ b/apps/hosted-e2e/src/api-server.ts
@@ -47,7 +47,12 @@ export const startApiServer = async (
         PATH: process.env.PATH ?? "",
         HOME: process.env.HOME ?? "",
         NODE_ENV: "test",
+        // The enterprise edition, matching the spawned gateway: an entitled
+        // self-host, so the licensed control-plane arms (RBAC role resolver,
+        // workspace-access bindings) are wired exactly as a licensed
+        // deployment wires them.
         EDITION: "onprem",
+        ENTERPRISE_ENABLED: "true",
         PORT: String(opts.port),
         DATABASE_URL: opts.databaseUrl,
         SECRET_ENCRYPTION_KEY: secretEncryptionKey(),

--- a/apps/hosted-e2e/src/env.ts
+++ b/apps/hosted-e2e/src/env.ts
@@ -24,6 +24,14 @@ export interface HostedE2EConfig {
    * runner's ExtraHosts `host-gateway` entry (set alongside this).
    */
   readonly hostGatewayHost: string;
+  /**
+   * Optional Redis for the spawned gateway (the licensed HA stores). Set in
+   * CI so the enterprise lane runs the canonical Redis-backed deployment;
+   * unset locally the entitled gateway falls back to its in-memory stores —
+   * a legitimate licensed configuration, so nothing skips.
+   */
+  readonly redisHost: string | undefined;
+  readonly redisPort: string;
 }
 
 const read = (name: string): string | undefined => {
@@ -68,6 +76,8 @@ const resolve = (): HostedE2EConfig | null => {
     agentImage: read("E2E_AGENT_IMAGE") ?? "onecli-agent:dev",
     dockerSocket: read("E2E_DOCKER_SOCKET") ?? "/var/run/docker.sock",
     hostGatewayHost: read("E2E_HOST_GATEWAY_HOST") ?? "host.docker.internal",
+    redisHost: read("E2E_REDIS_HOST"),
+    redisPort: read("E2E_REDIS_PORT") ?? "6379",
   };
 };
 

--- a/apps/hosted-e2e/src/gateway.ts
+++ b/apps/hosted-e2e/src/gateway.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { gatewayBinary, secretEncryptionKey } from "./env.js";
+import { e2eConfig, gatewayBinary, secretEncryptionKey } from "./env.js";
 import {
   messageIncludes,
   spawnService,
@@ -40,6 +40,18 @@ export const startGateway = async (
 ): Promise<GatewayHandle> => {
   const dataDir = mkdtempSync(join(tmpdir(), "onecli-hosted-e2e-gw-"));
 
+  // The licensed HA stores when CI provides a Redis; the in-memory stores
+  // otherwise — both are legitimate entitled configurations (see env.ts).
+  const config = e2eConfig();
+  const redisEnv: Record<string, string> =
+    config?.redisHost !== undefined
+      ? {
+          REDIS_HOST: config.redisHost,
+          REDIS_PORT: config.redisPort,
+          REDIS_TLS: "false",
+        }
+      : {};
+
   const service: ServiceChild = spawnService(
     gatewayBinary(),
     ["--port", "0", "--data-dir", dataDir],
@@ -47,9 +59,13 @@ export const startGateway = async (
       env: {
         PATH: process.env.PATH ?? "",
         HOME: process.env.HOME ?? "",
+        // The enterprise edition: an entitled self-host — the canonical
+        // licensed deployment, matching the gateway-e2e default lane.
         EDITION: "onprem",
+        ENTERPRISE_ENABLED: "true",
         DATABASE_URL: opts.databaseUrl,
         SECRET_ENCRYPTION_KEY: secretEncryptionKey(),
+        ...redisEnv,
         // The stub upstream's self-signed cert lives on 127.0.0.1 — narrower
         // than the global danger flag, same as gateway-e2e.
         GATEWAY_SKIP_VERIFY_HOSTS: "127.0.0.1",

--- a/apps/hosted-e2e/tests/live-jcode-incident.test.ts
+++ b/apps/hosted-e2e/tests/live-jcode-incident.test.ts
@@ -64,6 +64,14 @@ const seedSecondMember = async (cx: Cx): Promise<string> => {
       role: "member",
     },
   });
+  // The suite runs entitled (RBAC armed), so a plain member needs the
+  // production-shape workspace binding for their key to pass the recheck.
+  await cx.prisma.workspaceAccess.create({
+    data: {
+      workspaceId: cx.ids.workspace,
+      userId,
+    },
+  });
   await cx.prisma.apiKey.create({
     data: {
       id: `${cx.ids.workspace}-key-b`,

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/composer.test.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/composer.test.tsx
@@ -40,6 +40,56 @@ describe("Composer", () => {
     expect(field).toHaveValue("");
   });
 
+  it("opens prefilled, focused, with the caret parked at the end of the draft", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(
+      <Composer
+        {...baseProps}
+        onSend={onSend}
+        initialDraft="Hey Donna, what can you do for me?"
+      />,
+    );
+
+    const field = screen.getByRole("textbox", {
+      name: "Message",
+    }) as HTMLTextAreaElement;
+    expect(field).toHaveValue("Hey Donna, what can you do for me?");
+    await waitFor(() => expect(field).toHaveFocus());
+    // A caret, never a selection: selected text is one keystroke from gone.
+    expect(field.selectionStart).toBe(field.value.length);
+    expect(field.selectionEnd).toBe(field.value.length);
+
+    // Enter accepts the prefilled draft as-is.
+    await user.keyboard("{Enter}");
+    expect(onSend).toHaveBeenCalledExactlyOnceWith({
+      message: "Hey Donna, what can you do for me?",
+      attachments: [],
+    });
+    expect(field).toHaveValue("");
+  });
+
+  it("never resurrects a cleared prefilled draft on a re-render", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        initialDraft="Hey Donna, what can you do for me?"
+      />,
+    );
+
+    const field = screen.getByRole("textbox", { name: "Message" });
+    await user.clear(field);
+    rerender(
+      <Composer
+        {...baseProps}
+        initialDraft="Hey Donna, what can you do for me?"
+      />,
+    );
+
+    expect(field).toHaveValue("");
+  });
+
   it("inserts a newline on Shift+Enter instead of sending", async () => {
     const user = userEvent.setup();
     const onSend = vi.fn();

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/composer.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/composer.tsx
@@ -59,6 +59,10 @@ interface ComposerProps {
   onStop?: () => void;
   stopPending?: boolean;
   autoFocus?: boolean;
+  /** A first message to open with (the onboarding greeting). Applied once, on
+   * mount, with the caret parked at its end — a later change must never
+   * overwrite words the user is typing. */
+  initialDraft?: string;
   className?: string;
 }
 
@@ -90,9 +94,13 @@ export const Composer = ({
   onStop,
   stopPending = false,
   autoFocus = false,
+  initialDraft,
   className,
 }: ComposerProps) => {
-  const [message, setMessage] = useState("");
+  // Initial state, not an effect: the draft is there on the first paint, so
+  // the field never flashes empty and a re-render can't resurrect it after
+  // the user clears it.
+  const [message, setMessage] = useState(initialDraft ?? "");
   const [staged, setStaged] = useState<StagedAttachment[]>([]);
   const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -100,6 +108,23 @@ export const Composer = ({
    * inside a state updater (see its header). */
   const stagedRef = useRef<StagedAttachment[]>(staged);
   stagedRef.current = staged;
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  /** The caret is parked exactly once — a later `initialDraft` change must not
+   * yank the caret out from under someone who is already typing. */
+  const draftPlacedRef = useRef(false);
+
+  // A prefilled field opens with the caret at its END — Enter sends it,
+  // backspace edits it. Never a selection: selected text is one keystroke
+  // from being gone. (Same behavior as the onboarding name field.)
+  useEffect(() => {
+    if (!initialDraft || draftPlacedRef.current) return;
+    const el = textareaRef.current;
+    if (!el) return;
+    draftPlacedRef.current = true;
+    el.focus();
+    const end = el.value.length;
+    el.setSelectionRange(end, end);
+  }, [initialDraft]);
 
   // The field clears optimistically at submit; if that send then fails, put
   // the words back (unless the user already started typing something new).
@@ -351,6 +376,7 @@ export const Composer = ({
           <Paperclip className="size-4" />
         </Button>
         <Textarea
+          ref={textareaRef}
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           onKeyDown={(e) => {

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/direct-thread-section.test.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/direct-thread-section.test.tsx
@@ -18,6 +18,10 @@ import { DirectThreadSection } from "./direct-thread-section";
 // resend's fresh-cache read exercises the same keys the section writes.
 vi.mock("next/navigation", () => ({
   usePathname: () => "/w/ws-1/agents/agent-1/chat",
+  // Real-router behavior for the greeting seam: params reflect the current
+  // URL at render time (jsdom keeps window.location in sync with the
+  // history calls the tests and the section itself make).
+  useSearchParams: () => new URLSearchParams(window.location.search),
 }));
 
 vi.mock("../../_components/agent-page-frame", () => ({
@@ -44,7 +48,14 @@ vi.mock("./chat-thread", () => ({
   ),
 }));
 
-vi.mock("./composer", () => ({ Composer: () => null }));
+// The composer stub surfaces the one prop this section computes for it —
+// `initialDraft` — so the greeting seam (URL flag → draft text) is testable
+// without the real textarea (whose own behavior composer.test.tsx covers).
+vi.mock("./composer", () => ({
+  Composer: ({ initialDraft }: { initialDraft?: string }) => (
+    <div data-testid="composer" data-initial-draft={initialDraft ?? ""} />
+  ),
+}));
 vi.mock("./offline-banner", () => ({ OfflineBanner: () => null }));
 
 vi.mock(
@@ -257,5 +268,63 @@ describe("the chat's in-place model-key door", () => {
       expect(toast.success).toHaveBeenCalledWith("Model key connected."),
     );
     expect(conversations.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("the onboarding greeting hand-off (?hello=1)", () => {
+  afterEach(() => {
+    vi.mocked(conversations.ensureDirect).mockReset();
+    vi.mocked(conversations.turns).mockReset();
+    window.history.replaceState(null, "", "/w/ws-1/agents/agent-1/chat");
+  });
+
+  const arrange = () => {
+    vi.mocked(conversations.ensureDirect).mockResolvedValue({
+      id: "conv-1",
+    } as never);
+    vi.mocked(conversations.turns).mockResolvedValue([]);
+  };
+
+  it("hands the composer the greeting draft and strips the flag from the URL", async () => {
+    arrange();
+    window.history.replaceState(
+      null,
+      "",
+      "/w/ws-1/agents/agent-1/chat?hello=1",
+    );
+    renderSection();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("composer")).toHaveAttribute(
+        "data-initial-draft",
+        "Hey Agent, what can you do for me?",
+      ),
+    );
+    // Consumed: the flag is gone, so a refresh opens a plain empty chat.
+    expect(window.location.search).toBe("");
+  });
+
+  it("stripping the flag leaves the URL's other params alone", async () => {
+    arrange();
+    window.history.replaceState(
+      null,
+      "",
+      "/w/ws-1/agents/agent-1/chat?attach=slack&hello=1",
+    );
+    renderSection();
+
+    await waitFor(() => expect(window.location.search).toBe("?attach=slack"));
+  });
+
+  it("opens empty without the flag — every non-onboarding route is untouched", async () => {
+    arrange();
+    renderSection();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("composer")).toHaveAttribute(
+        "data-initial-draft",
+        "",
+      ),
+    );
   });
 });

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/direct-thread-section.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/direct-thread-section.tsx
@@ -23,8 +23,12 @@ import {
 import { useUploadAttachment } from "@/hooks/use-attachments";
 import { useConversationStream } from "@/hooks/use-conversation-stream";
 import { useHostedAvailability } from "@/hooks/use-hosted-availability";
-import { usePathname } from "next/navigation";
-import { agentSectionPath } from "@/lib/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
+import {
+  agentSectionPath,
+  agentGreetingDraft,
+  CHAT_GREETING_PARAM,
+} from "@/lib/navigation";
 import { useAgentPageAgent } from "../../_components/agent-page-frame";
 import { EmptyState } from "../../_components/empty-state";
 import { useCreateThenAttachSecret } from "@/hooks/use-create-then-attach-secret";
@@ -61,6 +65,24 @@ export const DirectThreadSection = () => {
   const agentId = agent.id;
   const pathname = usePathname();
   const availability = useHostedAvailability({ poll: true });
+
+  // `?hello=1` (the last step of onboarding) opens the composer with the
+  // first message already typed. Latched ONCE, from `useSearchParams` — the
+  // router-synced source, present already at the render that mounts this
+  // section. `window.location` is NOT that source: on a client-side
+  // navigation (the onboarding hand-off is a `router.replace`) Next only
+  // syncs it at commit, after this initializer has run. Consumed exactly
+  // once: the URL is cleaned immediately, so a refresh never refills a
+  // draft the user deliberately cleared.
+  const searchParams = useSearchParams();
+  const [greeting] = useState(() => searchParams.has(CHAT_GREETING_PARAM));
+
+  useEffect(() => {
+    if (!greeting) return;
+    const url = new URL(window.location.href);
+    url.searchParams.delete(CHAT_GREETING_PARAM);
+    window.history.replaceState(null, "", `${url.pathname}${url.search}`);
+  }, [greeting]);
 
   const direct = useDirectConversation(agentId);
   const conversationId = direct.data?.id;
@@ -321,6 +343,10 @@ export const DirectThreadSection = () => {
         onStop={active ? () => abortTurn.mutate(active.id) : undefined}
         stopPending={abortTurn.isPending}
         autoFocus
+        // The draft is read once, when the composer mounts — which is why the
+        // flag comes from the URL at mount too, rather than from the turns
+        // query that is still in flight at that moment.
+        initialDraft={greeting ? agentGreetingDraft(agent.name) : undefined}
       />
     </>,
   );

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/page.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/page.tsx
@@ -13,7 +13,12 @@ export const metadata: Metadata = {
 export default function AgentChatPage() {
   return (
     <>
-      <DirectThreadSection />
+      {/* Suspense: useSearchParams (the onboarding `?hello=1` greeting flag).
+          The section renders its own skeleton while its queries resolve, so
+          the boundary needs no fallback of its own. */}
+      <Suspense>
+        <DirectThreadSection />
+      </Suspense>
       {/* `?attach=<provider>` deep links (the Slack card's Attach button)
           open the attach dialog over the chat. Suspense: useSearchParams. */}
       <Suspense>

--- a/apps/web/src/app/layout-injection.test.ts
+++ b/apps/web/src/app/layout-injection.test.ts
@@ -31,3 +31,17 @@ describe("root layout browser-origin injection", () => {
     expect(source).toContain("{!IS_CLOUD && (");
   });
 });
+
+describe("root layout CSP nonce (OC-01)", () => {
+  it("reads the nonce proxy.ts forwards on x-nonce", () => {
+    expect(source).toContain('(await headers()).get("x-nonce")');
+  });
+
+  it("passes it to next-themes — its inline theme script needs the attr", () => {
+    expect(source).toMatch(/<ThemeProvider[^>]*(\n\s+[^>\n]+)*\n\s+nonce=/);
+  });
+
+  it("stamps the self-host origin script — inert today, ready for an onprem CSP", () => {
+    expect(source).toMatch(/<script\s*\n\s+nonce=\{nonce\}/);
+  });
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import { Source_Serif_4 } from "next/font/google";
+import { headers } from "next/headers";
 import "@onecli/ui/globals.css";
 import "./globals.css";
 import { AuthProvider } from "@/providers/auth-provider";
@@ -63,16 +64,23 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Set by proxy.ts alongside the request's Content-Security-Policy (cloud;
+  // OC-01). Next stamps it on its own scripts automatically; this reaches the
+  // inline scripts Next does not own — next-themes' theme bootstrap and the
+  // self-host origin injection below. Absent (onprem) it renders as no attr.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <html lang="en" suppressHydrationWarning className="bg-background">
       {!IS_CLOUD && (
         <head>
           <script
+            nonce={nonce}
             dangerouslySetInnerHTML={{
               __html: browserOriginScript(),
             }}
@@ -90,6 +98,7 @@ export default function RootLayout({
               defaultTheme="light"
               enableSystem
               disableTransitionOnChange
+              nonce={nonce}
             >
               <ThemeColorSync />
               {children}

--- a/apps/web/src/lib/csp.test.ts
+++ b/apps/web/src/lib/csp.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildCsp, createCspNonce } from "./csp";
+
+/**
+ * OC-01 pins: script-src must never regress back to 'unsafe-inline' /
+ * 'unsafe-eval' in production, and the rest of the policy must keep the
+ * hardened shape the retired CloudFront header had.
+ */
+
+const directives = (csp: string): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const part of csp.split("; ")) {
+    const [name = "", ...rest] = part.split(" ");
+    map.set(name, rest.join(" "));
+  }
+  return map;
+};
+
+describe("createCspNonce", () => {
+  it("returns base64 and never repeats", () => {
+    const a = createCspNonce();
+    const b = createCspNonce();
+    expect(a).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    expect(a).not.toBe(b);
+    // 16 random bytes -> 24 base64 chars.
+    expect(a).toHaveLength(24);
+  });
+});
+
+describe("buildCsp", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://api.onecli.sh");
+    vi.stubEnv("NEXT_PUBLIC_GATEWAY_API_URL", "https://api.onecli.sh");
+    vi.stubEnv("COGNITO_DOMAIN", "auth.onecli.sh");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("production script-src: nonce + strict-dynamic, NO unsafe-inline/unsafe-eval", () => {
+    const csp = buildCsp("abc123");
+    const scriptSrc = directives(csp).get("script-src")!;
+
+    expect(scriptSrc).toContain("'nonce-abc123'");
+    expect(scriptSrc).toContain("'strict-dynamic'");
+    expect(scriptSrc).toContain("'self'");
+    expect(scriptSrc).not.toContain("unsafe-inline");
+    expect(scriptSrc).not.toContain("unsafe-eval");
+  });
+
+  it("keeps the third-party script hosts as the CSP2 fallback", () => {
+    const scriptSrc = directives(buildCsp("n")).get("script-src")!;
+    for (const host of [
+      "https://js.stripe.com",
+      "https://t.1cli.sh",
+      "https://cdn.usefathom.com",
+    ]) {
+      expect(scriptSrc).toContain(host);
+    }
+  });
+
+  it("dev adds unsafe-eval only (React server-stack debugging)", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const scriptSrc = directives(buildCsp("n")).get("script-src")!;
+    expect(scriptSrc).toContain("'unsafe-eval'");
+    expect(scriptSrc).not.toContain("unsafe-inline");
+  });
+
+  it("matches the retired CloudFront policy on every other directive", () => {
+    const map = directives(buildCsp("n"));
+
+    expect(map.get("default-src")).toBe("'self'");
+    expect(map.get("style-src")).toBe(
+      "'self' 'unsafe-inline' https://fonts.googleapis.com",
+    );
+    expect(map.get("font-src")).toBe("'self' https://fonts.gstatic.com");
+    expect(map.get("img-src")).toBe("'self' data: blob: https:");
+    expect(map.get("frame-src")).toBe("https://js.stripe.com");
+    expect(map.get("frame-ancestors")).toBe("'none'");
+    expect(map.get("base-uri")).toBe("'self'");
+    expect(map.get("form-action")).toBe("'self'");
+    expect(map.get("object-src")).toBe("'none'");
+  });
+
+  it("connect-src carries the resolved api/auth origins + the fixed hosts", () => {
+    const connectSrc = directives(buildCsp("n")).get("connect-src")!;
+    for (const host of [
+      "'self'",
+      "https://api.onecli.sh",
+      "https://auth.onecli.sh",
+      "https://*.amazoncognito.com",
+      "https://*.auth.us-east-1.amazoncognito.com",
+      "https://cognito-idp.us-east-1.amazonaws.com",
+      "https://api.stripe.com",
+      "https://t.1cli.sh",
+      "https://cdn.usefathom.com",
+    ]) {
+      expect(connectSrc).toContain(host);
+    }
+    // api and gateway share an origin in cloud — deduped, not repeated.
+    expect(connectSrc.match(/https:\/\/api\.onecli\.sh/g)).toHaveLength(1);
+  });
+
+  it("omits the auth host cleanly when no Cognito domain is configured", () => {
+    vi.stubEnv("COGNITO_DOMAIN", "");
+    vi.stubEnv("NEXT_PUBLIC_COGNITO_DOMAIN", "");
+    const connectSrc = directives(buildCsp("n")).get("connect-src")!;
+    expect(connectSrc).not.toContain("https://auth.onecli.sh");
+    expect(connectSrc).not.toMatch(/https:\/\/\s/);
+  });
+});

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -1,0 +1,82 @@
+/**
+ * Content-Security-Policy for the cloud dashboard (OC-01).
+ *
+ * The CSP moved from a static CloudFront ResponseHeadersPolicy row into the
+ * app so `script-src` can drop `'unsafe-inline'` / `'unsafe-eval'` in favor
+ * of a per-request nonce: Next.js reads the request's CSP header during SSR
+ * and stamps the nonce onto every framework, chunk, and inline script it
+ * emits — something a static edge header can never do. `proxy.ts` generates
+ * the nonce, threads it to the layout via `x-nonce`, and mirrors the header
+ * onto the response; the CloudFront policy no longer carries a CSP row.
+ *
+ * Env access is a literal dot read at call time (the public-origins rules):
+ * Next.js can only inline `NEXT_PUBLIC_*` literals, and tests stub env per
+ * case with no module dance.
+ */
+import { apiOrigin, gatewayHttpOrigin } from "@onecli/api/lib/public-origins";
+
+/** 128-bit random nonce, base64 — regenerated for every request. */
+export const createCspNonce = (): string => {
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  return btoa(String.fromCharCode(...bytes));
+};
+
+/**
+ * The full policy, one nonce per request. Every directive except
+ * `script-src` is byte-equivalent to the retired CloudFront row; the
+ * api/auth hosts are resolved instead of hardcoded so dev and prod both get
+ * their own domains.
+ */
+export const buildCsp = (nonce: string): string => {
+  // React needs eval only under `next dev` (it reconstructs server error
+  // stacks in the browser); production drops it entirely — neither React nor
+  // Next.js uses eval in a production build.
+  const isDev = process.env.NODE_ENV === "development";
+
+  // CSP3 browsers enforce the nonce + 'strict-dynamic' and ignore the host
+  // allowlist; the hosts stay as the fallback for older CSP2 browsers, so no
+  // browser gets a weaker policy than the pre-nonce one ('unsafe-inline'
+  // aside — dropping it is the point).
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    ...(isDev ? ["'unsafe-eval'"] : []),
+    "https://js.stripe.com",
+    "https://t.1cli.sh",
+    "https://cdn.usefathom.com",
+  ];
+
+  // Bare Cognito hosted-UI domain (e.g. auth.onecli.sh) — the same value
+  // amplify-config hands to Amplify's oauth.domain.
+  const cognitoDomain =
+    process.env.COGNITO_DOMAIN?.trim() ||
+    process.env.NEXT_PUBLIC_COGNITO_DOMAIN?.trim();
+
+  const connectSrc = [
+    "'self'",
+    // One entry when the gateway rides the api origin (cloud does).
+    ...new Set([apiOrigin(), gatewayHttpOrigin()]),
+    ...(cognitoDomain ? [`https://${cognitoDomain}`] : []),
+    "https://*.amazoncognito.com",
+    "https://*.auth.us-east-1.amazoncognito.com",
+    "https://cognito-idp.us-east-1.amazonaws.com",
+    "https://api.stripe.com",
+    "https://t.1cli.sh",
+    "https://cdn.usefathom.com",
+  ];
+
+  return [
+    "default-src 'self'",
+    `script-src ${scriptSrc.join(" ")}`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    "img-src 'self' data: blob: https:",
+    `connect-src ${connectSrc.join(" ")}`,
+    "frame-src https://js.stripe.com",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ].join("; ");
+};

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   AGENT_CREATE_PARAM,
   agentChatPath,
+  agentChatGreetingPath,
+  agentGreetingDraft,
   agentPath,
   agentsCreatePath,
   agentSectionPath,
@@ -152,6 +154,34 @@ describe("agentChatPath", () => {
 
   it("encodes both ids so neither can splice extra path segments", () => {
     expect(agentChatPath("w/1", "a/b")).toBe("/w/w%2F1/agents/a%2Fb/chat");
+  });
+});
+
+describe("agentChatGreetingPath", () => {
+  it("carries the greeting flag so the composer opens prefilled", () => {
+    expect(agentChatGreetingPath("w1", "ag-1")).toBe(
+      "/w/w1/agents/ag-1/chat?hello=1",
+    );
+  });
+
+  it("keeps the same encoding guarantees as the plain chat path", () => {
+    expect(agentChatGreetingPath("w/1", "a/b")).toBe(
+      "/w/w%2F1/agents/a%2Fb/chat?hello=1",
+    );
+  });
+});
+
+describe("agentGreetingDraft", () => {
+  it("addresses the agent by name", () => {
+    expect(agentGreetingDraft("Donna")).toBe(
+      "Hey Donna, what can you do for me?",
+    );
+  });
+
+  it("trims the name so a padded value can't read as a typo", () => {
+    expect(agentGreetingDraft("  Donna  ")).toBe(
+      "Hey Donna, what can you do for me?",
+    );
   });
 });
 

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -120,6 +120,24 @@ export const agentsCreatePath = (workspaceId: string): string =>
 export const agentChatPath = (workspaceId: string, agentId: string): string =>
   `/w/${encodeURIComponent(workspaceId)}/agents/${encodeURIComponent(agentId)}/chat`;
 
+/**
+ * Marks an arrival that should open with a prefilled first message ("Hey
+ * <Agent>, what can you do for me?"). A param, not local state, because the
+ * onboarding flow navigates to a fresh page — and the chat strips it once
+ * consumed so a refresh doesn't refill a draft the user cleared.
+ */
+export const CHAT_GREETING_PARAM = "hello";
+
+/** The agent's chat, opened with the greeting draft prefilled. */
+export const agentChatGreetingPath = (
+  workspaceId: string,
+  agentId: string,
+): string => `${agentChatPath(workspaceId, agentId)}?${CHAT_GREETING_PARAM}=1`;
+
+/** The prefilled first message. One definition so the copy can't drift. */
+export const agentGreetingDraft = (agentName: string): string =>
+  `Hey ${agentName.trim()}, what can you do for me?`;
+
 /** The last-visited org, written client-side on org pages and read by the
  * Get Started button on account routes (which belong to no org). One
  * definition so writer and reader can't drift. */

--- a/apps/web/src/lib/onboarding/team-page.test.tsx
+++ b/apps/web/src/lib/onboarding/team-page.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The unit here is the hand-off: BOTH ways out of the last onboarding step
+// must land on the greeting path — the chat URL carrying `?hello=1` — so the
+// composer opens with the first message already typed. The layout boot,
+// invitations, and step guard are stubbed to their contracts.
+const { handleComplete, prefetch } = vi.hoisted(() => ({
+  handleComplete: vi.fn().mockResolvedValue(undefined),
+  prefetch: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ prefetch, replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/hooks/use-invitations", () => ({
+  useInviteTeammates: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+vi.mock("./use-step-guard", () => ({ useStepGuard: () => true }));
+
+vi.mock("./onboarding-context", () => ({
+  useOnboarding: () => ({
+    createdAgentId: "ag-1",
+    createdAgentName: "Donna",
+    workspaceId: "ws-1",
+    completing: false,
+    handleComplete,
+  }),
+}));
+
+import TeamPage from "./team-page";
+
+const GREETING_DESTINATION = "/w/ws-1/agents/ag-1/chat?hello=1";
+
+describe("the team step's hand-off into chat", () => {
+  beforeEach(() => {
+    handleComplete.mockClear();
+    prefetch.mockClear();
+  });
+
+  it("Skip completes into the greeting path — the prefilled first message", async () => {
+    const user = userEvent.setup();
+    render(<TeamPage />);
+
+    await user.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(handleComplete).toHaveBeenCalledExactlyOnceWith(
+      GREETING_DESTINATION,
+    );
+  });
+
+  it("Continue (no invites) completes into the same greeting path", async () => {
+    const user = userEvent.setup();
+    render(<TeamPage />);
+
+    await user.click(screen.getByRole("button", { name: /meet your agent/i }));
+
+    expect(handleComplete).toHaveBeenCalledExactlyOnceWith(
+      GREETING_DESTINATION,
+    );
+  });
+
+  it("prefetches the greeting destination while the user types", () => {
+    render(<TeamPage />);
+
+    expect(prefetch).toHaveBeenCalledWith(GREETING_DESTINATION);
+  });
+});

--- a/apps/web/src/lib/onboarding/team-page.tsx
+++ b/apps/web/src/lib/onboarding/team-page.tsx
@@ -8,7 +8,7 @@ import { Input } from "@onecli/ui/components/input";
 import { Label } from "@onecli/ui/components/label";
 import { cn } from "@onecli/ui/lib/utils";
 import { toast } from "sonner";
-import { agentChatPath } from "@/lib/navigation";
+import { agentChatGreetingPath } from "@/lib/navigation";
 import { useInviteTeammates } from "@/hooks/use-invitations";
 import { useOnboarding } from "./onboarding-context";
 import { useStepGuard } from "./use-step-guard";
@@ -36,7 +36,7 @@ export default function TeamPage() {
 
   const chatDestination =
     createdAgentId && workspaceId
-      ? agentChatPath(workspaceId, createdAgentId)
+      ? agentChatGreetingPath(workspaceId, createdAgentId)
       : undefined;
 
   // The chat page is a heavy surface and it is where both buttons land —

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { WEB_AUTH_PAGES } from "./proxy";
@@ -46,5 +46,39 @@ describe("WEB_AUTH_PAGES", () => {
           "remove it or the dev proxy will never forward that path",
       ).toBe(true);
     }
+  });
+});
+
+// Source-as-assertion pins for the cloud CSP (OC-01). `IS_CLOUD` is baked at
+// module load, so the load-bearing wiring is pinned on source, layout-
+// injection style; the policy CONTENT is unit-tested in lib/csp.test.ts.
+describe("cloud nonce CSP wiring", () => {
+  const source = readFileSync(join(__dirname, "proxy.ts"), "utf8");
+
+  it("is cloud-gated — onprem responses stay CSP-free", () => {
+    expect(source).toMatch(/if \(IS_CLOUD\) \{\s*\n\s*const nonce/);
+  });
+
+  it("sets the CSP on the FORWARDED REQUEST — what makes Next nonce its scripts", () => {
+    expect(source).toContain(
+      'requestHeaders.set("content-security-policy", csp)',
+    );
+  });
+
+  it("mirrors the same CSP onto the response the browser enforces", () => {
+    expect(source).toContain(
+      'response.headers.set("content-security-policy", csp)',
+    );
+  });
+
+  it("hands the nonce to server components via x-nonce", () => {
+    expect(source).toContain('requestHeaders.set("x-nonce", nonce)');
+  });
+
+  it("strips any client-supplied x-nonce before minting its own", () => {
+    const strip = source.indexOf('requestHeaders.delete("x-nonce")');
+    const mint = source.indexOf('requestHeaders.set("x-nonce", nonce)');
+    expect(strip).toBeGreaterThan(-1);
+    expect(strip).toBeLessThan(mint);
   });
 });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { isMissingSessionSecret } from "@onecli/api/lib/session-secret";
 import { IS_CLOUD, SECRET_ENCRYPTION_KEY } from "@/lib/env";
+import { buildCsp, createCspNonce } from "@/lib/csp";
 import { WORKSPACE_PATH_RE, ORG_PATH_RE } from "@/lib/navigation";
 
 type SetupErrorCode = "missing-auth-secret" | "missing-encryption-key";
@@ -104,6 +105,31 @@ export const proxy = (request: NextRequest) => {
     (fromQuery ? searchParams.get("orgId") : null);
   if (orgId) {
     requestHeaders.set("x-organization-id", orgId);
+  }
+
+  // Never trust an inbound x-nonce: the layout stamps it into script tags,
+  // so only the value minted below may reach it (cloud overwrites; onprem
+  // must not let a client-supplied one through).
+  requestHeaders.delete("x-nonce");
+
+  // Cloud: per-request nonce CSP (OC-01). The header must be on the
+  // FORWARDED REQUEST — Next.js parses it during SSR and stamps the nonce
+  // onto every script it emits — and mirrored onto the response so the
+  // browser enforces the same policy. `x-nonce` hands the value to server
+  // components (the layout) for scripts Next does not own. Onprem keeps its
+  // current no-CSP behavior; adding one there is a follow-up with its own
+  // design (self-host origins are runtime-configured).
+  if (IS_CLOUD) {
+    const nonce = createCspNonce();
+    const csp = buildCsp(nonce);
+    requestHeaders.set("x-nonce", nonce);
+    requestHeaders.set("content-security-policy", csp);
+
+    const response = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+    response.headers.set("content-security-policy", csp);
+    return response;
   }
 
   return NextResponse.next({

--- a/packages/api/src/ee/kms-crypto.contract.test.ts
+++ b/packages/api/src/ee/kms-crypto.contract.test.ts
@@ -1,0 +1,157 @@
+import { createDecipheriv, createCipheriv, randomBytes } from "crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  KMSClient,
+  GenerateDataKeyCommand,
+  DecryptCommand,
+} from "@aws-sdk/client-kms";
+
+/**
+ * The TS half of the TS↔Rust KMS envelope contract.
+ *
+ * TypeScript writes the 4-part envelope (`ee/kms-crypto.ts` at secret
+ * creation); the Rust gateway decrypts it (`apps/gateway/src/ee/kms_crypto.rs`
+ * on the request path). Neither can import the other, so the contract is a
+ * committed fixture both sides must open: `kms-envelope.fixture.json` here,
+ * `include_str!`-ed by the Rust twin (the corpus-test pattern).
+ *
+ * This used to be guarded only by the gateway E2E suite against a KMS
+ * emulator; the E2E lane now runs the enterprise edition (local AES), so this
+ * pair of unit tests is the contract's permanent home. What is deliberately
+ * NOT covered here: the live KMS GenerateDataKey/Decrypt round-trip — AWS SDK
+ * mechanics proven by cloud deploys.
+ */
+
+interface EnvelopeFixture {
+  readonly dataKeyB64: string;
+  readonly encryptedDataKeyB64: string;
+  readonly encryptionContextKey: string;
+  readonly encryptionContextValue: string;
+  readonly plaintext: string;
+  readonly envelope: string;
+}
+
+const fixture = JSON.parse(
+  readFileSync(join(import.meta.dirname, "kms-envelope.fixture.json"), "utf8"),
+) as EnvelopeFixture;
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+/** Open a 4-part envelope with a raw data key — the algorithm the Rust
+ * gateway applies after KMS Decrypt returns the data key. */
+const openEnvelope = (envelope: string, dataKey: Buffer): string => {
+  const parts = envelope.split(":");
+  expect(parts).toHaveLength(4);
+  const [, ivB64, authTagB64, ciphertextB64] = parts;
+  const iv = Buffer.from(ivB64!, "base64");
+  const authTag = Buffer.from(authTagB64!, "base64");
+  expect(iv).toHaveLength(IV_LENGTH);
+  expect(authTag).toHaveLength(AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, dataKey, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([
+    decipher.update(Buffer.from(ciphertextB64!, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+};
+
+describe("the committed envelope fixture", () => {
+  it("opens with the fixture data key to the fixture plaintext", () => {
+    const dataKey = Buffer.from(fixture.dataKeyB64, "base64");
+    expect(dataKey).toHaveLength(32);
+    expect(openEnvelope(fixture.envelope, dataKey)).toBe(fixture.plaintext);
+  });
+
+  it("carries the encrypted data key as its first part", () => {
+    const [edkB64] = fixture.envelope.split(":");
+    expect(edkB64).toBe(fixture.encryptedDataKeyB64);
+  });
+
+  it("does not open with a different key (positive control)", () => {
+    // Proves the pair of contract tests would actually detonate on drift:
+    // a mutated fixture or a changed algorithm fails, never passes vacuously.
+    expect(() => openEnvelope(fixture.envelope, randomBytes(32))).toThrow();
+  });
+});
+
+describe("the production encryptor (ee/kms-crypto.ts)", () => {
+  beforeEach(() => {
+    vi.stubEnv("KMS_KEY_ARN", "arn:aws:kms:us-east-1:000000000000:key/test");
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("writes an envelope the fixture algorithm opens, with the pinned encryption context", async () => {
+    const dataKey = Buffer.from(fixture.dataKeyB64, "base64");
+    const encryptedDataKey = Buffer.from(fixture.encryptedDataKeyB64, "base64");
+
+    // Stub only the network: GenerateDataKey hands back the fixture data key,
+    // exactly what a real KMS does. Everything after that — the AES-GCM seal,
+    // the part order, the base64 joins — is the real production code.
+    const contexts: Array<Record<string, string> | undefined> = [];
+    const sendSpy = vi
+      .spyOn(KMSClient.prototype, "send")
+      .mockImplementation((command: unknown) => {
+        if (command instanceof GenerateDataKeyCommand) {
+          contexts.push(command.input.EncryptionContext);
+          return Promise.resolve({
+            Plaintext: new Uint8Array(dataKey),
+            CiphertextBlob: new Uint8Array(encryptedDataKey),
+          });
+        }
+        if (command instanceof DecryptCommand) {
+          contexts.push(command.input.EncryptionContext);
+          return Promise.resolve({ Plaintext: new Uint8Array(dataKey) });
+        }
+        throw new Error("unexpected KMS command");
+      });
+
+    // Import AFTER the env stub: KMS_KEY_ARN resolves at module load.
+    const { cryptoService } = await import("./kms-crypto");
+
+    const envelope = await cryptoService.encrypt(fixture.plaintext);
+    expect(openEnvelope(envelope, dataKey)).toBe(fixture.plaintext);
+
+    // And the decrypt path opens the COMMITTED envelope — the exact bytes the
+    // Rust twin opens.
+    expect(await cryptoService.decrypt(fixture.envelope)).toBe(
+      fixture.plaintext,
+    );
+
+    // The encryption context is part of the contract: the Rust decryptor
+    // sends the same pair, and KMS refuses a mismatch.
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    for (const context of contexts) {
+      expect(context).toEqual({
+        [fixture.encryptionContextKey]: fixture.encryptionContextValue,
+      });
+    }
+  });
+
+  it("refuses the 3-part local-AES format with the re-create guidance", async () => {
+    const { cryptoService } = await import("./kms-crypto");
+    const key = randomBytes(32);
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, key, iv, {
+      authTagLength: AUTH_TAG_LENGTH,
+    });
+    const enc = Buffer.concat([cipher.update("v", "utf8"), cipher.final()]);
+    const threePart = [
+      iv.toString("base64"),
+      cipher.getAuthTag().toString("base64"),
+      enc.toString("base64"),
+    ].join(":");
+    await expect(cryptoService.decrypt(threePart)).rejects.toThrow(
+      /legacy encryption format/,
+    );
+  });
+});

--- a/packages/api/src/ee/kms-envelope.fixture.json
+++ b/packages/api/src/ee/kms-envelope.fixture.json
@@ -1,0 +1,9 @@
+{
+  "comment": "TS<->Rust KMS envelope contract fixture. The envelope was assembled by the exact algorithm packages/api/src/ee/kms-crypto.ts uses (AES-256-GCM, 12-byte IV, 16-byte tag, 4 base64 parts joined by colons). Both sides must open it with the data key. Regenerating it is a CONTRACT CHANGE - both tests must be updated together.",
+  "dataKeyB64": "wyooZ62/3dfNmEcQdo2eHiWqcNKZaQJWkWpGWTI+kHI=",
+  "encryptedDataKeyB64": "Zml4dHVyZS1vcGFxdWUta21zLWNpcGhlcnRleHQtYmxvYi12MQ==",
+  "encryptionContextKey": "purpose",
+  "encryptionContextValue": "onecli-secret-encryption",
+  "plaintext": "{\"access_token\":\"ya29.fixture\",\"refresh_token\":\"1//0e-fixture\",\"expires_at\":1700000000}",
+  "envelope": "Zml4dHVyZS1vcGFxdWUta21zLWNpcGhlcnRleHQtYmxvYi12MQ==:mxHsa0X1zM6OW3S6:lwKv+n/J/awYK/tu8bp7Tg==:m1ZmB3yQrkymKpFPwfDbglLLnBFCxOEeg7ZE/NrbsI1/izsmOLzrfMem8D80aNe3GywKRv6JAoqkbRVEnvJZIIIL62Vy9kVe4qhWN1J2IeZCDJ0RG4V9"
+}

--- a/packages/api/src/licensing/__snapshots__/ee-boundary.test.ts.snap
+++ b/packages/api/src/licensing/__snapshots__/ee-boundary.test.ts.snap
@@ -172,6 +172,7 @@ exports[`enterprise-license boundary > the licensed file set changes only by del
     "hooks/rule-action-gate.ts",
     "hooks/team-hooks.ts",
     "index.ts",
+    "kms-crypto.contract.test.ts",
     "kms-crypto.ts",
     "middleware/cloud-only.ts",
     "middleware/enterprise-gate.ts",

--- a/packages/api/src/licensing/ee-boundary.ts
+++ b/packages/api/src/licensing/ee-boundary.ts
@@ -85,12 +85,6 @@ export const SEAMS: readonly Seam[] = [
     permanent: true,
   },
   {
-    from: "apps/gateway-e2e/**",
-    why: "Black-box test harness: builds fixtures with the licensed KMS crypto helper. Tests exercise licensed features by definition.",
-    count: 1,
-    permanent: true,
-  },
-  {
     from: "apps/web/src/lib/**",
     why: "DEBT. Free surfaces that statically embed an enterprise or hosted-platform control: quota dialogs and plan badges (inert without billing), workspace sharing, member provisioning and role management. Each render now sits behind the unified gate (usePlanGate locks by plan on cloud and by license on self-host), but the static imports remain; this number must only go down.",
     count: 43,


### PR DESCRIPTION
## What

Three changes from the shared tree, plus the matching CI topology update:

### Nonce-based CSP
`script-src` drops `unsafe-inline`/`unsafe-eval`. The proxy mints a per-request nonce (new `apps/web/src/lib/csp.ts` + tests) and the root layout threads it through to every inline script.

### E2E suites default to the enterprise edition
Both black-box suites (`apps/gateway-e2e`, `apps/hosted-e2e`) now spawn every child as an entitled self-host (`EDITION=onprem` + `ENTERPRISE_ENABLED=true`) with the licensed Redis-backed HA stores and local AES crypto. The KMS emulator requirement is gone: the TS↔Rust KMS envelope contract is pinned at unit level over a committed fixture (`packages/api/src/ee/kms-crypto.contract.test.ts` / `apps/gateway/src/ee/kms_crypto.rs`), with positive controls proving drift detonates. The fixture switch also removes the e2e harness's ee-boundary seam (`ee-boundary.ts` + snapshot). The unlicensed lane keeps its flag-off differentials; `platform-llm` becomes the explicit cloud arm.

### Onboarding lands in chat
The onboarding flow ends in the agent chat with the first message already typed (composer + direct-thread updates, navigation, team page).

### CI: five legible checks
`ci.yml` follows the new topology of the tree it tests: **Lint & Format**, **Build & Type Check**, **Unit (TS)**, **Unit (Rust)**, and ONE **E2E (enterprise)** job running both black-box suites against one Postgres and one Redis. The MiniStack KMS emulator leaves CI entirely; the Rust job becomes a pure unit lane. `ci-cache-seed.yml` gets the matching comment fix (same `gateway-debug` shared-key and `ci-agent` buildx scope, so the seeder itself is unchanged).

> **Note for repo admins:** check names changed — "Rust" → "Unit (Rust)", "Test" → "Unit (TS)", "Hosted E2E" → "E2E (enterprise)". If branch protection pins required checks by name, update them after this merges.

## Verification

- Full `pnpm check` green (lint, types, format, scripts suites, licensing suites)
- New KMS envelope contract test: 5/5 passing
- All changed web test files: 67/67 passing (csp, proxy, layout-injection, navigation, team-page, composer, direct-thread-section)
- Both workflow files parse; the Rust contract half and both E2E suites run in this PR's own CI lanes (their paths are in the filters)