### PR TITLE
feat(gateway): add OrcaRouter as a known LLM provider

### DIFF
--- a/apps/gateway/src/ee/platform_llm.rs
+++ b/apps/gateway/src/ee/platform_llm.rs
@@ -363,8 +363,10 @@ mod tests {
 
     #[test]
     fn generic_secret_on_an_llm_host_disqualifies() {
-        let secrets = [secret("generic", "api.openrouter.ai")];
-        assert!(pool_has_llm_credential(&secrets));
+        for host in ["api.openrouter.ai", "api.orcarouter.ai"] {
+            let secrets = [secret("generic", host)];
+            assert!(pool_has_llm_credential(&secrets), "host {host}");
+        }
     }
 
     #[test]

--- a/apps/gateway/src/policy.rs
+++ b/apps/gateway/src/policy.rs
@@ -179,6 +179,7 @@ pub(crate) fn is_llm_host(host: &str) -> bool {
         || h.contains("deepseek.com")
         || h.contains("groq.com")
         || h.contains("openrouter.ai")
+        || h.contains("orcarouter.ai")
         || h.contains("moonshot.cn")
         || h.contains("generativelanguage.googleapis.com")
 }
@@ -352,6 +353,7 @@ mod tests {
         assert!(is_llm_host("api.deepseek.com"));
         assert!(is_llm_host("api.groq.com"));
         assert!(is_llm_host("openrouter.ai"));
+        assert!(is_llm_host("api.orcarouter.ai"));
         assert!(is_llm_host("api.moonshot.cn"));
         assert!(is_llm_host("generativelanguage.googleapis.com"));
     }

--- a/apps/gateway/src/telemetry.rs
+++ b/apps/gateway/src/telemetry.rs
@@ -33,7 +33,7 @@ pub(crate) use crate::telemetry_core::{on_request, RequestEvent};
 fn is_llm_provider(provider: &str) -> bool {
     matches!(
         provider,
-        "anthropic" | "openai" | "deepseek" | "groq" | "openrouter"
+        "anthropic" | "openai" | "deepseek" | "groq" | "openrouter" | "orcarouter"
     ) || crate::policy::is_llm_host(provider)
 }
 

--- a/packages/api/src/ee/services/platform-llm.test.ts
+++ b/packages/api/src/ee/services/platform-llm.test.ts
@@ -53,11 +53,12 @@ describe("eePlatformLlm.trialCreditApplies", () => {
   });
 
   it("a generic secret pointed at an LLM host disqualifies", () => {
-    expect(
-      eePlatformLlm.trialCreditApplies([
-        secret("generic", "api.openrouter.ai"),
-      ]),
-    ).toBe(false);
+    for (const host of ["api.openrouter.ai", "api.orcarouter.ai"]) {
+      expect(
+        eePlatformLlm.trialCreditApplies([secret("generic", host)]),
+        `host ${host}`,
+      ).toBe(false);
+    }
   });
 
   it("non-LLM secrets do not disqualify", () => {

--- a/packages/api/src/lib/llm-hosts.ts
+++ b/packages/api/src/lib/llm-hosts.ts
@@ -13,6 +13,7 @@ export const LLM_HOST_FRAGMENTS = [
   "deepseek.com",
   "groq.com",
   "openrouter.ai",
+  "orcarouter.ai",
   "moonshot.cn",
   "generativelanguage.googleapis.com",
 ] as const;

--- a/packages/api/src/lib/path-match.test.ts
+++ b/packages/api/src/lib/path-match.test.ts
@@ -80,6 +80,7 @@ describe("isLlmHost", () => {
   it("matches known LLM providers (port stripped)", () => {
     expect(isLlmHost("api.anthropic.com")).toBe(true);
     expect(isLlmHost("api.openai.com:443")).toBe(true);
+    expect(isLlmHost("api.orcarouter.ai")).toBe(true);
     expect(isLlmHost("generativelanguage.googleapis.com")).toBe(true);
     expect(isLlmHost("gmail.googleapis.com")).toBe(false);
   });

--- a/packages/api/src/lib/path-match.ts
+++ b/packages/api/src/lib/path-match.ts
@@ -106,6 +106,7 @@ export const isLlmHost = (host: string): boolean => {
     h.includes("deepseek.com") ||
     h.includes("groq.com") ||
     h.includes("openrouter.ai") ||
+    h.includes("orcarouter.ai") ||
     h.includes("moonshot.cn") ||
     h.includes("generativelanguage.googleapis.com")
   );


### PR DESCRIPTION
## Add OrcaRouter as a first-class LLM provider

OneCLI's gateway classifies AI-provider traffic through a host registry (`is_llm_host` in `apps/gateway/src/policy.rs`, mirrored in TypeScript). Requests to known providers bypass the deny-by-default policy and are always logged — which is exactly what an LLM gateway like [OrcaRouter](https://www.orcarouter.ai) needs to be treated as.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means OneCLI users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Changes

- `apps/gateway/src/policy.rs`: added `orcarouter.ai` to `is_llm_host`, mirroring the existing `openrouter.ai` entry, plus a test assertion.
- `apps/gateway/src/telemetry.rs`: added `"orcarouter"` to the `is_llm_provider` provider list so OrcaRouter traffic is attributed in telemetry.
- `apps/gateway/src/ee/platform_llm.rs`: extended the trial-credit test to assert a generic secret pointed at `api.orcarouter.ai` disqualifies (same as OpenRouter).
- `packages/api/src/lib/llm-hosts.ts` and `packages/api/src/lib/path-match.ts`: kept the TypeScript mirror of the gateway's host registry in sync.
- `packages/api/src/lib/path-match.test.ts` and `packages/api/src/ee/services/platform-llm.test.ts`: added matching test coverage.

### Verification

- `pnpm --filter @onecli/api check-types` — clean
- `pnpm --filter @onecli/api lint` — clean
- `pnpm --filter @onecli/api test` — 2407 passed, 0 failed
- Prettier check on all changed files — clean
- Live test: `https://api.orcarouter.ai/v1/chat/completions` returns `200` with a valid `chat.completion` response using the OrcaRouter API key, confirming the host fragment points at a real OpenAI-compatible endpoint.

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
