### PR TITLE
feat(runner): operator-level extra env vars for sandbox containers

### DIFF
--- a/apps/hosted-e2e/src/runner.ts
+++ b/apps/hosted-e2e/src/runner.ts
@@ -76,6 +76,7 @@ export const startTestRunner = async (
     agentImage: opts.config.agentImage,
     sandboxNetwork: opts.ids.network,
     networkInternal: false,
+    sandboxExtraEnv: {},
     wsPort,
     advertisedHost: opts.config.hostGatewayHost,
     maxSandboxes: opts.maxSandboxes ?? 4,

--- a/apps/runner/src/config.ts
+++ b/apps/runner/src/config.ts
@@ -38,6 +38,15 @@ export interface RunnerConfig {
    */
   sandboxExtraHosts: string[];
   /**
+   * Extra environment variables injected into every sandbox container
+   * (`KEY=VALUE`, comma-separated). Operator-level plumbing for values the
+   * control plane does not know about — e.g. pointing every harness at an
+   * organization LLM proxy with `ANTHROPIC_BASE_URL=https://…`. Entries
+   * without a `=` are dropped. Control-plane-owned variables (SANDBOX_ID,
+   * RUNNER_WS_URL, SANDBOX_WS_TOKEN) always win over these.
+   */
+  sandboxExtraEnv: Record<string, string>;
+  /**
    * The stale-label orphan sweep (step 13): reap containers/volumes whose
    * sandbox no longer exists anywhere in the control plane. False = detect
    * and log, delete nothing — the operator kill-switch.
@@ -154,6 +163,18 @@ export const loadConfig = (
       .split(",")
       .map((entry) => entry.trim())
       .filter((entry) => entry.length > 0),
+    sandboxExtraEnv: Object.fromEntries(
+      (env.RUNNER_SANDBOX_EXTRA_ENV ?? "")
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+        .flatMap((entry) => {
+          const eq = entry.indexOf("=");
+          // A key-less entry is a configuration mistake — drop it rather than
+          // inject an empty-named variable the daemon would reject.
+          return eq > 0 ? [[entry.slice(0, eq), entry.slice(eq + 1)]] : [];
+        }),
+    ),
     orphanReap: bool(env.RUNNER_ORPHAN_REAP, true),
     orphanGraceSeconds: int(env.RUNNER_ORPHAN_GRACE_SECONDS, 3600),
     sandboxManagerUrl,

--- a/apps/runner/src/orphan-sweep.test.ts
+++ b/apps/runner/src/orphan-sweep.test.ts
@@ -41,6 +41,7 @@ const baseConfig: RunnerConfig = {
   reconcileSeconds: 60,
   dockerSocket: "/var/run/docker.sock",
   sandboxExtraHosts: [],
+  sandboxExtraEnv: {},
   orphanReap: true,
   orphanGraceSeconds: 3600,
   sandboxManagerUrl: null,

--- a/apps/runner/src/runner.test.ts
+++ b/apps/runner/src/runner.test.ts
@@ -35,6 +35,7 @@ const config: RunnerConfig = {
   reconcileSeconds: 60,
   dockerSocket: "/var/run/docker.sock",
   sandboxExtraHosts: [],
+  sandboxExtraEnv: {},
   orphanReap: true,
   orphanGraceSeconds: 3600,
   sandboxManagerUrl: null,
@@ -330,6 +331,31 @@ describe("every start hands the sandbox a live control-channel credential", () =
     expect(backend.sandboxes.get("sb-1")?.spec.env.HTTPS_PROXY).toContain(
       "aoc_ROTATED",
     );
+  });
+
+  it("injects operator sandboxExtraEnv without touching control-channel vars", async () => {
+    runner = createRunner({
+      config: {
+        ...config,
+        sandboxExtraEnv: {
+          ANTHROPIC_BASE_URL: "https://proxy.example.com/aifoundry-sdk",
+        },
+      },
+      backend,
+      controlPlane,
+      wsServer,
+    });
+    queued.push(startItem());
+    await drive();
+
+    const env = backend.sandboxes.get("sb-1")?.spec.env;
+    expect(env?.ANTHROPIC_BASE_URL).toBe(
+      "https://proxy.example.com/aifoundry-sdk",
+    );
+    // Payload and control-channel variables are still present.
+    expect(env?.ANTHROPIC_API_KEY).toBe("placeholder");
+    expect(env?.SANDBOX_ID).toBe("sb-1");
+    expect(env?.SANDBOX_WS_TOKEN).toBeTruthy();
   });
 
   it("keeps the SAME home across a recreate (the durable disk)", async () => {

--- a/apps/runner/src/runner.ts
+++ b/apps/runner/src/runner.ts
@@ -461,6 +461,10 @@ export const createRunner = ({
           env: {
             ...item.payload.env,
             ...noProxyForRunner(config.advertisedHost, item.payload.env),
+            // Operator-level extras (e.g. ANTHROPIC_BASE_URL for an org LLM
+            // proxy) — after the payload so the operator wins on conflict,
+            // before the control-channel variables so those stay untouchable.
+            ...config.sandboxExtraEnv,
             ...(item.payload.model && { AGENT_MODEL: item.payload.model }),
             ...(item.payload.effort && { AGENT_EFFORT: item.payload.effort }),
             ...(item.payload.harness && {


### PR DESCRIPTION
## Why

Operators sometimes need to hand every sandboxed agent an environment value the control plane does not know about. The driving use case: pointing every harness at an organization LLM proxy with `ANTHROPIC_BASE_URL=https://…` (pairs with the gateway-side override in #535, but useful independently).

## What

`RUNNER_SANDBOX_EXTRA_ENV` — comma-separated `KEY=VALUE` pairs injected into every sandbox container the runner creates.

Precedence, deliberate:
1. queue payload env
2. **operator extras (this feature)** — operator wins over payload on conflict
3. control-channel variables (`SANDBOX_ID`, `RUNNER_WS_URL`, `SANDBOX_WS_TOKEN`) — always win, stay untouchable

Entries without `=` are dropped rather than injected as empty-named variables the daemon would reject.

## Testing

- Behavioral test: extras are injected, payload vars survive, control-channel vars untouched
- `pnpm check-types` and full runner suite green (234 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfqxppumx3sNFTyxixshmn