### PR TITLE
feat(runner): opt-in escape hatch for hosts that cannot run hardened sandboxes

### DIFF
--- a/apps/hosted-e2e/src/runner.ts
+++ b/apps/hosted-e2e/src/runner.ts
@@ -76,6 +76,7 @@ export const startTestRunner = async (
     agentImage: opts.config.agentImage,
     sandboxNetwork: opts.ids.network,
     networkInternal: false,
+    sandboxUnsafeSeccomp: false,
     wsPort,
     advertisedHost: opts.config.hostGatewayHost,
     maxSandboxes: opts.maxSandboxes ?? 4,

--- a/apps/runner/src/backend/docker/docker-backend.test.ts
+++ b/apps/runner/src/backend/docker/docker-backend.test.ts
@@ -57,7 +57,11 @@ const createRecordingTransport = (
 
 const makeBackend = (
   responses: Record<string, unknown> = {},
-  overrides: { networkInternal?: boolean; extraHosts?: string[] } = {},
+  overrides: {
+    networkInternal?: boolean;
+    extraHosts?: string[];
+    unsafeSeccomp?: boolean;
+  } = {},
 ) => {
   const { transport, calls } = createRecordingTransport(responses);
   const backend: SandboxBackend = createDockerBackend({
@@ -67,6 +71,9 @@ const makeBackend = (
     networkInternal: overrides.networkInternal ?? true,
     socketPath: "/var/run/docker.sock",
     ...(overrides.extraHosts && { extraHosts: overrides.extraHosts }),
+    ...(overrides.unsafeSeccomp !== undefined && {
+      unsafeSeccomp: overrides.unsafeSeccomp,
+    }),
     transport,
   });
   return { backend, calls };
@@ -215,13 +222,14 @@ describe("createSandbox", () => {
     ).toEqual(["ALL"]);
   });
 
-  it("never weakens the daemon's default seccomp profile (the shared-kernel userns gate)", async () => {
+  it("never weakens the daemon's default seccomp profile by default (the shared-kernel userns gate)", async () => {
     // The agent image ships podman; on this SHARED kernel the default seccomp
     // profile is what actually blocks the `unshare`/`clone` namespace syscalls
     // rootless containers need (CapDrop:ALL + no-new-privileges disarm the
     // capability and setuid paths, but seccomp is the syscall gate). A
     // `seccomp=unconfined` SecurityOpt here would silently re-open rootless
-    // podman on the shared kernel — assert no SecurityOpt touches seccomp.
+    // podman on the shared kernel — assert no SecurityOpt touches seccomp
+    // UNLESS the explicit, documented unsafeSeccomp escape hatch is set.
     const { backend, calls } = makeBackend({ "/networks?": [] });
     await backend.prepare();
     await backend.createSandbox(spec);
@@ -234,6 +242,23 @@ describe("createSandbox", () => {
     ).HostConfig.SecurityOpt;
     expect(securityOpt).toEqual(["no-new-privileges"]);
     expect(securityOpt.some((opt) => opt.includes("seccomp"))).toBe(false);
+  });
+
+  it("unconfines seccomp ONLY when unsafeSeccomp is explicitly opted into", async () => {
+    const { backend, calls } = makeBackend(
+      { "/networks?": [] },
+      { unsafeSeccomp: true },
+    );
+    await backend.prepare();
+    await backend.createSandbox(spec);
+
+    const create = calls.find((call) =>
+      call.path.includes("/containers/create"),
+    );
+    const securityOpt = (
+      create?.body as { HostConfig: { SecurityOpt: string[] } }
+    ).HostConfig.SecurityOpt;
+    expect(securityOpt).toEqual(["seccomp=unconfined", "apparmor=unconfined"]);
   });
 
   it("labels the container for reconcile, including the payload hash", async () => {

--- a/apps/runner/src/backend/docker/docker-backend.ts
+++ b/apps/runner/src/backend/docker/docker-backend.ts
@@ -124,6 +124,13 @@ export interface DockerBackendOptions {
    * docker host) — how a plain-Linux sandbox resolves `host.docker.internal`
    * when the gateway runs on the host. Empty = no entries, no change. */
   extraHosts?: string[];
+  /**
+   * DANGEROUS, opt-in only (RUNNER_SANDBOX_UNSAFE_SECCOMP): drops
+   * `no-new-privileges` and unconfines seccomp for sandbox containers. Exists
+   * only for hosts whose runtime cannot exec the agent image's entrypoint
+   * under the default hardened profile. See config.ts for the full warning.
+   */
+  unsafeSeccomp?: boolean;
   /** Injectable for tests — the real one talks to the docker socket. */
   transport?: EngineTransport;
 }
@@ -371,11 +378,15 @@ export const createDockerBackend = (
               // capability, and no-new-privileges neuters the setuid uidmap
               // helpers — so rootless containers cannot set up their user
               // namespace here (they are a hosted-microVM-only capability; see
-              // apps/runner/README.md). NEVER add a `seccomp=…` SecurityOpt
-              // that weakens the default profile: seccomp is the actual syscall
-              // gate, and `seccomp=unconfined` would re-open single-uid rootless
-              // podman on the shared kernel. Pinned by the test.
-              SecurityOpt: ["no-new-privileges"],
+              // apps/runner/README.md). Do NOT add a `seccomp=…` SecurityOpt
+              // that weakens the default profile except behind the explicit,
+              // documented `unsafeSeccomp` escape hatch below (off by default,
+              // RUNNER_SANDBOX_UNSAFE_SECCOMP): seccomp is the actual syscall
+              // gate, and `seccomp=unconfined` re-opens single-uid rootless
+              // podman on the shared kernel. Default path pinned by the test.
+              SecurityOpt: options.unsafeSeccomp
+                ? ["seccomp=unconfined", "apparmor=unconfined"]
+                : ["no-new-privileges"],
               CapDrop: ["ALL"],
               RestartPolicy: { Name: "no" },
               ...(options.extraHosts &&

--- a/apps/runner/src/config.ts
+++ b/apps/runner/src/config.ts
@@ -23,6 +23,18 @@ export interface RunnerConfig {
   /** `internal` networks have no route out; the gateway is dual-homed onto
    * them. False only for local dev, where the gateway runs on the host. */
   networkInternal: boolean;
+  /**
+   * DANGEROUS, opt-in only: relaxes the sandbox container's `no-new-privileges`
+   * guard and unconfines its seccomp profile. Exists solely for hosts whose
+   * kernel/container runtime cannot exec the agent image's entrypoint under
+   * `no-new-privileges` (observed on some nested/restricted Docker hosts —
+   * `exec ...: operation not permitted`). Defaults to false: leaving this on
+   * re-opens the rootless-podman-on-shared-kernel path the default profile
+   * exists to block (see docker-backend.ts). Set
+   * RUNNER_SANDBOX_UNSAFE_SECCOMP=true only when you understand and accept
+   * that tradeoff for this specific host.
+   */
+  sandboxUnsafeSeccomp: boolean;
   wsPort: number;
   /** How a sandbox addresses this runner — a container-network name. */
   advertisedHost: string;
@@ -132,6 +144,7 @@ export const loadConfig = (
     agentImage: env.RUNNER_AGENT_IMAGE ?? "onecli-agent:dev",
     sandboxNetwork: env.RUNNER_SANDBOX_NETWORK ?? "onecli-sandboxes",
     networkInternal: bool(env.RUNNER_NETWORK_INTERNAL, true),
+    sandboxUnsafeSeccomp: bool(env.RUNNER_SANDBOX_UNSAFE_SECCOMP, false),
     wsPort: int(env.RUNNER_WS_PORT, 8484),
     advertisedHost: env.RUNNER_ADVERTISED_HOST ?? "runner",
     maxSandboxes: int(env.RUNNER_MAX_SANDBOXES, 4),

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -56,6 +56,7 @@ const selectBackend = (
     networkInternal: config.networkInternal,
     socketPath: config.dockerSocket,
     extraHosts: config.sandboxExtraHosts,
+    unsafeSeccomp: config.sandboxUnsafeSeccomp,
   });
 };
 

--- a/apps/runner/src/orphan-sweep.test.ts
+++ b/apps/runner/src/orphan-sweep.test.ts
@@ -34,6 +34,7 @@ const baseConfig: RunnerConfig = {
   agentImage: "onecli-agent:test",
   sandboxNetwork: "onecli-sandboxes",
   networkInternal: true,
+  sandboxUnsafeSeccomp: false,
   wsPort: 8484,
   advertisedHost: "runner",
   maxSandboxes: 2,

--- a/apps/runner/src/runner.test.ts
+++ b/apps/runner/src/runner.test.ts
@@ -28,6 +28,7 @@ const config: RunnerConfig = {
   agentImage: "onecli-agent:test",
   sandboxNetwork: "onecli-sandboxes",
   networkInternal: true,
+  sandboxUnsafeSeccomp: false,
   wsPort: 8484,
   advertisedHost: "runner",
   maxSandboxes: 2,


### PR DESCRIPTION
## Why

Some nested/restricted Docker hosts cannot exec the agent image's entrypoint under the default hardened profile — container creation fails with `exec ...: operation not permitted` under `no-new-privileges`. On such hosts the runner is currently unusable, with no supported way forward.

## What

`RUNNER_SANDBOX_UNSAFE_SECCOMP` (default **false**). When explicitly enabled, sandbox containers are created with `seccomp=unconfined` + `apparmor=unconfined` instead of `no-new-privileges`.

This is deliberately loud about its tradeoff: the default seccomp profile is the syscall gate that keeps rootless podman inside the sandbox off the shared kernel, and the config docs and code comments say so at every layer. I fully expect maintainers may prefer a different shape here (e.g. a custom seccomp profile instead of unconfined) — happy to rework; the pain point is real.

- Default path unchanged, still pinned by the existing "never weakens seccomp" test
- New test pins that unconfined applies **only** behind the explicit opt-in

## Testing

- `pnpm check-types` and full runner suite green (234 tests)
- Verified on a restricted Azure Docker host where the default profile cannot exec the entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfqxppumx3sNFTyxixshmn