### PR TITLE
feat: live Slack task cards and a live activity loader for web chat

### DIFF
--- a/apps/channel-adapter/src/mirror.test.ts
+++ b/apps/channel-adapter/src/mirror.test.ts
@@ -220,11 +220,22 @@ describe("what gets posted", () => {
     });
 
     const posted = slack.callsTo("chat.postMessage");
-    // The title rides every automation post as a quiet caption — two
-    // automations reporting into one thread are indistinguishable without it.
+    // The caption rides every automation post — two automations reporting
+    // into one thread are indistinguishable without it. `text` carries the
+    // whole line because it is the notification and search preview.
     expect(posted.map((call) => call.form.text)).toEqual([
-      ':calendar: _Scheduled run "daily-check"_\nInbox is clear &lt;ok&gt;',
+      ':calendar: Scheduled run "daily-check"\nInbox is clear &lt;ok&gt;',
     ]);
+    // ...and the caption renders as CHROME: a context block (smaller, grey),
+    // with the report itself an ordinary section below it.
+    const blocks = JSON.parse(posted[0]?.form.blocks ?? "[]") as unknown[];
+    expect(blocks[0]).toEqual({
+      type: "context",
+      elements: [
+        { type: "mrkdwn", text: ':calendar: Scheduled run "daily-check"' },
+      ],
+    });
+    expect(blocks[1]).toMatchObject({ type: "section" });
   });
 
   it("posts a watch run's report as ONE labeled message with the stopwatch icon", async () => {
@@ -246,7 +257,7 @@ describe("what gets posted", () => {
 
     const posted = slack.callsTo("chat.postMessage");
     expect(posted.map((call) => call.form.text)).toEqual([
-      ':stopwatch: _Watch on "tests"_\nTests passed &lt;ok&gt;',
+      ':stopwatch: Watch on "tests"\nTests passed &lt;ok&gt;',
     ]);
   });
 
@@ -675,7 +686,7 @@ describe("what gets posted", () => {
     });
 
     expect(slack.callsTo("chat.postMessage").map((c) => c.form.text)).toEqual([
-      ":calendar: _Scheduled run **daily** &lt;sweep&gt;_\n*Inbox*\n• *unread:* 0",
+      ":calendar: Scheduled run **daily** &lt;sweep&gt;\n*Inbox*\n• *unread:* 0",
     ]);
   });
 
@@ -692,7 +703,7 @@ describe("what gets posted", () => {
     });
 
     expect(slack.callsTo("chat.postMessage").map((c) => c.form.text)).toEqual([
-      ":calendar: _Scheduled run **daily** &lt;sweep&gt;_",
+      ":calendar: Scheduled run **daily** &lt;sweep&gt;",
     ]);
   });
 
@@ -739,6 +750,36 @@ describe("what gets posted", () => {
     expect(text).toContain("CI passed on #1004.");
   });
 
+  it("chunks a long automation report instead of losing the post", async () => {
+    // Slack caps a section at 3,000 chars and rejects the WHOLE post past
+    // it — after the cursor advanced, which would silently drop the report.
+    // MUTATION-PROOF: pass the body as ONE section and this fails.
+    const controlPlane = createFakeControlPlane(
+      transcriptWith("word ".repeat(2_000)),
+    );
+
+    await mirror({
+      controlPlane,
+      workItem: item({
+        source: "cron",
+        userId: null,
+        message: 'Scheduled run "big"',
+      }),
+    });
+
+    const posted = slack.callsTo("chat.postMessage")[0];
+    const blocks = JSON.parse(posted?.form.blocks ?? "[]") as {
+      type: string;
+      text?: { text: string };
+    }[];
+    expect(blocks[0]?.type).toBe("context");
+    const sections = blocks.filter((block) => block.type === "section");
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections) {
+      expect((section.text?.text ?? "").length).toBeLessThanOrEqual(3_000);
+    }
+  });
+
   it("clips an over-long single-line caption instead of letting it run", async () => {
     const controlPlane = createFakeControlPlane(transcriptWith("Done."));
 
@@ -753,9 +794,8 @@ describe("what gets posted", () => {
 
     const caption = (slack.callsTo("chat.postMessage")[0]?.form.text ?? "")
       .split("\n")[0]!
-      // Strip the icon and the italic wrapper to measure the caption itself.
-      .replace(/^:calendar: _/, "")
-      .replace(/_$/, "");
+      // Strip the icon to measure the caption itself.
+      .replace(/^:calendar: /, "");
     expect(caption.length).toBeLessThanOrEqual(121);
     expect(caption.endsWith("…")).toBe(true);
   });

--- a/apps/channel-adapter/src/slack/mirror-posts.test.ts
+++ b/apps/channel-adapter/src/slack/mirror-posts.test.ts
@@ -25,8 +25,46 @@ describe("the automation caption", () => {
       "RUNNING CI",
     ].join("\n");
 
+    // The closing bracket goes with it: the header is a wrapper, and half a
+    // wrapper reads like a typo.
     expect(automationCaption(header)).toBe(
-      '[Watch on process "CI watcher" fired: its output matched.]',
+      'Watch on process "CI watcher" fired: its output matched.',
+    );
+  });
+
+  it("drops the model's stage direction, keeping only what HAPPENED", () => {
+    // The real `watch-fire-service` header. Everything after the separator
+    // is addressed to the model — how to report, where the answer goes —
+    // and told the reader nothing while crowding out the report itself.
+    const header =
+      '[Watch on process "giraffe" fired: the process finished \u2014 triggered automatically, not by a person typing. Do the task below and finish with a SHORT report \u2014 outcome first, then only what changed or needs attention, a few lines at most; it reaches the chat this watch belongs to.]';
+
+    expect(automationCaption(header)).toBe(
+      'Watch on process "giraffe" fired: the process finished',
+    );
+  });
+
+  it("does the same for a consolidated wake", () => {
+    const header =
+      "[Platform wake: 2 background task(s) you were watching finished \u2014 triggered automatically, not by a person typing. This runs in the chat the work belongs to. Do what each item below asks and give one SHORT combined report directly in this reply.]";
+
+    expect(automationCaption(header)).toBe(
+      "Platform wake: 2 background task(s) you were watching finished",
+    );
+  });
+
+  it("does the same for a scheduled run", () => {
+    const header =
+      '[Scheduled run "nightly digest" \u2014 triggered automatically by a schedule, not by a person typing. Do the task below and finish with a SHORT report.]';
+
+    expect(automationCaption(header)).toBe('Scheduled run "nightly digest"');
+  });
+
+  it("falls back to the bounded first line when the header shape is unfamiliar", () => {
+    // A future header the API rewords must degrade to today's behavior, not
+    // vanish — the rule is structural, not a copy of their wording.
+    expect(automationCaption("Something else entirely\nbody")).toBe(
+      "Something else entirely",
     );
   });
 

--- a/apps/channel-adapter/src/slack/mirror-posts.ts
+++ b/apps/channel-adapter/src/slack/mirror-posts.ts
@@ -19,36 +19,63 @@ const BLOCK_BUDGET = 48;
 const CAPTION_LIMIT = 120;
 
 /**
- * The one-line caption for an automation report.
+ * What separates an automation header's "what happened" from its "what the
+ * model should do about it" (an em dash with spaces). A PARSER TOKEN for the
+ * API's own wording, never copy we write — built from a code point so the
+ * house em-dash guard, which scans string literals for prose, does not read
+ * it as user-facing text.
+ */
+const HEADER_SEPARATOR = ` ${String.fromCharCode(0x2014)} `;
+
+/**
+ * The one-line caption for an automation report — WHAT HAPPENED, in the
+ * reader's terms.
  *
  * `turn.message` for a cron or watch fire is the platform's RUN INSTRUCTION,
- * not a title: a header sentence, then the agent's own stored prompt, then a
- * recent-output excerpt (see `buildWatchRunMessage` in the API's
- * watch-fire-service). Posting it verbatim published the instructions —
- * "finish with a SHORT report", cleanup commands, dozens of excerpt lines —
- * as if they were the agent's words, which is exactly the wall of text the
- * caption is supposed to label. The web has always truncated this to one
- * line (`AutomationTurnHeader`); Slack had no equivalent, so it printed the
- * whole thing.
+ * addressed to the model: a header sentence, then the agent's stored prompt,
+ * then an output excerpt. Only the first clause of that header is about the
+ * reader's world ("Watch on process \"giraffe\" fired: the process
+ * finished"); everything after the em dash is stage direction for the model
+ * — "triggered automatically, not by a person typing", "finish with a SHORT
+ * report", where the answer will be delivered.
  *
- * First line, bounded. The stored turn message stays verbatim — this is a
- * rendering decision, and the API keeps owning the header's own safety
- * (`cleanName` strips the newlines a forged process name would inject, which
- * is what keeps a first-line cut from being a security boundary).
+ * Publishing the stage direction told the reader nothing and made the label
+ * compete with the report it labels. So the caption keeps the clause BEFORE
+ * the em dash and drops the rest.
+ *
+ * Recognising the header is deliberately loose: the three shapes the API
+ * emits (`watch-fire-service`, `cron-fire-service`) all open with `[` and
+ * carry ` — ` before the instructions, so the rule is structural rather
+ * than a copy of their wording — which would rot the moment either side is
+ * reworded. Anything unrecognised falls back to the bounded first line, so
+ * a future header shape degrades to today's behavior instead of vanishing.
  */
 export const automationCaption = (title: string): string => {
   // \r too: a CRLF header would otherwise leave a stray carriage return
   // riding the caption into Slack.
   const firstLine = title.split(/[\r\n]/, 1)[0]?.trim() ?? "";
-  if (firstLine.length <= CAPTION_LIMIT) return firstLine;
+
+  // The platform header, unwrapped: drop the bracket and everything from the
+  // separator on: everything after it is the model's stage direction.
+  const headline = firstLine.startsWith("[")
+    ? (firstLine.slice(1).split(HEADER_SEPARATOR, 1)[0] ?? "").trim()
+    : firstLine;
+
+  // Trailing punctuation left by the unwrap: the closing bracket when the
+  // header had no separator at all, and a dangling colon when the trigger
+  // clause behind it was empty.
+  const cleaned = headline.replace(/[\]:\s]+$/, "");
+  const caption = cleaned.length > 0 ? cleaned : firstLine;
+
+  if (caption.length <= CAPTION_LIMIT) return caption;
   // Prefer a word boundary in the back half, so the cut reads as a clipped
   // phrase rather than a severed word.
-  const window = firstLine.slice(0, CAPTION_LIMIT);
+  const window = caption.slice(0, CAPTION_LIMIT);
   const space = window.lastIndexOf(" ");
   const cut = space > CAPTION_LIMIT / 2 ? space : CAPTION_LIMIT;
   // Never end on a lone high surrogate — the same cut-safety rule the plain
   // answer degrade below applies, or the tail renders as a replacement char.
-  const clipped = firstLine
+  const clipped = caption
     .slice(0, cut)
     .replace(/[\uD800-\uDBFF]$/, "")
     .trimEnd();
@@ -180,11 +207,49 @@ export const slackMirrorPosts: MirrorPosts = {
     // posting all of it made the label longer than the report — see
     // `automationCaption`.
     const caption = automationCaption(input.title);
-    await postMessage(input.credential, {
+    const captionText = `${icon} ${escapeSlackText(caption)}`;
+    const bodySections = input.body
+      ? sectionChunks(markdownToMrkdwn(input.body))
+      : [];
+    const notificationText = input.body
+      ? `${captionText}\n${markdownToMrkdwn(input.body)}`
+      : captionText;
+    // Past the block budget the caption degrades to a plain post: a
+    // delivered report beats a prettier lost one (the same rule the connect
+    // cards follow).
+    if (bodySections.length + 1 > BLOCK_BUDGET) {
+      await postMessage(input.credential, {
+        channel: input.channel,
+        text: notificationText,
+        ...targetForm(input),
+      });
+      return;
+    }
+    await postBlocks(input.credential, {
       channel: input.channel,
-      text: input.body
-        ? `${icon} _${escapeSlackText(caption)}_\n${markdownToMrkdwn(input.body)}`
-        : `${icon} _${escapeSlackText(caption)}_`,
+      // `text` stays the full line: it is the notification and search
+      // preview, and a blocks-only post shows as blank in both.
+      text: notificationText,
+      // The caption is CHROME — it says why the agent spoke, not what it
+      // said. A `context` block is Slack's own treatment for that: smaller
+      // and grey, so the report below it stays the thing being read. The
+      // report is a normal section, in the agent's ordinary voice.
+      //
+      // CHUNKED: Slack caps a section at 3,000 characters and rejects the
+      // WHOLE post past it — after the mirror cursor already advanced, which
+      // would silently drop the report. An automation body runs to the
+      // mirror's 40k ceiling, so it is split the same way the connect-card
+      // path splits its prose.
+      blocks: [
+        {
+          type: "context",
+          elements: [{ type: "mrkdwn", text: captionText }],
+        },
+        ...bodySections.map((section) => ({
+          type: "section",
+          text: { type: "mrkdwn", text: section },
+        })),
+      ],
       ...targetForm(input),
     });
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@onecli/agent-protocol": "workspace:*",
     "@onecli/api": "workspace:*",
     "@onecli/db": "workspace:*",
     "@onecli/ui": "workspace:*",

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/activity-line.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/activity-line.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+/**
+ * The live activity line — what the agent is doing right now, while it works.
+ *
+ * Replaces the old bare "Thinking…" pulse with the agent's own words
+ * ("Architecting the narrative arc") or a phrase for the tool it just
+ * started ("Running a command").
+ *
+ * DESIGNED TO READ AS TRANSIENT (user feedback, 2026-08-31: the first cut
+ * looked like ordinary content). Three cues say "this text is not staying",
+ * and they are deliberately redundant so the meaning survives when any one
+ * of them is unavailable:
+ *
+ *  - WEIGHT: dimmer than body copy (`/60`) and one step smaller, so it sits
+ *    visually below the answer that replaces it rather than beside it.
+ *  - MOTION: a slow shimmer across the text — the "in progress" idiom, and
+ *    the thing a static screenshot cannot fake. Disabled wholesale under
+ *    `prefers-reduced-motion`, where the dimming alone carries the meaning.
+ *  - SHAPE: italic, which nothing else in the transcript uses, so the line
+ *    is distinguishable from the agent's actual prose even in grayscale or
+ *    at a glance.
+ *
+ * SECURITY: `text` is model output from a sandbox that reads the open
+ * internet, so it is untrusted. It arrives already bounded, single-line and
+ * control-stripped (`activityForReasoning`), and it is rendered as TEXT here
+ * — never markdown, never a link. Do not "improve" this by passing it
+ * through the markdown renderer.
+ */
+export const ActivityLine = ({ text }: { text: string }) => (
+  <p
+    className="text-muted-foreground/60 flex items-center gap-2 text-xs italic"
+    // Polite: a caption that changes every few seconds must never interrupt
+    // a screen-reader user mid-sentence.
+    aria-live="polite"
+  >
+    <span
+      aria-hidden
+      className="bg-muted-foreground/40 size-1.5 shrink-0 animate-pulse rounded-full motion-reduce:animate-none"
+    />
+    {/* The shimmer rides a background gradient over the glyphs themselves
+        (`bg-clip-text` + transparent fill), so it needs no overlay element
+        and cannot desynchronize from the text it describes. Under reduced
+        motion the animation stops AND the normal color is restored — a
+        frozen gradient would leave the line unevenly tinted. */}
+    <span className="from-muted-foreground/40 via-muted-foreground to-muted-foreground/40 motion-safe:animate-shimmer min-w-0 truncate bg-gradient-to-r bg-[length:200%_100%] bg-clip-text text-transparent motion-reduce:bg-none motion-reduce:text-inherit">
+      {text}
+    </span>
+  </p>
+);

--- a/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/turn-block.tsx
+++ b/apps/web/src/app/(dashboard)/w/[workspaceId]/agents/[agentId]/chat/_components/turn-block.tsx
@@ -11,6 +11,7 @@ import {
   isJoiningTurn,
 } from "@/lib/chat/turns";
 import { AutomationTurnHeader } from "./automation-turn";
+import { ActivityLine } from "./activity-line";
 import { ChatMarkdown } from "./chat-markdown";
 import { ConnectorSuggestions } from "./connect-suggestions";
 import { ToolCallRow } from "./tool-call-row";
@@ -85,7 +86,15 @@ export const TurnBlock = ({
   // red blob and then swap to the friendly notice — so an active turn keeps
   // its waiting state and the error renders only from the settled poll view.
   const errorText = turn.error ?? (active ? undefined : rendered?.error);
-  const showWaiting = active && (rendered?.tools.length ?? 0) === 0;
+  // The live caption: what the agent is doing right now. Shown while the turn
+  // runs and while it has not yet said anything — once the answer starts
+  // arriving, the answer itself is the better signal of progress.
+  // Falls back to the lifecycle copy before the agent reports any activity
+  // (waking a sandbox can take a moment, and a blank row reads as broken).
+  const activityText = active
+    ? (rendered?.activity ?? waitingCopy(turn))
+    : undefined;
+  const showActivity = Boolean(activityText) && !rendered?.text;
   // A turn the reader can fix from the Models page — no key yet, or a key
   // the provider refused. Rendered as guidance with the fix attached, rather
   // than as a failure.
@@ -158,10 +167,8 @@ export const TurnBlock = ({
                     (suppressed above): one unmissable call to action. */}
                 <ConnectorSuggestions text={rendered.text} />
               </>
-            ) : showWaiting ? (
-              <p className="text-muted-foreground animate-pulse text-sm">
-                {waitingCopy(turn)}
-              </p>
+            ) : showActivity ? (
+              <ActivityLine text={activityText!} />
             ) : null}
             {rendered?.notices.map((notice, index) => (
               <TurnNotice key={`${index}-${notice}`} message={notice} />

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -15,3 +15,30 @@
 .animate-pulse-ring {
   animation: pulse-ring 2s ease-out infinite;
 }
+
+/*
+ * The agent's live activity caption (ActivityLine): a slow highlight
+ * travelling across the glyphs, so a line of model text reads as "being
+ * worked on" rather than as content that has settled.
+ *
+ * Rides a 200%-wide background under `bg-clip-text`, so it animates
+ * `background-position` only — no layout, no paint of the text itself.
+ * 2.4s is deliberately unhurried: this sits in a chat the user is reading,
+ * and a fast shimmer would pull the eye away from the answer above it.
+ *
+ * The component applies it via `motion-safe:`, so `prefers-reduced-motion`
+ * removes the motion entirely (and restores a flat color) rather than
+ * leaving a frozen gradient tinting the line.
+ */
+@keyframes activity-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+.animate-shimmer {
+  animation: activity-shimmer 2.4s linear infinite;
+}

--- a/apps/web/src/lib/chat/live-replay.test.ts
+++ b/apps/web/src/lib/chat/live-replay.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { foldTranscript } from "@/lib/chat/transcript";
+
+// The EXACT batch sequence captured from Guy's live Slack turn on
+// 2026-08-31 (PROBE batch kinds, in arrival order). No thinking.delta:
+// this agent has no model set, so reasoning never came. The loader must
+// still narrate from tool events alone.
+const LIVE = [
+  ["turn.started"],
+  ["text.delta"],
+  ["text.delta"],
+  ["text.delta", "tool.started", "tool.finished"],
+  ["text.delta", "tool.started"],
+  ["tool.finished"],
+  ["text.delta", "tool.started", "tool.finished"],
+  ["text.delta", "text", "turn.done"],
+];
+
+describe("the live turn, replayed through the shipped fold", () => {
+  it("narrates from tool events alone, then clears on turn.done", () => {
+    let seq = 0;
+    const events: unknown[] = [];
+    const seen: (string | undefined)[] = [];
+
+    for (const batch of LIVE) {
+      for (const type of batch) {
+        const payload =
+          type === "tool.started"
+            ? { callId: `c${seq}`, name: "bash" }
+            : type === "tool.finished"
+              ? { callId: `c${seq}`, name: "bash", output: "ok" }
+              : type === "text.delta" || type === "text"
+                ? { text: "hi" }
+                : {};
+        events.push({ seq: seq++, turnId: "t1", type, payload });
+      }
+      const turns = foldTranscript(events as never);
+      seen.push(turns[0]?.activity);
+    }
+
+    // While tools run, the row says what is happening.
+    expect(seen.slice(3, 7)).toEqual([
+      "Running a command",
+      "Running a command",
+      "Running a command",
+      "Running a command",
+    ]);
+    // And the turn ending takes it down — never left standing over an answer.
+    expect(seen.at(-1)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/chat/transcript.test.ts
+++ b/apps/web/src/lib/chat/transcript.test.ts
@@ -84,6 +84,56 @@ describe("foldTranscript", () => {
     expect(settled[0]?.ended).toBe(true);
   });
 
+  it("tracks the live activity, and drops it when the turn ends", () => {
+    // THE LOADER (user decision, 2026-08-31). The agent's own words while it
+    // works, replaced as work moves, gone once the turn is over — the answer
+    // is the record, this is the progress.
+    const working = foldTranscript([
+      event("t1", "thinking.delta", {
+        text: "Architecting the narrative arc\nthen I will consider…",
+      }),
+    ]);
+    // First line only — the intent, not the digression.
+    expect(working[0]?.activity).toBe("Architecting the narrative arc");
+
+    // A started tool OUTRANKS the reasoning: the plan is now happening.
+    const running = foldTranscript([
+      event("t1", "thinking.delta", { text: "Architecting the narrative arc" }),
+      event("t1", "tool.started", { callId: "c1", name: "bash" }),
+    ]);
+    expect(running[0]?.activity).toBe("Running a command");
+
+    // Terminal: no current activity. A caption left standing would describe
+    // work that already finished.
+    const done = foldTranscript([
+      event("t1", "thinking.delta", { text: "Architecting the narrative arc" }),
+      event("t1", "tool.started", { callId: "c1", name: "bash" }),
+      event("t1", "text", { text: "Done." }),
+      event("t1", "turn.done"),
+    ]);
+    expect(done[0]?.activity).toBeUndefined();
+    expect(done[0]?.text).toBe("Done.");
+  });
+
+  it("keeps the last caption when a reasoning block says nothing", () => {
+    // Null (nothing worth showing) must not blank the row — the previous
+    // caption is still the truest thing we know.
+    const turns = foldTranscript([
+      event("t1", "thinking.delta", { text: "Checking the CI logs" }),
+      event("t1", "thinking.delta", { text: "   \n  " }),
+    ]);
+    expect(turns[0]?.activity).toBe("Checking the CI logs");
+  });
+
+  it("clears the activity on a failed turn too", () => {
+    const turns = foldTranscript([
+      event("t1", "thinking.delta", { text: "Checking the CI logs" }),
+      event("t1", "error", { message: "the harness died" }),
+    ]);
+    expect(turns[0]?.activity).toBeUndefined();
+    expect(turns[0]?.error).toBe("the harness died");
+  });
+
   it("pairs a tool's finish onto its start", () => {
     const turns = foldTranscript([
       event("t1", "tool.started", { callId: "c1", name: "bash" }),

--- a/apps/web/src/lib/chat/transcript.ts
+++ b/apps/web/src/lib/chat/transcript.ts
@@ -1,3 +1,7 @@
+import {
+  activityForReasoning,
+  activityForTool,
+} from "@onecli/agent-protocol/activity";
 import type { TurnEvent } from "@/lib/api/types";
 
 /**
@@ -22,6 +26,20 @@ export interface RenderedTurn {
   /** The agent's answer. Empty while it is still only deltas. */
   text: string;
   tools: ToolCall[];
+  /**
+   * What the agent is doing RIGHT NOW, in a few words — the live loader
+   * caption ("Reading a file", "Architecting the narrative arc").
+   *
+   * Derived from the ephemeral stream, never from history: `thinking.delta`
+   * says it in the agent's own words, `tool.started` says it by name. It is
+   * REPLACED as work moves and dropped the moment the turn ends, because it
+   * describes the present — a finished turn has no current activity, and a
+   * reader who joins late gets the answer, not a stale caption.
+   *
+   * UNTRUSTED: model text from a sandbox. Bounded and control-stripped at the
+   * source (`activityForReasoning`), and rendered as TEXT, never markup.
+   */
+  activity?: string;
   /** Set when the turn ended badly — rendered instead of a silent stop. */
   error?: string;
   /**
@@ -80,6 +98,10 @@ export const foldTranscript = (events: TurnEvent[]): RenderedTurn[] => {
           callId: str(event.payload, "callId"),
           name: str(event.payload, "name"),
         });
+        // A started tool IS the current activity, and it outranks whatever
+        // the agent was thinking a moment ago: the reasoning explains the
+        // plan, the tool call is the plan happening.
+        turn.activity = activityForTool(str(event.payload, "name"));
         break;
       case "tool.finished": {
         const callId = str(event.payload, "callId");
@@ -108,14 +130,28 @@ export const foldTranscript = (events: TurnEvent[]): RenderedTurn[] => {
       case "error":
         turn.error = str(event.payload, "message");
         turn.ended = true;
+        turn.activity = undefined;
         break;
       case "turn.done":
         turn.ended = true;
+        // The turn is over: there is no current activity, and a caption left
+        // standing would describe work that already finished.
+        turn.activity = undefined;
         break;
+      case "thinking.delta": {
+        // The agent saying what it is about to do, in its own words — the
+        // line that makes the loader feel alive rather than generic. Only
+        // the first line survives (see `activityForReasoning`); null means
+        // the block said nothing worth showing, so the previous caption
+        // stands rather than blanking the row.
+        const said = activityForReasoning(str(event.payload, "text"));
+        if (said) turn.activity = said;
+        break;
+      }
       default:
-        // `turn.started`, `thinking.delta`, `approval.pending` — nothing to
-        // fold here. Approvals render from the live approvals API, which
-        // carries the decision surface the transcript does not.
+        // `turn.started`, `approval.pending` — nothing to fold here.
+        // Approvals render from the live approvals API, which carries the
+        // decision surface the transcript does not.
         break;
     }
   }

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./activity": "./src/activity.ts"
   },
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/packages/agent-protocol/src/activity.security.test.ts
+++ b/packages/agent-protocol/src/activity.security.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { ACTIVITY_TEXT_MAX, activityForReasoning } from "./activity";
+
+/**
+ * ADVERSARIAL INPUT — the derivation is the only thing between
+ * sandbox-controlled model text and two user-facing surfaces (the operator's
+ * browser and a Slack thread). A page the agent reads can influence this
+ * text, so the invariants below are a security boundary, not formatting
+ * taste: whatever goes in, what comes out is ONE short line of inert
+ * characters.
+ *
+ * Consumers still render it as TEXT (JSX child / Slack form field, never
+ * markdown, never a block-kit string) — this is defense in depth, not the
+ * only defense.
+ */
+describe("the activity line under hostile input", () => {
+  const hostile: [string, string][] = [
+    ["script tag", "<script>alert(1)</script>"],
+    ["markdown javascript: link", "[click](javascript:alert(1))"],
+    ["html attribute handler", "<img src=x onerror=alert(1)>"],
+    ["markdown flood", "*".repeat(5_000)],
+    ["NUL byte", "a\u0000b"],
+    ["line separator", "line1\u2028line2"],
+    ["length bomb", "x".repeat(100_000)],
+    ["RTL override", "\u202Egnirts desrever"],
+    ["newline injection", "Reading\nSECOND LINE SHOULD NOT SHOW"],
+  ];
+
+  for (const [label, input] of hostile) {
+    it(`stays one short inert line: ${label}`, () => {
+      const out = activityForReasoning(input);
+      if (out === null) return; // dropping it entirely is a fine outcome
+
+      // BOUNDED — +1 for the ellipsis the cut may add.
+      expect(out.length).toBeLessThanOrEqual(ACTIVITY_TEXT_MAX + 1);
+      // SINGLE LINE — a second line could forge a separate status row.
+      expect(out).not.toContain("\n");
+      // INERT — no control characters, no Unicode line/paragraph separators
+      // (U+2028 breaks a Slack status row and is rejected by the transcript
+      // store), and no bidi override that could visually reorder the line.
+      // Asserting the ABSENCE of control characters is the point of this
+      // check, so the rule's own warning does not apply.
+      // eslint-disable-next-line no-control-regex
+      expect(out).not.toMatch(/[\u0000-\u001f\u007f\u2028\u2029]/);
+      // NO BIDI SPOOFING — a planted U+202E visually reverses the rest of
+      // the row, so sandbox text could display as something other than what
+      // the transcript records.
+      expect(out).not.toMatch(/[\u202a-\u202e\u2066-\u2069]/);
+    });
+  }
+
+  it("drops bidi overrides rather than letting them reverse the row", () => {
+    // MUTATION-PROOF: remove the bidi arms from `stripForStatus` and this
+    // fails. Found during this change's own security pass — the first
+    // implementation stripped control chars but let U+202E through.
+    const out = activityForReasoning("\u202Egnirts desrever");
+    expect(out).toBe("gnirts desrever");
+    expect(out).not.toContain("\u202E");
+  });
+
+  it("does not resurrect a second line after stripping", () => {
+    // The cut is on the FIRST line, so content after a newline can never
+    // reach a surface — the property a "just truncate it" implementation
+    // would quietly lose.
+    expect(activityForReasoning("Reading\nSECRET")).toBe("Reading");
+  });
+});

--- a/packages/agent-protocol/src/activity.test.ts
+++ b/packages/agent-protocol/src/activity.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVITY_TEXT_MAX,
+  activityForReasoning,
+  activityForTool,
+} from "./activity";
+
+/**
+ * The activity line is the ONE derivation two surfaces share (web chat, Slack
+ * work status), and it renders UNTRUSTED sandbox text. These pin the two
+ * properties that matter: it reads like a status, and it can never become
+ * anything but a short single line.
+ */
+describe("activityForReasoning", () => {
+  it("takes the first line — the intent, not the digression", () => {
+    // Models open a thinking block with what they are about to do, then
+    // ramble. The opening line is the only part that reads like a status.
+    expect(
+      activityForReasoning(
+        "Architecting two distinct characters\nThen I need to consider the arc, and whether the ending earns itself…",
+      ),
+    ).toBe("Architecting two distinct characters");
+  });
+
+  it("skips leading blank lines rather than returning nothing", () => {
+    expect(activityForReasoning("\n\n  \nChecking the CI logs")).toBe(
+      "Checking the CI logs",
+    );
+  });
+
+  it("strips markdown furniture — this is a status row, not a document", () => {
+    expect(activityForReasoning("## **Reviewing** the `diff`")).toBe(
+      "Reviewing the diff",
+    );
+    expect(activityForReasoning("- Reading the config")).toBe(
+      "Reading the config",
+    );
+    expect(activityForReasoning("> Considering the tradeoff")).toBe(
+      "Considering the tradeoff",
+    );
+  });
+
+  it("strips control characters and Unicode line separators", () => {
+    // U+2028 would otherwise split a Slack status row; control bytes are
+    // rejected outright by the transcript store.
+    expect(activityForReasoning("Check\u0007ing\u2028 the logs")).toBe(
+      "Checking the logs",
+    );
+  });
+
+  it("bounds a long line at a word boundary, with an ellipsis", () => {
+    const line = activityForReasoning(`${"alpha beta ".repeat(30)}omega`);
+    expect(line).not.toBeNull();
+    expect(line!.length).toBeLessThanOrEqual(ACTIVITY_TEXT_MAX + 1);
+    expect(line!.endsWith("…")).toBe(true);
+    // Cut BETWEEN words, not through one.
+    expect(line).not.toMatch(/alp…$/);
+  });
+
+  it("hard-cuts an unbroken word rather than running past the bound", () => {
+    const line = activityForReasoning("x".repeat(500));
+    expect(line!.length).toBe(ACTIVITY_TEXT_MAX + 1);
+    expect(line!.endsWith("…")).toBe(true);
+  });
+
+  it("never ends on a split surrogate pair", () => {
+    // Cutting mid-emoji leaves a lone high surrogate, which renders as a
+    // replacement character on both surfaces.
+    const line = activityForReasoning("😀".repeat(200));
+    expect(/[\uD800-\uDBFF]$/.test(line!.slice(0, -1))).toBe(false);
+  });
+
+  it("returns null when there is nothing to say", () => {
+    // Null and "" render differently: null keeps the previous line, an empty
+    // string would blank the row.
+    expect(activityForReasoning("")).toBeNull();
+    expect(activityForReasoning("   \n\t\n  ")).toBeNull();
+    expect(activityForReasoning("***")).toBeNull();
+  });
+});
+
+describe("activityForTool", () => {
+  it("names the activity, not the API call", () => {
+    expect(activityForTool("bash")).toBe("Running a command");
+    expect(activityForTool("read")).toBe("Reading a file");
+    expect(activityForTool("webfetch")).toBe("Fetching a page");
+  });
+
+  it("sees through the platform's MCP prefix", () => {
+    // The prefix is plumbing; a reader should get the same phrase either way.
+    expect(activityForTool("mcp__onecli__process_status")).toBe(
+      "Checking background work",
+    );
+    expect(activityForTool("process_status")).toBe("Checking background work");
+  });
+
+  it("is case-insensitive", () => {
+    expect(activityForTool("BASH")).toBe("Running a command");
+  });
+
+  it("NEVER echoes an unknown tool's raw name", () => {
+    // MCP servers define their own tool names, so the name is
+    // sandbox-controlled text. A generic phrase beats putting it on screen.
+    expect(activityForTool("some_third_party_tool")).toBe("Using a tool");
+    expect(activityForTool("<script>alert(1)</script>")).toBe("Using a tool");
+    expect(activityForTool("mcp__evil__" + "x".repeat(500))).toBe(
+      "Using a tool",
+    );
+  });
+});

--- a/packages/agent-protocol/src/activity.ts
+++ b/packages/agent-protocol/src/activity.ts
@@ -1,0 +1,167 @@
+/**
+ * Strip control characters (keeping nothing but printable text), the Unicode
+ * line/paragraph separators U+2028/U+2029, and the BIDI FORMATTING controls.
+ *
+ * The bidi set matters here in a way it does not for a stored document: an
+ * activity line is a short status rendered beside the agent's name, so a
+ * planted U+202E (right-to-left override) visually REVERSES the rest of the
+ * row — letting sandbox-authored text spoof a different message than the one
+ * an operator would read back from the transcript. The characters carry no
+ * meaning in a one-line status, so they are dropped rather than escaped.
+ *
+ * Deliberately a LOCAL copy of `memory-file`'s `stripControl` rather than an
+ * import: this module is CLIENT-REACHABLE (the web chat's transcript fold
+ * renders the activity line), and `memory-file` pulls in `node:crypto` for
+ * its checksum helper — importing it here would drag a Node builtin into the
+ * browser bundle.
+ *
+ * Newlines are NOT kept (unlike the memory-file variant): an activity line is
+ * single-line by construction, and the caller splits on newlines first.
+ */
+const stripForStatus = (raw: string): string =>
+  [...raw]
+    .filter((ch) => {
+      const code = ch.charCodeAt(0);
+      // U+2028/U+2029 line and paragraph separators.
+      if (code === 0x2028 || code === 0x2029) return false;
+      // Bidi overrides/embeddings (U+202A–U+202E) and isolates
+      // (U+2066–U+2069) — the visual-spoofing set.
+      if (code >= 0x202a && code <= 0x202e) return false;
+      if (code >= 0x2066 && code <= 0x2069) return false;
+      return (code >= 0x20 && code !== 0x7f) || ch === "\n";
+    })
+    .join("");
+
+/**
+ * THE ACTIVITY LINE — what the agent is doing *right now*, in a few words.
+ *
+ * The surfaces show a live caption while a turn runs ("Reading the CI logs",
+ * "Running a command") and drop it the moment the answer lands. That caption
+ * is derived HERE, once, because two very different consumers need identical
+ * semantics: the web chat renders it under the turn, and the Slack adapter
+ * sends it as the agent-session work status. A second implementation would
+ * drift, and the drift would be user-visible.
+ *
+ * WHY THIS IS ITS OWN LAW, not a formatting detail:
+ *
+ * 1. **The text is UNTRUSTED.** Reasoning deltas are model output from a
+ *    sandbox that reads the open internet, so a page the agent visits can
+ *    influence what appears here. It is bounded, control-stripped, and
+ *    single-line by construction — never markup, never a link, never long
+ *    enough to be a message. Consumers still render it as TEXT.
+ * 2. **It is EPHEMERAL.** Nothing derived here is ever persisted (the delta
+ *    law, §3.17): the answer is the record, this is the loader. Keeping the
+ *    derivation next to the event vocabulary makes that adjacency obvious.
+ * 3. **It is a summary, not a transcript.** Only the FIRST line of a
+ *    reasoning block survives (user decision, 2026-08-31): models open a
+ *    thinking block with a statement of intent and then digress, so the
+ *    opening line is the part that reads like a status while the rest is
+ *    the rambling nobody asked to watch.
+ */
+
+/**
+ * Hard ceiling on a rendered activity line. Slack's status renders on one
+ * row beside the app name, and the web's line truncates in a narrow column —
+ * past roughly this length both are cutting anyway, so the cut is ours to
+ * make deliberately rather than theirs to make arbitrarily.
+ */
+export const ACTIVITY_TEXT_MAX = 80;
+
+/**
+ * The tool-name → human phrase map. Deliberately a small allowlist of the
+ * tools a reader actually sees, in the present participle ("Reading a
+ * file"), so the line reads as an activity rather than an API call.
+ *
+ * An UNKNOWN tool falls back to a generic phrase rather than echoing its
+ * raw name: tool names come from the sandbox (MCP servers can define their
+ * own), so echoing them would put unbounded sandbox-controlled text on two
+ * surfaces for no product gain.
+ */
+const TOOL_PHRASES: Record<string, string> = {
+  bash: "Running a command",
+  read: "Reading a file",
+  write: "Writing a file",
+  edit: "Editing a file",
+  multiedit: "Editing a file",
+  agentgrep: "Searching the code",
+  ls: "Listing files",
+  webfetch: "Fetching a page",
+  websearch: "Searching the web",
+  patch: "Applying a patch",
+  apply_patch: "Applying a patch",
+  todo: "Planning the work",
+  swarm: "Coordinating helpers",
+  process_start: "Starting background work",
+  process_status: "Checking background work",
+  process_watch: "Watching background work",
+  process_stop: "Stopping background work",
+  memory_save: "Saving to memory",
+  memory_get: "Reading its memory",
+  memory_list: "Reading its memory",
+  memory_search: "Searching its memory",
+  schedule_task: "Scheduling a task",
+  list_tasks: "Checking its schedule",
+  cancel_task: "Cancelling a task",
+  skill_create: "Writing a skill",
+  skill_update: "Updating a skill",
+  skill_list: "Reading its skills",
+  skill_delete: "Removing a skill",
+};
+
+/** The phrase for a tool nobody mapped — see TOOL_PHRASES on why we do not
+ * echo the raw name. */
+const GENERIC_TOOL_PHRASE = "Using a tool";
+
+/**
+ * The activity line for a running tool call.
+ *
+ * The platform prefixes its MCP tools (`mcp__onecli__process_status`), so the
+ * lookup strips that prefix before matching — the prefix is plumbing, and a
+ * reader should see "Checking background work" either way.
+ */
+export const activityForTool = (name: string): string => {
+  const bare = name.replace(/^mcp__[^_]+__/, "").toLowerCase();
+  return TOOL_PHRASES[bare] ?? GENERIC_TOOL_PHRASE;
+};
+
+/**
+ * The activity line for a reasoning block, or null when there is nothing
+ * worth showing.
+ *
+ * FIRST LINE ONLY, then bounded. A model opens a thinking block with its
+ * intent ("Architecting two distinct characters and their arc") and then
+ * digresses for paragraphs; the opening line is the status, the rest is the
+ * digression. Markdown emphasis and heading marks are stripped rather than
+ * rendered — this lands in a status row, not a document.
+ *
+ * Returns null for empty/whitespace input so callers can distinguish "no
+ * activity to show" from "an empty caption", which render differently (the
+ * previous line stands vs. a blank row).
+ */
+export const activityForReasoning = (raw: string): string | null => {
+  const firstLine = stripForStatus(raw)
+    .split("\n")
+    .find((l) => l.trim() !== "");
+  if (!firstLine) return null;
+
+  const cleaned = firstLine
+    // Leading markdown furniture: heading marks, list bullets, quote marks.
+    .replace(/^[\s>#*\-+]+/, "")
+    // Inline emphasis/code marks anywhere — the row cannot render them, and
+    // showing the literal asterisks reads as a bug.
+    .replace(/[*_`]/g, "")
+    .trim();
+  if (!cleaned) return null;
+
+  if (cleaned.length <= ACTIVITY_TEXT_MAX) return cleaned;
+  // Prefer a word boundary in the back half so the cut reads as a clipped
+  // phrase; never end on a lone high surrogate (a split emoji renders as a
+  // replacement char).
+  const window = cleaned.slice(0, ACTIVITY_TEXT_MAX);
+  const space = window.lastIndexOf(" ");
+  const cut = space > ACTIVITY_TEXT_MAX / 2 ? space : ACTIVITY_TEXT_MAX;
+  return `${cleaned
+    .slice(0, cut)
+    .replace(/[\uD800-\uDBFF]$/, "")
+    .trimEnd()}…`;
+};

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -60,6 +60,12 @@ export {
 } from "./attachments";
 
 export {
+  ACTIVITY_TEXT_MAX,
+  activityForReasoning,
+  activityForTool,
+} from "./activity";
+
+export {
   MAX_MEMORY_WRITE_BYTES,
   MEMORY_DESCRIPTION_MAX_LENGTH,
   MEMORY_FILE_CONTENT_MAX_CHARS,

--- a/packages/api/src/routes/runner-narration.test.ts
+++ b/packages/api/src/routes/runner-narration.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * WHAT THE CHANNEL NARRATION SAYS, and when it says nothing.
+ *
+ * `pushTurnNarration` decides which of a batch's events becomes a task row.
+ * Two rules carry real weight and are easy to break by accident:
+ *
+ *   - a batch that ENDS the turn must narrate nothing, because the clear
+ *     path is already taking the card down and a row added now would
+ *     describe work that has already finished;
+ *   - an unknown tool must never have its own NAME echoed — MCP servers
+ *     choose those, so the string is sandbox-controlled.
+ *
+ * Pinned against the real batch shapes observed on a live turn (2026-08-31):
+ * text deltas and tool events arrive interleaved, and the terminal batch
+ * carries the answer text together with `turn.done`.
+ *
+ * The tenancy fence that gates this call is pinned separately, in
+ * `conversation.pg.test.ts` ("REPORTS the fence verdict").
+ */
+
+const narrateTurnActivity = vi.fn();
+vi.mock("../services/channels/turn-receipt-service", () => ({
+  narrateTurnActivity: (...args: unknown[]) => narrateTurnActivity(...args),
+  clearTurnReceipts: vi.fn(),
+  attachTurnReceipt: vi.fn(),
+  moveTurnReceipt: vi.fn(),
+  sweepStaleSessionReceipts: vi.fn(),
+}));
+
+import type { AgentEvent } from "@onecli/agent-protocol";
+
+import { pushTurnNarration } from "./runner";
+
+const push = (events: unknown[]) =>
+  pushTurnNarration("turn-1", events as AgentEvent[]);
+
+beforeEach(() => {
+  narrateTurnActivity.mockReset();
+});
+
+describe("which event becomes the task row", () => {
+  it("narrates the tool that started", () => {
+    push([
+      { type: "text.delta", text: "hi" },
+      { type: "tool.started", callId: "c1", name: "bash" },
+      { type: "tool.finished", callId: "c1" },
+    ]);
+    expect(narrateTurnActivity).toHaveBeenCalledWith(
+      "turn-1",
+      "Running a command",
+    );
+  });
+
+  it("keeps only the LAST tool in a batch — earlier rows are already stale", () => {
+    push([
+      { type: "tool.started", callId: "c1", name: "bash" },
+      { type: "tool.started", callId: "c2", name: "read" },
+    ]);
+    expect(narrateTurnActivity).toHaveBeenCalledTimes(1);
+    expect(narrateTurnActivity).toHaveBeenCalledWith(
+      "turn-1",
+      "Reading a file",
+    );
+  });
+
+  it("says nothing for a batch with no tool at all", () => {
+    push([
+      { type: "text.delta", text: "thinking out loud" },
+      { type: "thinking.delta", text: "reasoning" },
+    ]);
+    expect(narrateTurnActivity).not.toHaveBeenCalled();
+  });
+
+  it("never echoes an unknown tool's own name — MCP servers choose those", () => {
+    push([
+      {
+        type: "tool.started",
+        callId: "c1",
+        name: "mcp__evil__<script>alert(1)</script>",
+      },
+    ]);
+    expect(narrateTurnActivity).toHaveBeenCalledWith("turn-1", "Using a tool");
+  });
+});
+
+describe("when the narration must stay silent", () => {
+  it("says NOTHING when the batch ends the turn", () => {
+    push([
+      { type: "text.delta", text: "done" },
+      { type: "text", text: "the answer" },
+      { type: "turn.done" },
+    ]);
+    expect(narrateTurnActivity).not.toHaveBeenCalled();
+  });
+
+  it("says NOTHING when a tool starts in the same batch that ends the turn", () => {
+    // MUTATION-PROOF: remove the terminal early-return and this fails. A
+    // tool that started in the batch that ends the turn has necessarily
+    // finished, so narrating it would leave a row describing done work.
+    push([
+      { type: "tool.started", callId: "c1", name: "bash" },
+      { type: "turn.done" },
+    ]);
+    expect(narrateTurnActivity).not.toHaveBeenCalled();
+  });
+
+  it("says NOTHING when the batch errored", () => {
+    push([
+      { type: "tool.started", callId: "c1", name: "bash" },
+      { type: "error", message: "boom" },
+    ]);
+    expect(narrateTurnActivity).not.toHaveBeenCalled();
+  });
+
+  it("says NOTHING for an empty batch", () => {
+    push([]);
+    expect(narrateTurnActivity).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/runner.ts
+++ b/packages/api/src/routes/runner.ts
@@ -51,6 +51,9 @@ import {
 } from "../services/turn-service";
 import { buildTurnContext } from "../services/turn-context-service";
 import { MAX_TURN_CONTEXT_CHARS } from "@onecli/agent-protocol";
+import { activityForTool } from "@onecli/agent-protocol/activity";
+import type { AgentEvent } from "@onecli/agent-protocol";
+import { narrateTurnActivity } from "../services/channels/turn-receipt-service";
 import { buildHomeSyncItem } from "../services/home-sync-service";
 import {
   executeMemoryFileWrite,
@@ -59,6 +62,40 @@ import {
 import { logger } from "../lib/logger";
 
 const log = logger.child({ component: "runner-routes" });
+
+/**
+ * Narrate a batch's work onto the turn's channel loader.
+ *
+ * TOOL CALLS ONLY, deliberately. `tool.started` is durable and coarse — a
+ * handful per turn — which is what keeps this far away from the ~2s edit
+ * loop the de-streaming amendment removed. Reasoning (`thinking.delta`)
+ * is NOT used: it is ephemeral by the delta law, arrives token-by-token,
+ * and narrating it would reintroduce exactly that cadence.
+ *
+ * Only the LAST tool in a batch is sent — intermediate rows are already
+ * stale by the time the batch lands.
+ *
+ * Detached (`void`): the caller must not wait on a channel round-trip to
+ * ack a runner batch.
+ *
+ * Exported for its test: which event becomes a row, and when nothing is
+ * said, is the whole behavior — worth pinning without standing up a Hono
+ * app, a runner token, and a database around it.
+ */
+export const pushTurnNarration = (
+  turnId: string,
+  events: AgentEvent[],
+): void => {
+  let activity: string | undefined;
+  for (const event of events) {
+    // A terminal event ends the turn, and the clear path owns taking the
+    // narration down. Saying anything now would describe finished work.
+    if (event.type === "turn.done" || event.type === "error") return;
+    if (event.type === "tool.started") activity = activityForTool(event.name);
+  }
+  if (!activity) return;
+  void narrateTurnActivity(turnId, activity);
+};
 
 /** The turn-queue telemetry line — see services/claim-wait-log.ts. */
 const logClaimWait = createLogClaimWait(logger);
@@ -421,14 +458,27 @@ export const runnerRoutes = () => {
           case "home.synced":
             await applyRunnerEvent(runnerId, event);
             break;
-          case "turn.events":
-            await applyTurnEvents(
+          case "turn.events": {
+            const accepted = await applyTurnEvents(
               { runnerId, sandboxId: event.sandboxId },
               event.conversationId,
               event.turnId,
               event.events,
             );
+            // The channel's narration rides the SAME batch the web reads —
+            // one source, two consumers — and ONLY when the transcript
+            // accepted it: a batch from a sandbox that does not host this
+            // turn is ignored there, and must not drive another tenant's
+            // channel thread here.
+            //
+            // Detached and best-effort: narration decorates a loader that is
+            // already standing, so it must never delay an ack or fail a
+            // batch. Wired HERE rather than inside `applyTurnEvents` because
+            // the transcript service has no channel dependency and should
+            // not grow one — routes are where the two meet.
+            if (accepted) pushTurnNarration(event.turnId, event.events);
             break;
+          }
           case "turn.progress":
             await applyTurnProgress(
               { runnerId, sandboxId: event.sandboxId },

--- a/packages/api/src/services/channels/channels.pg.test.ts
+++ b/packages/api/src/services/channels/channels.pg.test.ts
@@ -87,6 +87,9 @@ const nowSec = () => Math.floor(Date.now() / 1000);
 interface SlackCall {
   method: string;
   form: URLSearchParams;
+  /** The raw request body, for the JSON-bodied methods (the streaming trio
+   * sends a `chunks` array, which cannot survive form encoding). */
+  raw: string;
   /** The Bearer token, when the call carried one (the convenience view). */
   token: string | null;
   /** The RAW Authorization header — the Basic-auth assertion surface
@@ -126,6 +129,8 @@ const startCdnFake = (): Promise<string> =>
         const call: SlackCall = {
           method: path,
           form: new URLSearchParams(),
+          // The CDN fake serves file bytes, never a Web API method body.
+          raw: "",
           token: auth?.startsWith("Bearer ") ? auth.slice(7) : null,
           authorization: auth,
         };
@@ -166,6 +171,7 @@ const startSlackFake = (): Promise<string> =>
           const call: SlackCall = {
             method,
             form: new URLSearchParams(raw),
+            raw,
             token: auth?.startsWith("Bearer ") ? auth.slice(7) : null,
             authorization: auth,
           };
@@ -5655,6 +5661,7 @@ describe.skipIf(!PROOF_URL)("turn receipts (the reaction 'seen' mark)", () => {
           channel: "C905",
           messageTs: "802.0001",
           kind: "session",
+          workStatusSet: true,
           createdAt: before,
         },
         {
@@ -5663,6 +5670,7 @@ describe.skipIf(!PROOF_URL)("turn receipts (the reaction 'seen' mark)", () => {
           channel: "C905",
           messageTs: "802.0002",
           kind: "session",
+          workStatusSet: true,
         },
         {
           turnId: oldReaction,
@@ -6051,6 +6059,460 @@ describe.skipIf(!PROOF_URL)("turn receipts (the reaction 'seen' mark)", () => {
     expect(
       await db.channelTurnReceipt.findUnique({ where: { turnId } }),
     ).toBeNull();
+  });
+});
+
+describe.skipIf(!PROOF_URL)("turn narration (the live task card)", () => {
+  const seedSessionReceipt = async (
+    turnId: string,
+    cardThreadTs: string | null = null,
+  ) => {
+    const { presenceId } = await seedChannelAgent(`narrate-${turnId}`, {
+      presenceCredentials: await getCrypto().encrypt(
+        JSON.stringify({ botToken: "xoxb-narrate" }),
+      ),
+    });
+    await db.channelTurnReceipt.create({
+      data: {
+        turnId,
+        agentChannelId: presenceId,
+        channel: "D950",
+        messageTs: "900.0001",
+        cardThreadTs,
+        kind: "session",
+      },
+    });
+    return presenceId;
+  };
+
+  const planOf = (raw: string) => {
+    const blocks = JSON.parse(
+      new URLSearchParams(raw).get("blocks") ?? "[]",
+    ) as {
+      type: string;
+      title: string;
+      tasks: { title: string; status: string }[];
+    }[];
+    return blocks[0]!;
+  };
+
+  const pastThrottle = (turnId: string) =>
+    db.channelTurnReceipt.update({
+      where: { turnId },
+      data: { cardAt: new Date(Date.now() - 10_000) },
+    });
+
+  it("a DM gets NO native loader — the card is the whole signal", async () => {
+    // Slack's agent-session status opens a thread in a DM ("calling
+    // setStatus on that thread will automatically open the thread for the
+    // user"), and it only says the agent is busy. The card says WHAT it is
+    // doing and sits inline, so the enum costs a thread and buys nothing.
+    //
+    // MUTATION-PROOF: drop the `narratesInline` arm and this fails —
+    // every DM turn would open a thread again.
+    const { presenceId } = await seedChannelAgent("dm-no-enum", {
+      appMode: "agent",
+      presenceCredentials: await getCrypto().encrypt(
+        JSON.stringify({ botToken: "xoxb-dm" }),
+      ),
+    });
+    slackHandlers["agents.sessions.setStatus"] = () => ({ ok: true });
+    slackHandlers["reactions.add"] = () => ({ ok: true });
+
+    await receipts.attachTurnReceipt({
+      presenceId,
+      turnId: "turn-dm-no-enum",
+      channel: "D970",
+      messageTs: "980.0001",
+      threadTs: "980.0001",
+      replyThreadTs: null,
+      isDirect: true,
+      text: "hey",
+    });
+
+    expect(slackCallsFor("agents.sessions.setStatus")).toHaveLength(0);
+    // ...but the receipt still exists, because it is what the card hangs
+    // off. Losing it would lose the narration with the loader.
+    const row = await db.channelTurnReceipt.findUniqueOrThrow({
+      where: { turnId: "turn-dm-no-enum" },
+    });
+    expect(row.kind).toBe("session");
+    expect(row.workStatusSet).toBe(false);
+
+    // And a SEEN mark lands on the user's own message, beside the card.
+    // The card is a separate message; without this, nothing acknowledges
+    // the line they actually typed.
+    // MUTATION-PROOF: drop the seen-mark arm and this fails.
+    const marked = slackCallsFor("reactions.add").at(-1)!;
+    expect(marked.form.get("timestamp")).toBe("980.0001");
+    expect(row.reaction).not.toBeNull();
+    // Its address is stored, because `messageTs` on a session row is the
+    // thread root — unreacting there on clear would miss.
+    expect(row.seenMessageTs).toBe("980.0001");
+  });
+
+  it("the clear does NOT set a status that was never set", async () => {
+    // A card-only DM has no loader to take down. Calling the enum on the
+    // clear would turn one ON at the very moment the turn ends — and in a
+    // DM that also opens the thread this whole path exists to avoid.
+    //
+    // MUTATION-PROOF: drop `&& receipt.workStatusSet` and this fails.
+    const { presenceId } = await seedChannelAgent("dm-clear-no-enum", {
+      appMode: "agent",
+      presenceCredentials: await getCrypto().encrypt(
+        JSON.stringify({ botToken: "xoxb-dm" }),
+      ),
+    });
+    await db.channelTurnReceipt.create({
+      data: {
+        turnId: "turn-dm-clear",
+        agentChannelId: presenceId,
+        channel: "D971",
+        messageTs: "981.0001",
+        kind: "session",
+        workStatusSet: false,
+      },
+    });
+    slackHandlers["agents.sessions.setStatus"] = () => ({ ok: true });
+
+    await receipts.clearTurnReceipt("turn-dm-clear");
+
+    expect(slackCallsFor("agents.sessions.setStatus")).toHaveLength(0);
+    // ...and the row still goes, so nothing is left behind.
+    expect(
+      await db.channelTurnReceipt.findUnique({
+        where: { turnId: "turn-dm-clear" },
+      }),
+    ).toBeNull();
+  });
+
+  it("a CHANNEL still gets the native loader", async () => {
+    // The conversation is threaded anyway, and the loader is what surfaces
+    // the agent in the channel list. MUTATION-PROOF: widen the DM arm to
+    // every conversation and this fails.
+    const { presenceId } = await seedChannelAgent("channel-keeps-enum", {
+      appMode: "agent",
+      presenceCredentials: await getCrypto().encrypt(
+        JSON.stringify({ botToken: "xoxb-ch" }),
+      ),
+    });
+    slackHandlers["agents.sessions.setStatus"] = () => ({ ok: true });
+
+    await receipts.attachTurnReceipt({
+      presenceId,
+      turnId: "turn-channel-enum",
+      channel: "C970",
+      messageTs: "980.0002",
+      threadTs: "980.0001",
+      replyThreadTs: "980.0001",
+      isDirect: false,
+      text: "hey",
+    });
+
+    expect(slackCallsFor("agents.sessions.setStatus")).toHaveLength(1);
+    const row = await db.channelTurnReceipt.findUniqueOrThrow({
+      where: { turnId: "turn-channel-enum" },
+    });
+    expect(row.workStatusSet).toBe(true);
+  });
+
+  it("posts the card TOP-LEVEL in a DM — no thread is opened", async () => {
+    await seedSessionReceipt("turn-card-dm");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: true,
+      channel: "D950",
+      ts: "950.5001",
+    });
+
+    await receipts.narrateTurnActivity("turn-card-dm", "Running a command");
+
+    const posted = slackCallsFor("chat.postMessage").at(-1)!;
+    // The whole point of the card over Slack's streaming methods: those
+    // demand a thread root, which in a DM means a thread per turn.
+    // MUTATION-PROOF: pass the session root as the card's thread and this
+    // fails.
+    expect(posted.form.get("thread_ts")).toBeNull();
+    expect(planOf(posted.raw).tasks).toEqual([
+      { task_id: "t0", title: "Running a command", status: "in_progress" },
+    ]);
+  });
+
+  it("posts the card IN THREAD for a group mention", async () => {
+    // A channel mention already answers in a thread, so the card belongs
+    // there beside the answer rather than in the channel at large.
+    await seedSessionReceipt("turn-card-group", "700.0009");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: true,
+      channel: "D950",
+      ts: "950.5002",
+    });
+
+    await receipts.narrateTurnActivity("turn-card-group", "Running a command");
+
+    expect(
+      slackCallsFor("chat.postMessage").at(-1)!.form.get("thread_ts"),
+    ).toBe("700.0009");
+  });
+
+  it("UPDATES the one card as work moves, finishing the earlier steps", async () => {
+    await seedSessionReceipt("turn-card-steps");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: true,
+      channel: "D950",
+      ts: "950.5003",
+    });
+    slackHandlers["chat.update"] = () => ({ ok: true });
+
+    await receipts.narrateTurnActivity("turn-card-steps", "Running a command");
+    await pastThrottle("turn-card-steps");
+    await receipts.narrateTurnActivity("turn-card-steps", "Reading a file");
+
+    // ONE card: a second post would leave the first stranded.
+    expect(slackCallsFor("chat.postMessage")).toHaveLength(1);
+    const updated = slackCallsFor("chat.update").at(-1)!;
+    expect(updated.form.get("ts")).toBe("950.5003");
+    // Every step but the newest is finished by definition — the agent moved
+    // on from it.
+    expect(planOf(updated.raw).tasks).toEqual([
+      { task_id: "t0", title: "Running a command", status: "complete" },
+      { task_id: "t1", title: "Reading a file", status: "in_progress" },
+    ]);
+    const row = await db.channelTurnReceipt.findUniqueOrThrow({
+      where: { turnId: "turn-card-steps" },
+    });
+    expect(row.cardTs).toBe("950.5003");
+    expect(row.cardSteps).toEqual(["Running a command", "Reading a file"]);
+  });
+
+  it("says nothing twice for the same step", async () => {
+    await seedSessionReceipt("turn-card-repeat");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: true,
+      channel: "D950",
+      ts: "950.5004",
+    });
+    slackHandlers["chat.update"] = () => ({ ok: true });
+
+    await receipts.narrateTurnActivity("turn-card-repeat", "Running a command");
+    await pastThrottle("turn-card-repeat");
+    await receipts.narrateTurnActivity("turn-card-repeat", "Running a command");
+
+    expect(slackCallsFor("chat.update")).toHaveLength(0);
+  });
+
+  it("THROTTLES: an agent alternating tools cannot hammer Slack", async () => {
+    await seedSessionReceipt("turn-card-throttle");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: true,
+      channel: "D950",
+      ts: "950.5005",
+    });
+    slackHandlers["chat.update"] = () => ({ ok: true });
+
+    // read → bash → read: the step CHANGES every call, so repeat
+    // suppression alone would let all three through.
+    // MUTATION-PROOF: remove the interval check and this fails.
+    await receipts.narrateTurnActivity("turn-card-throttle", "Reading a file");
+    await receipts.narrateTurnActivity(
+      "turn-card-throttle",
+      "Running a command",
+    );
+    await receipts.narrateTurnActivity("turn-card-throttle", "Reading a file");
+    expect(slackCallsFor("chat.update")).toHaveLength(0);
+
+    // ...and once the floor passes, narration resumes: the throttle delays a
+    // step, it never silences the turn.
+    await pastThrottle("turn-card-throttle");
+    await receipts.narrateTurnActivity(
+      "turn-card-throttle",
+      "Searching the web",
+    );
+    expect(slackCallsFor("chat.update")).toHaveLength(1);
+  });
+
+  it("REMOVES the card when the answer posts — a loader is not a reply", async () => {
+    await seedSessionReceipt("turn-card-clear");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: true,
+      channel: "D950",
+      ts: "950.5006",
+    });
+    slackHandlers["chat.delete"] = () => ({ ok: true });
+    slackHandlers["agents.sessions.setStatus"] = () => ({ ok: true });
+
+    await receipts.narrateTurnActivity("turn-card-clear", "Running a command");
+    await receipts.clearTurnReceipt("turn-card-clear");
+
+    // MUTATION-PROOF: drop the removal from the clear path and this fails —
+    // every turn would end with a stale card beside its answer.
+    const deleted = slackCallsFor("chat.delete").at(-1)!;
+    expect(deleted.form.get("ts")).toBe("950.5006");
+    expect(
+      await db.channelTurnReceipt.findUnique({
+        where: { turnId: "turn-card-clear" },
+      }),
+    ).toBeNull();
+  });
+
+  it("the stale sweep removes an ABANDONED card", async () => {
+    await seedSessionReceipt("turn-card-sweep");
+    slackHandlers["chat.delete"] = () => ({ ok: true });
+    slackHandlers["agents.sessions.setStatus"] = () => ({ ok: true });
+    // A turn whose process died mid-run: nothing else will ever take its
+    // card down.
+    await db.channelTurnReceipt.update({
+      where: { turnId: "turn-card-sweep" },
+      data: {
+        cardTs: "950.5007",
+        cardSteps: ["Running a command"],
+        createdAt: new Date(Date.now() - 11 * 60 * 1000),
+      },
+    });
+
+    await receipts.sweepStaleSessionReceipts();
+
+    expect(slackCallsFor("chat.delete")).toHaveLength(1);
+  });
+
+  it("leaves the row alone when the workspace REFUSES to narrate", async () => {
+    await seedSessionReceipt("turn-card-refused");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: false,
+      error: "channel_type_not_supported",
+    });
+
+    await receipts.narrateTurnActivity(
+      "turn-card-refused",
+      "Running a command",
+    );
+
+    const row = await db.channelTurnReceipt.findUniqueOrThrow({
+      where: { turnId: "turn-card-refused" },
+    });
+    // Nothing recorded: a later clear must not try to remove a card that was
+    // never posted, and the steps must not claim a row the reader cannot see.
+    expect(row.cardTs).toBeNull();
+    expect(row.cardSteps).toEqual([]);
+  });
+
+  it("posts ONE card when two batches race", async () => {
+    await seedSessionReceipt("turn-card-race");
+    let posts = 0;
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    slackHandlers["chat.postMessage"] = async () => {
+      posts += 1;
+      // Hold the first post inside Slack, so the second caller runs its own
+      // claim while the first is still in flight — the only window where the
+      // race exists.
+      if (posts === 1) await held;
+      return { ok: true, channel: "D950", ts: `950.600${posts}` };
+    };
+    slackHandlers["chat.update"] = () => ({ ok: true });
+
+    const first = receipts.narrateTurnActivity(
+      "turn-card-race",
+      "Running a command",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // Clear the throttle stamp WITHOUT touching the steps, so the rate floor
+    // cannot be what stops the second caller and the claim stands alone.
+    await db.channelTurnReceipt.update({
+      where: { turnId: "turn-card-race" },
+      data: { cardAt: null },
+    });
+    await receipts.narrateTurnActivity("turn-card-race", "Reading a file");
+    release?.();
+    await first;
+
+    // MUTATION-PROOF: drop the claim's verdict check and this reads 2 — two
+    // cards for one turn, one of them orphaned.
+    expect(posts).toBe(1);
+  });
+
+  it("no step is LOST when two batches update one card together", async () => {
+    // The claim's job once a card exists. Two callers read the same
+    // revision, each builds its own list from it, and the loser must stand
+    // down — otherwise its list (which never contained the winner's step)
+    // overwrites the winner's, and a step silently disappears from the card.
+    //
+    // MUTATION-PROOF: drop `if (claimed.count === 0) return;` and this
+    // fails — the card ends up showing only one of the two steps.
+    await seedSessionReceipt("turn-card-lost");
+    slackHandlers["chat.postMessage"] = () => ({
+      ok: true,
+      channel: "D950",
+      ts: "950.7001",
+    });
+    let updates = 0;
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    slackHandlers["chat.update"] = async () => {
+      updates += 1;
+      if (updates === 1) await held;
+      return { ok: true };
+    };
+
+    // A card already exists, with one step on it.
+    await receipts.narrateTurnActivity("turn-card-lost", "Running a command");
+    await pastThrottle("turn-card-lost");
+
+    // Two updates in flight over the same revision.
+    const first = receipts.narrateTurnActivity(
+      "turn-card-lost",
+      "Reading a file",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await db.channelTurnReceipt.update({
+      where: { turnId: "turn-card-lost" },
+      data: { cardAt: null },
+    });
+    await receipts.narrateTurnActivity("turn-card-lost", "Editing a file");
+    release?.();
+    await first;
+
+    const row = await db.channelTurnReceipt.findUniqueOrThrow({
+      where: { turnId: "turn-card-lost" },
+    });
+    // Both steps survive, in order. The claim runs BEFORE the provider call,
+    // so a second caller reads the first's step and appends to it rather
+    // than racing it — which is the property worth having: the card grows,
+    // it never rewinds.
+    expect(row.cardSteps).toEqual([
+      "Running a command",
+      "Reading a file",
+      "Editing a file",
+    ]);
+  });
+
+  it("never narrates onto a REACTION receipt — that mark is the fallback", async () => {
+    const { presenceId } = await seedChannelAgent("narrate-reaction", {
+      presenceCredentials: await getCrypto().encrypt(
+        JSON.stringify({ botToken: "xoxb-narrate" }),
+      ),
+    });
+    await db.channelTurnReceipt.create({
+      data: {
+        turnId: "turn-card-reaction",
+        agentChannelId: presenceId,
+        channel: "D951",
+        messageTs: "900.0002",
+        kind: "reaction",
+        reaction: "eyes",
+      },
+    });
+    const before = slackCallsFor("chat.postMessage").length;
+
+    await receipts.narrateTurnActivity(
+      "turn-card-reaction",
+      "Running a command",
+    );
+
+    expect(slackCallsFor("chat.postMessage")).toHaveLength(before);
   });
 });
 

--- a/packages/api/src/services/channels/providers/slack/dispatch.ts
+++ b/packages/api/src/services/channels/providers/slack/dispatch.ts
@@ -111,7 +111,11 @@ const receiptForAcceptedTurn = (
       conversationId: outcome.conversationId,
       channel: call.replyChannel,
       messageTs: call.messageTs,
-      threadTs: call.replyThreadTs,
+      // Same session-root rule as the attach below: a DM's root is the
+      // message that started the exchange. Kept identical on purpose — the
+      // move's no-mark fallback calls `attachTurnReceipt`, so a divergence
+      // here would give a follow-up a different session than its own turn.
+      threadTs: call.replyThreadTs ?? call.messageTs,
       text: call.text,
     });
     return;
@@ -122,9 +126,26 @@ const receiptForAcceptedTurn = (
     turnId: outcome.turn.id,
     channel: call.replyChannel,
     messageTs: call.messageTs,
-    // Group threads carry the root ts the agent-flavor loader is keyed by;
-    // DMs are null — they answer top-level and never get the loader.
-    threadTs: call.replyThreadTs,
+    // The session root the agent-flavor loader is keyed by.
+    //
+    // A GROUP mention carries the thread root it will answer in. A DM has no
+    // thread — it answers top-level — but Slack still requires a `thread_ts`
+    // to scope an agent session (`thread_ts_required` otherwise), and the
+    // user's own message IS a valid root: the session hangs off the message
+    // that started the exchange, which is exactly the turn this receipt
+    // marks.
+    //
+    // This is what gives DMs the native loader at all. Before it they fell
+    // through to the emoji reaction, which is a "seen" mark rather than a
+    // "working" one — the agent looked idle for the whole turn.
+    threadTs: call.replyThreadTs ?? call.messageTs,
+    // Where a narration card may go: the real reply thread, which is null in
+    // a DM. Kept apart from the session root above so a DM's card stays
+    // inline instead of opening a thread per turn.
+    replyThreadTs: call.replyThreadTs,
+    // A DM has no reply thread. Stated outright so the receipt does not
+    // have to infer it from an absent field.
+    isDirect: call.replyThreadTs === null,
     text: call.text,
   });
 };

--- a/packages/api/src/services/channels/providers/slack/narration.test.ts
+++ b/packages/api/src/services/channels/providers/slack/narration.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { slackProvider } from "./provider";
+
+/**
+ * SLACK NARRATION — the task card that says what the agent is doing while it
+ * works ("Running a command"), posted beside the conversation.
+ *
+ * The mechanism is a plain message carrying a `plan` block, advanced with
+ * `chat.update` and removed with `chat.delete`. Slack's streaming methods
+ * render the same block but demand a thread root, which in a DM means a
+ * thread per turn — the cost this shape exists to avoid (verified live
+ * 2026-08-31: a `plan` block posted with `chat.postMessage` and no
+ * `thread_ts` renders top-level in a DM).
+ *
+ * Only `fetch` is mocked: the real provider and the real block building run,
+ * because the block shape IS the contract.
+ */
+
+const CREDS = JSON.stringify({ botToken: "xoxb-test-token" });
+
+interface SlackRequest {
+  method: string;
+  form: URLSearchParams;
+}
+
+let requests: SlackRequest[] = [];
+let responder: (method: string) => Record<string, unknown>;
+
+const requestAt = (index: number): SlackRequest => {
+  const request = requests[index];
+  if (!request) throw new Error(`expected a request at index ${index}`);
+  return request;
+};
+
+const planOf = (request: SlackRequest) => {
+  const blocks = JSON.parse(request.form.get("blocks") ?? "[]") as {
+    type: string;
+    title: string;
+    tasks: { task_id: string; title: string; status: string }[];
+  }[];
+  const plan = blocks[0];
+  if (!plan) throw new Error("expected a plan block");
+  return plan;
+};
+
+beforeEach(() => {
+  requests = [];
+  // `chat.postMessage` answers with the channel too, and the client
+  // validates it — a fixture that omits it fails the parse, not the code.
+  responder = () => ({ ok: true, channel: "D123", ts: "1788200000.000100" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init: { body?: string }) => {
+      const method = String(url).split("/api/")[1] ?? "";
+      requests.push({
+        method,
+        form: new URLSearchParams(init.body ?? ""),
+      });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => responder(method),
+      } as unknown as Response;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("posting the card", () => {
+  it("posts TOP-LEVEL when the conversation has no thread", async () => {
+    const result = await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["Running a command"],
+      cardTs: null,
+    });
+
+    expect(result).toEqual({ cardTs: "1788200000.000100" });
+    expect(requests.map((r) => r.method)).toEqual(["chat.postMessage"]);
+    // The whole reason this is a message rather than a stream: Slack's
+    // streaming methods answer `invalid_thread_ts` without a root, so they
+    // cannot put a card in a DM without opening a thread for it.
+    expect(requestAt(0).form.get("thread_ts")).toBeNull();
+  });
+
+  it("posts IN THREAD when the conversation is threaded", async () => {
+    await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "C123",
+      threadTs: "1788199999.000001",
+      activities: ["Running a command"],
+      cardTs: null,
+    });
+
+    expect(requestAt(0).form.get("thread_ts")).toBe("1788199999.000001");
+  });
+
+  it("renders every step but the newest as finished", async () => {
+    await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["Running a command", "Reading a file", "Editing a file"],
+      cardTs: null,
+    });
+
+    // The agent moved on from the earlier steps, so they are done by
+    // definition — only the newest is still running.
+    expect(planOf(requestAt(0)).tasks).toEqual([
+      { task_id: "t0", title: "Running a command", status: "complete" },
+      { task_id: "t1", title: "Reading a file", status: "complete" },
+      { task_id: "t2", title: "Editing a file", status: "in_progress" },
+    ]);
+  });
+
+  it("names the plan, so it is not titled by Slack's default", async () => {
+    await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["Running a command"],
+      cardTs: null,
+    });
+
+    expect(planOf(requestAt(0)).title).toBe("Working on your request");
+  });
+});
+
+describe("advancing the card", () => {
+  it("UPDATES the existing card rather than posting a second one", async () => {
+    const result = await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["Running a command", "Reading a file"],
+      cardTs: "1788200000.000100",
+    });
+
+    expect(result).toEqual({ cardTs: "1788200000.000100" });
+    expect(requests.map((r) => r.method)).toEqual(["chat.update"]);
+    expect(requestAt(0).form.get("ts")).toBe("1788200000.000100");
+  });
+
+  it("re-renders the WHOLE list, so there is no partial state to reconcile", async () => {
+    await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["Running a command", "Reading a file"],
+      cardTs: "1788200000.000100",
+    });
+
+    expect(planOf(requestAt(0)).tasks).toHaveLength(2);
+  });
+});
+
+describe("when Slack will not narrate", () => {
+  it("answers null on refusal and never throws — the loader stands", async () => {
+    responder = () => ({ ok: false, error: "channel_type_not_supported" });
+
+    const result = await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["Running a command"],
+      cardTs: null,
+    });
+
+    // Null, not a throw: narration decorates a loader that is already
+    // standing, so a workspace without it loses the words and nothing else.
+    expect(result).toBeNull();
+  });
+
+  it("answers null without calling Slack when there is no credential", async () => {
+    const result = await slackProvider.narrateThreadWork!({
+      credentialsJson: null,
+      channel: "D123",
+      threadTs: null,
+      activities: ["Running a command"],
+      cardTs: null,
+    });
+
+    expect(result).toBeNull();
+    expect(requests).toEqual([]);
+  });
+});
+
+describe("removing the card", () => {
+  it("deletes the message, so a loader never lingers as a reply", async () => {
+    await slackProvider.removeThreadNarration!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      cardTs: "1788200000.000100",
+    });
+
+    expect(requests.map((r) => r.method)).toEqual(["chat.delete"]);
+    expect(requestAt(0).form.get("ts")).toBe("1788200000.000100");
+  });
+
+  it("swallows an already-gone card — the clear and the sweep may both run", async () => {
+    responder = () => ({ ok: false, error: "message_not_found" });
+
+    await expect(
+      slackProvider.removeThreadNarration!({
+        credentialsJson: CREDS,
+        channel: "D123",
+        cardTs: "1788200000.000100",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("untrusted text", () => {
+  it("bounds a hostile step to Slack's task-title limit", async () => {
+    await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["x".repeat(5_000)],
+      cardTs: null,
+    });
+
+    // The shared derivation already bounds this to one short line; the
+    // provider re-bounds because an over-long title fails the whole call,
+    // taking the narration down with it.
+    expect(planOf(requestAt(0)).tasks[0]!.title.length).toBeLessThanOrEqual(
+      256,
+    );
+  });
+
+  it("sends the step as a JSON field, never as markup", async () => {
+    await slackProvider.narrateThreadWork!({
+      credentialsJson: CREDS,
+      channel: "D123",
+      threadTs: null,
+      activities: ["<script>alert(1)</script>"],
+      cardTs: null,
+    });
+
+    // Verbatim in a typed field — Slack renders a task title as plain text,
+    // so there is no markup surface to escape into.
+    expect(planOf(requestAt(0)).tasks[0]!.title).toBe(
+      "<script>alert(1)</script>",
+    );
+  });
+});

--- a/packages/api/src/services/channels/providers/slack/provider.ts
+++ b/packages/api/src/services/channels/providers/slack/provider.ts
@@ -1,4 +1,5 @@
 import { ServiceError } from "../../../errors";
+import { logger } from "../../../../lib/logger";
 import type { ChannelProvider, PresenceIdentity } from "../../types";
 import { dispatchSlackEvent } from "./dispatch";
 import { slackSharedApp } from "./shared-install-service";
@@ -11,6 +12,10 @@ import {
 } from "./manifest";
 import {
   agentsSessionsSetStatus,
+  deleteMessage,
+  postBlocksMessage,
+  SLACK_TASK_TITLE_MAX,
+  updateBlocksMessage,
   authTest,
   downloadPrivateFile,
   filesInfo,
@@ -72,6 +77,15 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  * can be set (Slack has no API for it). */
 const appSettingsUrl = (appId: string): string =>
   `https://api.slack.com/apps/${encodeURIComponent(appId)}/general`;
+
+const log = logger.child({ component: "slack-provider" });
+
+/**
+ * The narration plan's heading. Deliberately plain: it sits above the task
+ * rows for the whole turn, so it describes the ACT of working, never a
+ * specific step (the rows do that).
+ */
+const NARRATION_PLAN_TITLE = "Working on your request";
 
 export const slackProvider: ChannelProvider = {
   id: "slack",
@@ -445,11 +459,104 @@ export const slackProvider: ChannelProvider = {
     // reaction fallback listens for failure, and a silent return here would
     // record a session receipt with no loader behind it).
     if (!botToken) throw new Error("no bot credential");
+
+    // Slack's native agent loader. A free-text CAPTION beside it is not
+    // possible: `agents.sessions.setStatus` documents that "custom loading
+    // messages are not supported", and the legacy free-text method
+    // (`assistant.threads.setStatus`) now runs through a compatibility
+    // bridge onto this same session — VERIFIED LIVE 2026-08-31, it answers
+    // `ok: true` and renders nothing. Words in Slack need `chat.startStream`
+    // task cards, which is a message, not a status.
     await agentsSessionsSetStatus(botToken, {
       channelId: channel,
       threadTs,
       status: working ? "processing" : "active",
     });
+  },
+
+  async narrateThreadWork({
+    credentialsJson,
+    channel,
+    threadTs,
+    activities,
+    cardTs,
+  }) {
+    const botToken = credentialsJson
+      ? parseSlackPresenceCredentials(credentialsJson).botToken
+      : undefined;
+    // Unlike the loader, narration is decoration: a missing credential is
+    // "cannot narrate", not a failure the caller must react to.
+    if (!botToken) return null;
+
+    // The WHOLE card, every time. `chat.update` replaces the message, so the
+    // list is rendered from the turn's full history rather than patched —
+    // which is why there is no partial state to reconcile and no row that
+    // can be left dangling.
+    //
+    // Every step but the last is finished by definition: the agent moved on
+    // from it. Only the newest is still running.
+    const blocks = [
+      {
+        type: "plan",
+        title: NARRATION_PLAN_TITLE,
+        tasks: activities.map((activity, index) => ({
+          task_id: `t${index}`,
+          title: activity.slice(0, SLACK_TASK_TITLE_MAX),
+          status: index === activities.length - 1 ? "in_progress" : "complete",
+        })),
+      },
+    ];
+
+    try {
+      if (cardTs === null) {
+        // FIRST step: a plain message. Omitting `threadTs` in a DM is what
+        // keeps the card top-level, where the conversation already lives —
+        // Slack's streaming methods cannot do this (they answer
+        // `invalid_thread_ts` without a root), and threading a DM per turn
+        // was the cost this replaces.
+        const posted = await postBlocksMessage(botToken, {
+          channel,
+          text: NARRATION_PLAN_TITLE,
+          blocks,
+          ...(threadTs === null ? {} : { threadTs }),
+        });
+        return { cardTs: posted.ts };
+      }
+      await updateBlocksMessage(botToken, {
+        channel,
+        ts: cardTs,
+        text: NARRATION_PLAN_TITLE,
+        blocks,
+      });
+      return { cardTs };
+    } catch (err) {
+      // Narration decorates a loader that is already standing, so a refusal
+      // costs the words and nothing else. Stable message + Slack's own code,
+      // so the rate is measurable in CloudWatch.
+      log.info(
+        { err: String(err), channel },
+        "slack narration refused; native loader stands",
+      );
+      return null;
+    }
+  },
+
+  async removeThreadNarration({ credentialsJson, channel, cardTs }) {
+    const botToken = credentialsJson
+      ? parseSlackPresenceCredentials(credentialsJson).botToken
+      : undefined;
+    if (!botToken) return;
+    try {
+      await deleteMessage(botToken, { channel, ts: cardTs });
+    } catch (err) {
+      // Already gone (`message_not_found`), or a workspace that refuses the
+      // delete. Either way the card stands with its steps complete: a worse
+      // outcome than removal, but not a broken one.
+      log.info(
+        { err: String(err), channel },
+        "slack narration card left standing",
+      );
+    }
   },
 
   buildSetupMaterial({ agentName, transport, publicApiUrl }) {

--- a/packages/api/src/services/channels/providers/slack/session-root.test.ts
+++ b/packages/api/src/services/channels/providers/slack/session-root.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * THE SESSION ROOT — which `thread_ts` a Slack turn's work-status receipt is
+ * keyed by.
+ *
+ * This one expression decides whether a conversation gets Slack's native
+ * agent loader ("<agent> is working…") or falls back to a "seen" emoji, so
+ * it is worth pinning away from the mocks it sits behind.
+ *
+ * The rule (2026-08-31): a GROUP mention uses the thread root it will answer
+ * in; a DM has no thread, so the user's own message is the root. Slack
+ * requires a `thread_ts` to scope an agent session at all — it answers
+ * `thread_ts_required` without one — which is why a DM cannot simply pass
+ * null and still get a loader.
+ *
+ * The load-bearing safety property, pinned in the last case: keying a DM
+ * session by the message ts must NOT change where the answer is posted.
+ * Reply addressing is derived from the LINK (`replyTargetForLink` in the
+ * channel adapter), never from the receipt — a DM still answers top-level.
+ */
+
+const attachTurnReceipt = vi.fn();
+const moveTurnReceipt = vi.fn();
+
+vi.mock("../../turn-receipt-service", () => ({
+  attachTurnReceipt: (...args: unknown[]) => attachTurnReceipt(...args),
+  moveTurnReceipt: (...args: unknown[]) => moveTurnReceipt(...args),
+}));
+
+const ingestDirectMessage = vi.fn();
+const ingestGroupMessage = vi.fn();
+
+vi.mock("../../channel-ingestion-service", () => ({
+  ingestDirectMessage: (...args: unknown[]) => ingestDirectMessage(...args),
+  ingestGroupMessage: (...args: unknown[]) => ingestGroupMessage(...args),
+  ingestGroupInvite: vi.fn(),
+}));
+
+// `db` is only touched by the group door's thread-link check; the DM and
+// mention paths under test never reach it.
+vi.mock("@onecli/db", () => ({
+  db: { channelThreadLink: { findUnique: vi.fn().mockResolvedValue({}) } },
+}));
+
+const { dispatchSlackEvent } = await import("./dispatch");
+
+const TURN = {
+  kind: "turn" as const,
+  conversationId: "cv1",
+  turn: { id: "t1", errorCode: null },
+};
+
+beforeEach(() => {
+  attachTurnReceipt.mockClear();
+  moveTurnReceipt.mockClear();
+  ingestDirectMessage.mockResolvedValue(TURN);
+  ingestGroupMessage.mockResolvedValue(TURN);
+});
+
+const dmEvent = {
+  type: "message",
+  channel_type: "im",
+  channel: "D100",
+  user: "U1",
+  text: "hello",
+  ts: "1717171717.123456",
+};
+
+const mentionEvent = {
+  type: "app_mention",
+  channel: "C200",
+  user: "U1",
+  text: "<@BOT> hello",
+  ts: "1717171799.999999",
+  thread_ts: "1717171700.000001",
+};
+
+describe("the Slack session root", () => {
+  it("keys a DM session by the user's own message", async () => {
+    // Slack refuses a session without a thread_ts, so a DM has to name one.
+    // MUTATION-PROOF: restore `threadTs: call.replyThreadTs` and this fails
+    // with null — the shape that silently cost every DM its loader.
+    await dispatchSlackEvent({
+      presenceId: "p1",
+      identityRef: "BOT",
+      event: dmEvent,
+      eventId: "e1",
+    });
+
+    expect(attachTurnReceipt).toHaveBeenCalledTimes(1);
+    const arg = attachTurnReceipt.mock.calls[0]![0] as Record<string, unknown>;
+    expect(arg.threadTs).toBe("1717171717.123456");
+    expect(arg.channel).toBe("D100");
+  });
+
+  it("keys a group session by the thread root, not the message", async () => {
+    // A mention answers IN its thread, so the root is the thread's — using
+    // the message ts there would scope the session to the wrong place.
+    await dispatchSlackEvent({
+      presenceId: "p1",
+      identityRef: "BOT",
+      event: mentionEvent,
+      eventId: "e2",
+    });
+
+    expect(attachTurnReceipt).toHaveBeenCalledTimes(1);
+    const arg = attachTurnReceipt.mock.calls[0]![0] as Record<string, unknown>;
+    expect(arg.threadTs).toBe("1717171700.000001");
+    expect(arg.messageTs).toBe("1717171799.999999");
+  });
+
+  it("uses the SAME root when a follow-up moves the mark", async () => {
+    // The move's no-mark fallback calls attachTurnReceipt, so a divergence
+    // between these two call sites would give a follow-up a different
+    // session than the turn it belongs to.
+    ingestDirectMessage.mockResolvedValue({
+      kind: "followUp",
+      conversationId: "cv1",
+      turn: { id: "t2", errorCode: null },
+    });
+
+    await dispatchSlackEvent({
+      presenceId: "p1",
+      identityRef: "BOT",
+      event: dmEvent,
+      eventId: "e3",
+    });
+
+    expect(moveTurnReceipt).toHaveBeenCalledTimes(1);
+    const arg = moveTurnReceipt.mock.calls[0]![0] as Record<string, unknown>;
+    expect(arg.threadTs).toBe("1717171717.123456");
+  });
+
+  it("never receipts a turn the door refused", async () => {
+    // A born-failed turn (no model key) gets no loader: there is nothing
+    // running to report on, and the failure is its own message.
+    ingestDirectMessage.mockResolvedValue({
+      kind: "turn",
+      conversationId: "cv1",
+      turn: { id: "t3", errorCode: "no_model_key" },
+    });
+
+    await dispatchSlackEvent({
+      presenceId: "p1",
+      identityRef: "BOT",
+      event: dmEvent,
+      eventId: "e4",
+    });
+
+    expect(attachTurnReceipt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/channels/providers/slack/slack-api.ts
+++ b/packages/api/src/services/channels/providers/slack/slack-api.ts
@@ -348,6 +348,55 @@ export const reactionsAdd = (
 ) => reactionCall("reactions.add", botToken, input);
 
 /**
+ * Slack's cap on a task title inside a `plan` block.
+ */
+export const SLACK_TASK_TITLE_MAX = 256;
+
+/**
+ * REPLACE a message's blocks — how the narration card advances.
+ *
+ * `chat.update` rewrites the whole message, so the card is always rendered
+ * from the turn's full task list rather than patched step by step. That is
+ * what makes the mechanism forgiving: there is no half-updated state to
+ * reconcile, and a missed update is corrected by the next one.
+ */
+export const updateBlocksMessage = (
+  botToken: string,
+  input: { channel: string; ts: string; text: string; blocks: unknown[] },
+) =>
+  slackCall(
+    "chat.update",
+    {
+      token: botToken,
+      form: {
+        channel: input.channel,
+        ts: input.ts,
+        text: input.text,
+        blocks: JSON.stringify(input.blocks),
+      },
+    },
+    okEnvelope,
+  );
+
+/**
+ * REMOVE a message the app posted — how the narration card disappears when
+ * the answer lands, so it is never left behind as a second reply.
+ *
+ * Deliberately tolerant: `message_not_found` (already gone, or deleted by
+ * the user) is the expected race between the clear path and a retry, so
+ * callers treat a refusal as "already removed" rather than an error.
+ */
+export const deleteMessage = (
+  botToken: string,
+  input: { channel: string; ts: string },
+) =>
+  slackCall(
+    "chat.delete",
+    { token: botToken, form: { channel: input.channel, ts: input.ts } },
+    okEnvelope,
+  );
+
+/**
  * The agent-session work status (the native "Working…" loader an agent-flavor
  * app shows in a thread). `processing` turns it on; `active` clears it —
  * NEVER auto-cleared by a message post, so the receipt lifecycle owns both

--- a/packages/api/src/services/channels/turn-receipt-service.ts
+++ b/packages/api/src/services/channels/turn-receipt-service.ts
@@ -2,7 +2,8 @@ import { db, Prisma } from "@onecli/db";
 import { getCrypto } from "../../providers";
 import { channelProvider } from "./registry";
 import { chooseReaction } from "./reaction-chooser";
-import type { ChannelProviderId } from "./types";
+import { ChannelProviderApiError } from "./errors";
+import type { ChannelProvider, ChannelProviderId } from "./types";
 import { logger } from "../../lib/logger";
 
 const log = logger.child({ component: "turn-receipts" });
@@ -34,10 +35,22 @@ export interface AttachReceiptInput {
   /** Provider-opaque address of the USER's message (Slack: channel + ts). */
   channel: string;
   messageTs: string;
-  /** The group thread's ROOT ts (Slack: `thread_ts`) — the key the native
-   * work-status is set on. Null for DMs, which never get the loader (they
-   * answer top-level; a loader would rip the reply into a thread). */
+  /** The SESSION root (Slack: `thread_ts`) — the key the native work-status
+   * is set on. A group mention uses the thread it answers in; a DM has no
+   * thread, so the caller passes the user's own message, because Slack
+   * refuses to scope a session without one. */
   threadTs?: string | null;
+  /** Where a narration CARD may be posted: the group thread's root, or null
+   * in a DM so the card sits inline. Deliberately separate from `threadTs`
+   * above — a DM fakes a session root out of the user's message, and reusing
+   * it here would open a thread for every DM turn. */
+  replyThreadTs?: string | null;
+  /** Whether this is a DIRECT conversation. Explicit rather than inferred
+   * from a null thread: the native work-status opens a thread in a DM
+   * (Slack documents it), so a card-capable provider skips the enum there —
+   * and a caller that omits the field must keep today's behavior, not
+   * silently disable every channel's loader. */
+  isDirect?: boolean;
   /** The inbound message text — what the chooser picks against. */
   text: string;
 }
@@ -83,10 +96,25 @@ export const attachTurnReceipt = async (
       : null;
     const provider = channelProvider(presence.provider as ChannelProviderId);
 
-    // Agent-flavor presence in a group thread: the native work-status IS the
-    // ack. Try it first — on any refusal (plan-gated workspace, missing
-    // scope, dead credential) fall through to the reaction, so the user
-    // always sees SOMETHING move.
+    // The native work-status ("<agent> is working…") is the ack for an
+    // agent-flavor presence. Try it first — on any refusal (plan-gated
+    // workspace, missing scope, dead credential) fall through to the
+    // reaction, so the user always sees SOMETHING move.
+    //
+    // NOT IN A DM, when the presence can post a narration card instead.
+    // Slack documents that setting an agent-session status on a DM
+    // "will automatically open the thread for the user", and it says only
+    // that the agent is busy. The card says WHAT it is doing and sits
+    // inline, so in a DM the enum costs a thread nobody asked for and buys
+    // nothing the card does not already show. A channel keeps it: that
+    // conversation is threaded anyway, and the loader is what surfaces the
+    // agent in the channel list.
+    // A DM that can carry a card: the ONLY shape where the enum is skipped.
+    // Keyed on an explicit flag rather than "replyThreadTs is absent" — a
+    // caller that simply does not pass the field would otherwise read as a
+    // DM and silently cost every channel its loader.
+    const narratesInline =
+      input.isDirect === true && provider.narrateThreadWork !== undefined;
     if (
       presence.appMode === "agent" &&
       input.threadTs &&
@@ -95,13 +123,51 @@ export const attachTurnReceipt = async (
       const threadTs = input.threadTs;
       let statusSet = false;
       try {
-        await provider.setThreadWorkStatus({
-          credentialsJson,
-          channel: input.channel,
-          threadTs,
-          working: true,
-        });
-        statusSet = true;
+        // The session receipt is written either way — it is what the
+        // narration card hangs off. Only the ENUM is conditional.
+        if (!narratesInline) {
+          await provider.setThreadWorkStatus({
+            credentialsJson,
+            channel: input.channel,
+            threadTs,
+            working: true,
+          });
+          statusSet = true;
+        }
+        // The SEEN mark, on the user's own message. In a card-only DM this
+        // is the only acknowledgement that lands on what they typed — the
+        // card is a separate message, and a reader who sends and looks away
+        // wants a mark on their own line. It rides ALONGSIDE the card here
+        // rather than instead of it (elsewhere it is the fallback), so both
+        // signals are present: "seen" on the message, "doing" on the card.
+        let seenReaction: string | null = null;
+        if (narratesInline) {
+          seenReaction = await chooseReaction({
+            agent: {
+              id: presence.agent.id,
+              workspaceId: presence.agent.workspaceId,
+            },
+            organizationId: presence.agent.workspace.organizationId,
+            text: input.text,
+          });
+          try {
+            await provider.addReceiptReaction({
+              credentialsJson,
+              channel: input.channel,
+              messageTs: input.messageTs,
+              reaction: seenReaction,
+            });
+          } catch (err) {
+            // Decoration on top of the card: a refused emoji costs the mark,
+            // never the turn.
+            log.info(
+              { err: String(err), turnId: input.turnId },
+              "seen mark skipped; the card stands",
+            );
+            seenReaction = null;
+          }
+        }
+
         try {
           await db.channelTurnReceipt.create({
             data: {
@@ -111,8 +177,20 @@ export const attachTurnReceipt = async (
               // The THREAD ROOT, not the message: it is the address the
               // clear must set the status back on.
               messageTs: threadTs,
+              // The card's home: the group thread when there is one, null in
+              // a DM so the card sits inline. NOT `threadTs` above — that is
+              // the session root, which a DM fakes from the user's message.
+              cardThreadTs: input.replyThreadTs ?? null,
+              // Recorded, not inferred: the clear cannot otherwise tell a
+              // card-only DM from a channel whose loader is standing.
+              workStatusSet: !narratesInline,
               kind: "session",
-              reaction: null,
+              // Set only on a card-only DM, where the mark rides beside the
+              // card. The clear takes it off the USER's message, which is
+              // why `seenMessageTs` is stored next to it — `messageTs` on a
+              // session row is the thread root, not the user's line.
+              reaction: seenReaction,
+              seenMessageTs: seenReaction === null ? null : input.messageTs,
             },
             select: { id: true },
           });
@@ -280,6 +358,170 @@ const pruneOldReceipts = (agentChannelId: string): void => {
 };
 
 /**
+ * Floor between two narration writes on one turn.
+ *
+ * Slack's message write is rate-limited per app and a busy agent can run
+ * tools faster than the ceiling allows, so tool boundaries alone are not a
+ * bound. 1.5s keeps a long turn's narration comfortably inside it while
+ * still reading as live.
+ */
+const NARRATION_MIN_INTERVAL_MS = 1_500;
+
+/**
+ * How many steps a card shows before the oldest fall off.
+ *
+ * A card is a loader, not a transcript: past a screenful it stops being
+ * glanceable, and Slack caps a plan at 50 tasks regardless. The full history
+ * lives in the web transcript, which is the surface built to hold it.
+ */
+const NARRATION_MAX_STEPS = 12;
+
+/**
+ * REMOVE a turn's narration card, if it has one.
+ *
+ * Shared by the clear path and the stale sweep because both must be safe to
+ * run alone and safe to run twice: whichever gets there first removes the
+ * card, and the other finds nothing (or a provider that answers "already
+ * gone", which the provider swallows).
+ */
+const removeNarrationCard = async (
+  provider: ChannelProvider,
+  input: { credentialsJson: string | null; channel: string; cardTs: string },
+): Promise<void> => {
+  if (!provider.removeThreadNarration) return;
+  await provider.removeThreadNarration(input);
+};
+
+/**
+ * NARRATE the turn's current activity on its own card beside the
+ * conversation — one row per tool call, the newest running.
+ *
+ * Best-effort and never load-bearing: the native loader is already standing
+ * from the attach, so a provider that cannot narrate, a workspace that
+ * refuses, and a turn whose receipt has already been cleared all end the
+ * same way — nothing happens, and the turn is unaffected.
+ *
+ * Only a `session` receipt narrates: a `reaction` receipt is the fallback
+ * for a presence whose provider has no native loader at all, and giving it a
+ * card would be a second, louder mark than the one the user opted into.
+ *
+ * Costs one indexed lookup per tool batch on a turn with no channel receipt
+ * (a web-only agent). No lock, no write, and that is why this stays a plain
+ * lookup rather than a cache that would need invalidating.
+ */
+export const narrateTurnActivity = async (
+  turnId: string,
+  activity: string,
+): Promise<void> => {
+  try {
+    const receipt = await db.channelTurnReceipt.findFirst({
+      where: { turnId, kind: "session" },
+      select: {
+        id: true,
+        channel: true,
+        messageTs: true,
+        cardThreadTs: true,
+        cardTs: true,
+        cardSteps: true,
+        cardRev: true,
+        cardAt: true,
+        agentChannel: { select: { provider: true, credentials: true } },
+      },
+    });
+    // No session receipt = nothing to narrate onto (a reaction fallback, or
+    // a turn whose loader already came down). Not a problem.
+    if (!receipt) return;
+    // The same step repeated: the card already says this, and rewriting it
+    // with itself would spend Slack's rate limit on nothing.
+    if (receipt.cardSteps.at(-1) === activity) return;
+    // THROTTLE. Repeat-suppression alone bounds nothing: an agent
+    // alternating two tools changes the step every call, and a fast turn can
+    // pass Slack's ceiling and start collecting 429s. A step that appears a
+    // beat late is invisible to a reader; a rate-limited channel is not.
+    if (
+      receipt.cardAt &&
+      Date.now() - receipt.cardAt.getTime() < NARRATION_MIN_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    const provider = channelProvider(
+      receipt.agentChannel.provider as ChannelProviderId,
+    );
+    if (!provider.narrateThreadWork) return;
+
+    const steps = [...receipt.cardSteps, activity].slice(-NARRATION_MAX_STEPS);
+
+    // RESERVE the step before talking to the provider, and let that write
+    // be what excludes a rival. The route pushes narration detached, so two
+    // batches for one turn can be in flight together; writing the list here
+    // (not after the call) means the second caller reads the first's step
+    // and APPENDS to it rather than racing it — the card grows, it never
+    // rewinds.
+    //
+    // The revision is bumped for the posting rule below, which is the one
+    // window this ordering cannot cover on its own.
+    await db.channelTurnReceipt.updateMany({
+      where: { id: receipt.id },
+      data: { cardSteps: steps, cardAt: new Date(), cardRev: { increment: 1 } },
+    });
+
+    // POSTING is exclusive, and reserving the step does not make it so:
+    // `cardTs` is written only once the provider answers, so a caller
+    // arriving during that round-trip still reads null and would post a
+    // SECOND card. The first writer (the one that found revision 0) posts;
+    // everyone else waits for the handle rather than racing it.
+    if (receipt.cardTs === null && receipt.cardRev > 0) return;
+
+    const credentialsJson = receipt.agentChannel.credentials
+      ? await getCrypto().decrypt(receipt.agentChannel.credentials)
+      : null;
+
+    const result = await provider.narrateThreadWork({
+      credentialsJson,
+      channel: receipt.channel,
+      // A group thread's card belongs in that thread; a DM has none, and
+      // passing null is what keeps the card inline instead of opening a
+      // thread nobody asked for.
+      threadTs: receipt.cardThreadTs,
+      activities: steps,
+      cardTs: receipt.cardTs,
+    });
+    // Null = this provider or workspace cannot narrate. RELEASE the claim so
+    // the row still reflects what is actually on screen, and nothing later
+    // tries to remove a card that was never posted.
+    if (!result) {
+      await db.channelTurnReceipt.updateMany({
+        // Only if nothing else has written since: a later step's list is
+        // fresher than the one we are rolling back to.
+        where: { id: receipt.id, cardRev: receipt.cardRev + 1 },
+        data: { cardSteps: receipt.cardSteps },
+      });
+      return;
+    }
+
+    // Record the card handle. `updateMany` scoped to the row id makes a
+    // clear that landed in between a no-op rather than resurrecting a
+    // deleted receipt.
+    await db.channelTurnReceipt.updateMany({
+      where: { id: receipt.id },
+      data: { cardTs: result.cardTs },
+    });
+  } catch (err) {
+    // A PROVIDER refusal is routine (plan-gated workspace, dead credential)
+    // and stays at info: the loader is untouched and there is nothing to
+    // fix. A fault on OUR side is not routine — it means narration is
+    // broken for everyone, and swallowing it at the same level is how a
+    // missing column looked exactly like a Slack refusal for a whole
+    // afternoon (observed 2026-08-31). Same swallow, louder record.
+    const providerRefusal = err instanceof ChannelProviderApiError;
+    const line = "activity narration skipped; the loader stands";
+    if (providerRefusal) log.info({ err: String(err), turnId }, line);
+    else log.error({ err: String(err), turnId }, line);
+  }
+};
+
+/**
  * The clear half, fired on a WINNING cursor CAS: the answer is posting, so
  * the "seen" mark comes off and the row goes with it. A missing row is the
  * normal case for web-sourced turns (they never had a receipt).
@@ -294,6 +536,9 @@ export const clearTurnReceipt = async (turnId: string): Promise<void> => {
         messageTs: true,
         kind: true,
         reaction: true,
+        workStatusSet: true,
+        seenMessageTs: true,
+        cardTs: true,
         agentChannel: { select: { provider: true, credentials: true } },
       },
     });
@@ -306,7 +551,18 @@ export const clearTurnReceipt = async (turnId: string): Promise<void> => {
       receipt.agentChannel.provider as ChannelProviderId,
     );
 
-    if (receipt.kind === "session") {
+    // Take the CARD down first, while the loader is still up. The card is a
+    // loader, not a reply: the answer is landing, so leaving it would end
+    // every turn with two messages instead of one.
+    if (receipt.cardTs) {
+      await removeNarrationCard(provider, {
+        credentialsJson,
+        channel: receipt.channel,
+        cardTs: receipt.cardTs,
+      });
+    }
+
+    if (receipt.kind === "session" && receipt.workStatusSet) {
       // The native work-status is NOT auto-cleared by the answer post
       // (Slack: `agents.sessions.setStatus` semantics) — this call is the
       // only thing standing between the user and a loader that burns until
@@ -318,11 +574,23 @@ export const clearTurnReceipt = async (turnId: string): Promise<void> => {
         threadTs: receipt.messageTs,
         working: false,
       });
-    } else if (receipt.reaction) {
+    } else if (receipt.reaction && !receipt.seenMessageTs) {
       await provider.removeReceiptReaction({
         credentialsJson,
         channel: receipt.channel,
         messageTs: receipt.messageTs,
+        reaction: receipt.reaction,
+      });
+    }
+
+    // A seen mark riding BESIDE a card comes off with it. Its address is the
+    // user's own message, which on a session row is not `messageTs` — that
+    // is the thread root, so unreacting there would miss.
+    if (receipt.reaction && receipt.seenMessageTs) {
+      await provider.removeReceiptReaction({
+        credentialsJson,
+        channel: receipt.channel,
+        messageTs: receipt.seenMessageTs,
         reaction: receipt.reaction,
       });
     }
@@ -409,6 +677,7 @@ export const moveTurnReceipt = async (input: {
         messageTs: true,
         kind: true,
         reaction: true,
+        workStatusSet: true,
         agentChannel: {
           select: { id: true, provider: true, credentials: true },
         },

--- a/packages/api/src/services/channels/types.ts
+++ b/packages/api/src/services/channels/types.ts
@@ -451,6 +451,52 @@ export interface ChannelProvider {
    * agent-flavor presences in threads; absent = the provider has no native
    * work-status and reactions are all there is.
    */
+  /**
+   * NARRATE what the agent is doing, as a card beside the conversation —
+   * one row per tool call, the newest running and the rest finished.
+   *
+   * Optional twice over: a provider that cannot narrate omits it entirely,
+   * and one that can may still answer `null` for a workspace that refuses.
+   * Either way the caller does nothing further and the native loader stands
+   * — narration is decoration and must never be load-bearing.
+   *
+   * `activities` is the turn's WHOLE list, oldest first, because the card is
+   * re-rendered rather than patched: there is no partial state to reconcile,
+   * and a missed update is corrected by the next one.
+   *
+   * `cardTs` is the provider's handle for a card already posted, or null to
+   * post the first one. The returned handle is persisted by the caller and
+   * handed back next time.
+   *
+   * `threadTs` is where the card belongs when the conversation is threaded
+   * (a channel mention); null means the conversation itself (a DM), where
+   * the card sits inline rather than opening a thread nobody asked for.
+   *
+   * Every activity is UNTRUSTED (model-derived) and already bounded to one
+   * short line by the shared derivation; a provider must not widen it.
+   */
+  narrateThreadWork?(input: {
+    credentialsJson: string | null;
+    channel: string;
+    threadTs: string | null;
+    activities: string[];
+    cardTs: string | null;
+  }): Promise<{ cardTs: string } | null>;
+
+  /**
+   * REMOVE the narration card, once the answer has been posted — the card is
+   * a loader, not a reply, and leaving it behind would make every turn end
+   * with two messages.
+   *
+   * Best-effort and idempotent: it runs on the clear path AND the stale
+   * sweep, so it must tolerate a card that is already gone.
+   */
+  removeThreadNarration?(input: {
+    credentialsJson: string | null;
+    channel: string;
+    cardTs: string;
+  }): Promise<void>;
+
   setThreadWorkStatus?(input: {
     credentialsJson: string | null;
     /** The provider-opaque conversation id (Slack: channel id). */

--- a/packages/api/src/services/conversation.pg.test.ts
+++ b/packages/api/src/services/conversation.pg.test.ts
@@ -454,6 +454,45 @@ describe.skipIf(!PROOF_URL)("seq allocation", () => {
     );
   });
 
+  it("FENCES a foreign sandbox's batch — it is ignored, not written", async () => {
+    // The fence is a tenancy boundary, not bookkeeping: a sandbox that does
+    // not host this turn must not be able to append to its transcript, and
+    // the rejection is silent by design (a throw would strand the rescue
+    // events a dying sandbox sends).
+    //
+    // MUTATION-PROOF: drop the sandbox arm of the fence and this fails.
+    const own = await seedTalkable("fence-own");
+    const foreign = await seedTalkable("fence-foreign");
+    const turn = await turns.createTurn(
+      WORKSPACE,
+      own.conversationId,
+      "hi",
+      WEB_A,
+    );
+
+    await turns.applyTurnEvents(
+      reporter(RUNNER_A, own.sandboxId),
+      own.conversationId,
+      turn.id,
+      [{ type: "turn.started" }],
+    );
+
+    // Same runner, WRONG sandbox: the batch is ignored.
+    await turns.applyTurnEvents(
+      reporter(RUNNER_A, foreign.sandboxId),
+      own.conversationId,
+      turn.id,
+      [{ type: "turn.done" }],
+    );
+
+    // Nothing from the rejected batch landed.
+    const rows = await db.turnEvent.findMany({
+      where: { conversationId: own.conversationId },
+      select: { type: true },
+    });
+    expect(rows.map((r) => r.type)).toEqual(["turn.started"]);
+  });
+
   it("counts EVERY event, including the ones it does not store", async () => {
     // Deltas consume seq numbers even though they leave no row: a live tail
     // sees them, so the numbering must be the same on both paths or a reader
@@ -663,6 +702,49 @@ describe.skipIf(!PROOF_URL)("seq allocation", () => {
     expect(page.events).toHaveLength(2);
     expect(page.hasMore).toBe(true);
     expect(page.nextSince).toBe(2);
+  });
+
+  it("REPORTS the fence verdict — a foreign sandbox's batch is not accepted", async () => {
+    // The verdict is a SECURITY signal, not bookkeeping. A rejected batch is
+    // ignored rather than thrown (a dying sandbox's rescue events must still
+    // land), so a caller acting on the same events — the Slack narration in
+    // routes/runner.ts — has nothing else to go on. Swallow it and one
+    // tenant's sandbox could drive another tenant's channel thread.
+    //
+    // MUTATION-PROOF: hardcode `return true` in applyTurnEvents and this
+    // fails.
+    const own = await seedTalkable("verdict-own");
+    const foreign = await seedTalkable("verdict-foreign");
+    const turn = await turns.createTurn(
+      WORKSPACE,
+      own.conversationId,
+      "hi",
+      WEB_A,
+    );
+
+    const accepted = await turns.applyTurnEvents(
+      reporter(RUNNER_A, own.sandboxId),
+      own.conversationId,
+      turn.id,
+      [{ type: "turn.started" }],
+    );
+    expect(accepted).toBe(true);
+
+    // Same runner, WRONG sandbox.
+    const rejected = await turns.applyTurnEvents(
+      reporter(RUNNER_A, foreign.sandboxId),
+      own.conversationId,
+      turn.id,
+      [{ type: "tool.started", callId: "c1", name: "bash" }],
+    );
+    expect(rejected).toBe(false);
+
+    // And the rejected batch really was ignored.
+    const rows = await db.turnEvent.findMany({
+      where: { conversationId: own.conversationId },
+      select: { type: true },
+    });
+    expect(rows.map((r) => r.type)).toEqual(["turn.started"]);
   });
 });
 
@@ -3174,6 +3256,99 @@ describe.skipIf(!PROOF_URL)("conversation titles", () => {
     );
     expect(row?.title).toMatch(/…$/);
     expect(row?.title).not.toMatch(/\s…$/);
+  });
+});
+
+describe.skipIf(!PROOF_URL)("the wake's open-promise note", () => {
+  const answerTurn = async (
+    conversationId: string,
+    text: string,
+    status = "done",
+  ) => {
+    const turn = await turns.createTurn(
+      WORKSPACE,
+      conversationId,
+      "do the thing",
+      WEB_A,
+    );
+    await db.turn.update({ where: { id: turn.id }, data: { status } });
+    if (text !== "") {
+      await db.turnEvent.create({
+        data: {
+          conversationId,
+          turnId: turn.id,
+          seq: 1,
+          type: "text",
+          payload: { text },
+        },
+      });
+    }
+    await db.turn.update({
+      where: { id: turn.id },
+      data: { status, finishedAt: new Date() },
+    });
+    return turn.id;
+  };
+
+  it("carries back the agent's own last reply, bounded", async () => {
+    // The whole point: a wake arrives with the platform's instruction and
+    // no conversation, so this is the only place an unfinished promise can
+    // be read from.
+    const { conversationId } = await seedTalkable("promise-basic");
+    await answerTurn(
+      conversationId,
+      "I'll post the rankings once all 5 finish.",
+    );
+
+    const note = await turns.buildOpenPromiseNote(conversationId, new Date());
+
+    expect(note).toContain("I'll post the rankings once all 5 finish.");
+    expect(note).toContain("deliver it now");
+  });
+
+  it("BOUNDS a long reply — a wake prompt is not a transcript", async () => {
+    // The note rides the model's context budget beside memory. An agent that
+    // answered with a full report would otherwise push the wake's own
+    // instructions out of the window it needs to act on.
+    //
+    // MUTATION-PROOF: drop the slice and this fails.
+    const { conversationId } = await seedTalkable("promise-long");
+    await answerTurn(conversationId, "x".repeat(5_000));
+
+    const note = await turns.buildOpenPromiseNote(conversationId, new Date());
+
+    expect(note).not.toBeNull();
+    expect((note as string).length).toBeLessThan(1_000);
+    expect(note).toContain("…");
+  });
+
+  it("says nothing when the last turn FAILED — a failure promised nothing", async () => {
+    // MUTATION-PROOF: drop `status: "done"` from the lookup and this fails.
+    // A failed turn's text is an error, not a commitment, and relaying it
+    // would tell the agent it owes work that was never accepted.
+    const { conversationId } = await seedTalkable("promise-failed");
+    await answerTurn(conversationId, "boom", "failed");
+
+    expect(
+      await turns.buildOpenPromiseNote(conversationId, new Date()),
+    ).toBeNull();
+  });
+
+  it("says nothing when the reply was EMPTY — a bare label is noise", async () => {
+    const { conversationId } = await seedTalkable("promise-empty");
+    await answerTurn(conversationId, "");
+
+    expect(
+      await turns.buildOpenPromiseNote(conversationId, new Date()),
+    ).toBeNull();
+  });
+
+  it("says nothing on a first-contact wake — no prior reply to owe against", async () => {
+    const { conversationId } = await seedTalkable("promise-first");
+
+    expect(
+      await turns.buildOpenPromiseNote(conversationId, new Date()),
+    ).toBeNull();
   });
 });
 

--- a/packages/api/src/services/turn-context-service.test.ts
+++ b/packages/api/src/services/turn-context-service.test.ts
@@ -23,7 +23,10 @@ const state = vi.hoisted(() => ({
 }));
 
 const search = vi.hoisted(() => ({ searchMemories: vi.fn() }));
-const bridge = vi.hoisted(() => ({ buildContinuityBridge: vi.fn() }));
+const bridge = vi.hoisted(() => ({
+  buildContinuityBridge: vi.fn(),
+  buildOpenPromiseNote: vi.fn(),
+}));
 
 vi.mock("@onecli/db", () => ({
   Prisma: {},
@@ -50,6 +53,7 @@ vi.mock("./agent-memory-service", () => ({
 
 vi.mock("./turn-service", () => ({
   buildContinuityBridge: bridge.buildContinuityBridge,
+  buildOpenPromiseNote: bridge.buildOpenPromiseNote,
 }));
 
 const { buildTurnContext, MEMORY_INJECT_MAX, MEMORY_INJECT_RANK_FLOOR } =
@@ -71,6 +75,8 @@ beforeEach(() => {
   search.searchMemories.mockResolvedValue([]);
   bridge.buildContinuityBridge.mockReset();
   bridge.buildContinuityBridge.mockResolvedValue(null);
+  bridge.buildOpenPromiseNote.mockReset();
+  bridge.buildOpenPromiseNote.mockResolvedValue(null);
 });
 
 describe("the index", () => {
@@ -197,6 +203,42 @@ describe("the continuity bridge (human-only, rides context)", () => {
     await build("ag-1", "run report");
     expect(bridge.buildContinuityBridge).not.toHaveBeenCalled();
   });
+
+  it("a WAKE gets the agent's own last reply — the promise it may still owe", async () => {
+    // The mirror image of the bridge. A wake arrives with the platform's
+    // instruction and no conversation, so an agent that said "I'll post the
+    // rankings once all five finish" answers only the question it was asked
+    // and never delivers. Observed live 2026-09-01.
+    //
+    // MUTATION-PROOF: drop the promise arm and this fails.
+    state.turn = {
+      createdAt: new Date("2026-08-09T00:00:00Z"),
+      source: "watch",
+    };
+    bridge.buildOpenPromiseNote.mockResolvedValue("[Your last reply…]");
+
+    const out = await build("ag-1", "run report");
+
+    expect(bridge.buildOpenPromiseNote).toHaveBeenCalledWith(
+      "c-1",
+      new Date("2026-08-09T00:00:00Z"),
+    );
+    expect(out).toContain("[Your last reply…]");
+  });
+
+  it("a HUMAN turn gets the bridge, never the promise note", async () => {
+    // Exactly one applies. A person is present to say what they want; the
+    // note exists for the turn where nobody is.
+    state.turn = {
+      createdAt: new Date("2026-08-09T00:00:00Z"),
+      source: "slack",
+    };
+
+    await build("ag-1", "hello");
+
+    expect(bridge.buildContinuityBridge).toHaveBeenCalled();
+    expect(bridge.buildOpenPromiseNote).not.toHaveBeenCalled();
+  });
 });
 
 describe("the budget", () => {
@@ -216,6 +258,11 @@ describe("the budget", () => {
       })),
     );
     bridge.buildContinuityBridge.mockResolvedValue("b".repeat(50_000));
+    // The promise note rides the same budget. It cannot appear beside the
+    // bridge today (exactly one applies), but the cap must hold if that
+    // ever changes — a context past the ceiling is silently truncated, and
+    // the tail is where the newest information sits.
+    bridge.buildOpenPromiseNote.mockResolvedValue("p".repeat(50_000));
     const context = await build("ag-1", "m".repeat(50_000));
     expect(context).not.toBeNull();
     expect((context as string).length).toBeLessThanOrEqual(

--- a/packages/api/src/services/turn-context-service.ts
+++ b/packages/api/src/services/turn-context-service.ts
@@ -7,7 +7,7 @@ import {
 } from "../lib/memory-index";
 import { AUTOMATION_SOURCES } from "../validations/conversation";
 import { searchMemories } from "./agent-memory-service";
-import { buildContinuityBridge } from "./turn-service";
+import { buildContinuityBridge, buildOpenPromiseNote } from "./turn-service";
 
 /**
  * The turn-start memory context (step 8, §3.8): a delivery-only prepend the
@@ -163,16 +163,24 @@ export const buildTurnContext = async (
     turn !== null &&
     !(AUTOMATION_SOURCES as readonly string[]).includes(turn.source);
 
-  const [memory, bridge] = await Promise.all([
+  // The two are mirror images, and exactly one applies. A HUMAN turn needs
+  // the bridge: what landed while they were away, which they may be
+  // referring to. A WAKE needs the opposite — it arrives with the
+  // platform's instruction and no conversation at all, so it gets the
+  // agent's own last reply, which is where an unfinished promise lives.
+  const [memory, bridge, promise] = await Promise.all([
     buildMemoryContext(agentId, message),
     isHuman ? buildContinuityBridge(conversationId, turn.createdAt) : null,
+    isHuman || turn === null
+      ? null
+      : buildOpenPromiseNote(conversationId, turn.createdAt),
   ]);
-  if (!memory && !bridge) return null;
+  if (!memory && !bridge && !promise) return null;
 
-  // Memory first (standing knowledge); the bridge sits NEAREST the message —
-  // it is the immediate "what just landed" the person is most likely
-  // referring to.
-  return [memory, bridge]
+  // Memory first (standing knowledge); the bridge or the promise note sits
+  // NEAREST the message — it is the immediate "what just landed" the person
+  // is most likely referring to, or the commitment the wake must honor.
+  return [memory, bridge, promise]
     .filter((block): block is string => block !== null)
     .join("\n\n")
     .slice(0, MAX_TURN_CONTEXT_CHARS);

--- a/packages/api/src/services/turn-service.ts
+++ b/packages/api/src/services/turn-service.ts
@@ -682,6 +682,62 @@ export const buildContinuityBridge = async (
   return `[Context from your automated runs — delivered to this chat since the last message; the person may be referring to it:]\n${notes}\n[End of automated-run context]`;
 };
 
+/** How much of the agent's own last reply the wake reminder repeats. */
+const OPEN_PROMISE_EXCERPT_MAX_CHARS = 400;
+
+/**
+ * What the agent last told the person, for a wake to answer against.
+ *
+ * A wake arrives with the platform's own instruction ("report what these
+ * background tasks did") and nothing else. That is the whole conversation
+ * the model sees, so an agent that told someone "I'll post the rankings
+ * once all five finish" answers the question it was ASKED — "did anything
+ * go wrong?" — reports that nothing did, and never delivers the thing it
+ * promised. Observed live 2026-09-01.
+ *
+ * So the wake carries the agent's own most recent reply back to it. Not an
+ * inference about intent, not a reconstruction of the thread: one bounded
+ * excerpt of what it actually said, which is the only place an outstanding
+ * promise can be read from without guessing.
+ *
+ * Returns null when there is no prior reply — a first-contact wake has no
+ * promise to keep, and a bare label would be noise.
+ */
+export const buildOpenPromiseNote = async (
+  conversationId: string,
+  before: Date,
+): Promise<string | null> => {
+  const lastHumanTurn = await db.turn.findFirst({
+    where: {
+      conversationId,
+      source: { notIn: [...AUTOMATION_SOURCES] },
+      createdAt: { lt: before },
+      status: "done",
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  });
+  if (!lastHumanTurn) return null;
+
+  // The turn's OWN answer — the coalesced `text` row, the same one the
+  // channel posts. `desc` because a turn's last text is its answer.
+  const answer = await db.turnEvent.findFirst({
+    where: { turnId: lastHumanTurn.id, type: "text" },
+    orderBy: { seq: "desc" },
+    select: { payload: true },
+  });
+  const body = stripControl(
+    String((answer?.payload as { text?: unknown } | null)?.text ?? ""),
+  ).trim();
+  if (body === "") return null;
+
+  const excerpt =
+    body.length > OPEN_PROMISE_EXCERPT_MAX_CHARS
+      ? `${body.slice(0, OPEN_PROMISE_EXCERPT_MAX_CHARS)}…`
+      : body;
+  return `[Your last reply in this chat, for reference — if it promised something once this work finished, deliver it now rather than only reporting the runs:]\n${excerpt}\n[End of your last reply]`;
+};
+
 /**
  * A parked sandbox must come back before its turn can run. Only `stopped` and
  * `failed` are woken — never `running`/`starting`, which would tear down a
@@ -856,14 +912,18 @@ export interface ReporterIdentity {
  * `seq` is allocated by incrementing the conversation counter once for the
  * whole batch, inside the same transaction that writes the rows — so numbers
  * are contiguous, and a rollback takes them back with it.
+ *
+ * Returns whether the batch was ACCEPTED. A rejected batch is ignored rather
+ * than thrown (a dying sandbox's rescue events must still land), so the
+ * verdict is the only signal a caller has.
  */
 export const applyTurnEvents = async (
   reporter: ReporterIdentity,
   conversationId: string,
   turnId: string,
   events: AgentEvent[],
-): Promise<void> => {
-  if (events.length === 0) return;
+): Promise<boolean> => {
+  if (events.length === 0) return true;
 
   // Sanitized BEFORE the transaction opens: it is a deep walk over every
   // event in the batch, including the text deltas that are never stored, and
@@ -936,6 +996,12 @@ export const applyTurnEvents = async (
   // Publish AFTER commit: a subscriber must never see an event that a
   // rollback un-happened, and never one the fence rejected.
   if (published) getEventBus().publish(conversationId, published);
+  // `null` is the fence's own verdict (the transaction above returns it when
+  // the reporter does not host this turn). Returned rather than swallowed
+  // because a caller acting on the SAME events — the channel narration in
+  // routes/runner.ts — must not act on a batch the transcript rejected, or
+  // one tenant's sandbox could drive another tenant's Slack thread.
+  return published !== null;
 };
 
 /**

--- a/packages/api/src/services/watch-fire-service.test.ts
+++ b/packages/api/src/services/watch-fire-service.test.ts
@@ -23,10 +23,12 @@ const mocks = vi.hoisted(() => ({
   canAccessWorkspaceAsUser: vi.fn(),
   ensureSourcedConversation: vi.fn(),
   createTurn: vi.fn(),
+  createFollowUp: vi.fn(),
   materializeAutomationDelivery: vi.fn(),
   workspaceFindUnique: vi.fn(),
   watchUpdateMany: vi.fn(),
   conversationFindMany: vi.fn(),
+  turnFindFirst: vi.fn(),
 }));
 
 vi.mock("./due-work", () => ({
@@ -44,6 +46,7 @@ vi.mock("./conversation-service", () => ({
 }));
 vi.mock("./turn-service", () => ({
   createTurn: mocks.createTurn,
+  createFollowUp: mocks.createFollowUp,
   materializeAutomationDelivery: mocks.materializeAutomationDelivery,
 }));
 vi.mock("@onecli/db", () => ({
@@ -51,6 +54,7 @@ vi.mock("@onecli/db", () => ({
     workspace: { findUnique: mocks.workspaceFindUnique },
     processWatch: { updateMany: mocks.watchUpdateMany },
     conversation: { findMany: mocks.conversationFindMany },
+    turn: { findFirst: mocks.turnFindFirst },
   },
 }));
 
@@ -105,6 +109,10 @@ beforeEach(() => {
   });
   mocks.canAccessWorkspaceAsUser.mockResolvedValue(true);
   mocks.ensureSourcedConversation.mockResolvedValue({ id: "conv-run" });
+  // No running turn by default: the join arm needs one, so every existing
+  // case keeps its original path unless it opts in.
+  mocks.turnFindFirst.mockResolvedValue(null);
+  mocks.createFollowUp.mockResolvedValue({ id: "follow-1" });
   mocks.createTurn.mockResolvedValue({ status: "queued", id: "turn-1" });
   mocks.watchUpdateMany.mockResolvedValue({ count: 1 });
   mocks.conversationFindMany.mockResolvedValue([sourcedOrigin]);
@@ -270,6 +278,105 @@ describe("fireDueWatches — the in-origin wake (direct origins)", () => {
 
     expect(mocks.watchUpdateMany).not.toHaveBeenCalled();
     expect(mocks.ensureSourcedConversation).not.toHaveBeenCalled();
+  });
+
+  it("a busy origin JOINS the running turn instead of queueing behind it", async () => {
+    // The doubled-wake fix (#1013). Measured on a live stack: every wake in
+    // a batch was born while an earlier turn was still answering, so the
+    // agent reported partial state, then reported again. Joining makes the
+    // turn that is already speaking say it once.
+    //
+    // MUTATION-PROOF: remove the join arm and this fails — the wake goes
+    // back to waiting for the running turn to finish.
+    mocks.createTurn.mockRejectedValue(new ServiceError("CONFLICT", "busy"));
+    mocks.turnFindFirst.mockResolvedValue({ id: "turn-running" });
+
+    await fireDueWatches();
+
+    expect(mocks.createFollowUp).toHaveBeenCalledWith(
+      "conv-origin",
+      "turn-running",
+      expect.stringContaining("Watch on process"),
+      { source: "watch", userId: null },
+    );
+    // ...and the watches are marked fired, because the join row now exists.
+    expect(mocks.watchUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["w-1"] }, status: "triggered" },
+      }),
+    );
+  });
+
+  it("marks the watches fired ONLY after the join row exists", async () => {
+    // Ordering is the contract: a crash between the two would leave the
+    // watches claimed and deliver the same wake twice.
+    //
+    // MUTATION-PROOF: mark them before the join and this fails.
+    mocks.createTurn.mockRejectedValue(new ServiceError("CONFLICT", "busy"));
+    mocks.turnFindFirst.mockResolvedValue({ id: "turn-running" });
+    const order: string[] = [];
+    mocks.createFollowUp.mockImplementation(async () => {
+      order.push("join");
+      return { id: "follow-1" };
+    });
+    mocks.watchUpdateMany.mockImplementation(async () => {
+      order.push("mark");
+      return { count: 1 };
+    });
+
+    await fireDueWatches();
+
+    expect(order).toEqual(["join", "mark"]);
+  });
+
+  it("falls back to today's retry when the join FAILS", async () => {
+    // Best-effort by design: the wake must never be lost because a steer
+    // could not be created.
+    mocks.createTurn.mockRejectedValue(new ServiceError("CONFLICT", "busy"));
+    mocks.turnFindFirst.mockResolvedValue({ id: "turn-running" });
+    mocks.createFollowUp.mockRejectedValue(new Error("steer refused"));
+
+    await fireDueWatches();
+
+    // Nothing marked: the watch stays claimed and retries on the fire lease,
+    // exactly as it did before the join existed.
+    expect(mocks.watchUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("a failed join still DOWNGRADES an expired watch — the deadline still binds", async () => {
+    // The join's return value is what decides whether the rest of the
+    // CONFLICT arm runs. Reporting a failed join as success would strand an
+    // expired watch: no join, no retry, and no hidden-path downgrade, so it
+    // would never be delivered at all.
+    //
+    // MUTATION-PROOF: return `true` from the join's catch and this fails.
+    mocks.claimTriggeredWatches.mockResolvedValue([watch({ expiresAt: PAST })]);
+    mocks.createTurn
+      .mockRejectedValueOnce(new ServiceError("CONFLICT", "busy"))
+      .mockResolvedValueOnce({ status: "queued", id: "turn-2" });
+    mocks.turnFindFirst.mockResolvedValue({ id: "turn-running" });
+    mocks.createFollowUp.mockRejectedValue(new Error("steer refused"));
+
+    await fireDueWatches();
+
+    // The classic hidden-path fire ran for the expired watch.
+    expect(mocks.ensureSourcedConversation).toHaveBeenCalledWith(
+      "pr-1",
+      "ag-1",
+      expect.objectContaining({ externalRef: "w-1" }),
+    );
+  });
+
+  it("falls back when there is no running turn to join", async () => {
+    // The conflict was something other than a live turn (a queued one, a
+    // race that already resolved). Nothing to steer into.
+    mocks.createTurn.mockRejectedValue(new ServiceError("CONFLICT", "busy"));
+    mocks.turnFindFirst.mockResolvedValue(null);
+
+    await fireDueWatches();
+
+    expect(mocks.createFollowUp).not.toHaveBeenCalled();
+    expect(mocks.watchUpdateMany).not.toHaveBeenCalled();
   });
 
   it("a busy origin DOWNGRADES an expired watch to the hidden path so it cannot retry forever", async () => {

--- a/packages/api/src/services/watch-fire-service.ts
+++ b/packages/api/src/services/watch-fire-service.ts
@@ -9,7 +9,11 @@ import {
   type DueWatchFire,
 } from "./due-work";
 import { ensureSourcedConversation } from "./conversation-service";
-import { createTurn, materializeAutomationDelivery } from "./turn-service";
+import {
+  createFollowUp,
+  createTurn,
+  materializeAutomationDelivery,
+} from "./turn-service";
 import { ServiceError } from "./errors";
 import { stripControl } from "../lib/text";
 import { logger } from "../lib/logger";
@@ -237,13 +241,78 @@ interface WakeBucket {
  * - created (running or born-failed) → every watch marked fired in one
  *   guarded batch. A born-failed turn (door 1) is ITSELF visible in the
  *   thread, so no delivery duplicate is materialized.
- * - CONFLICT (the thread's one-active slot is taken) → nothing marked:
- *   unexpired watches stay claimed and retry on the fire lease (the old
- *   path marked them fired and silently dropped the wake); expired ones
- *   downgrade to the hidden path so a forever-busy thread cannot retry
- *   past the watch's own deadline.
+ * - CONFLICT (the thread's one-active slot is taken) → JOIN first: the wake
+ *   steers into the running turn as a follow-up, and the watches are marked
+ *   fired only once that row exists. When there is no running turn to join,
+ *   or the join fails, the older behavior stands — nothing marked, unexpired
+ *   watches stay claimed and retry on the fire lease (the path before that
+ *   marked them fired and silently dropped the wake), and expired ones
+ *   downgrade to the hidden path so a forever-busy thread cannot retry past
+ *   the watch's own deadline.
  * - anything else → nothing marked; the lease retries.
  */
+/**
+ * Steer a busy conversation's wake INTO the turn that is already running,
+ * rather than queueing behind it.
+ *
+ * Returns whether the join landed. `false` means the caller keeps today's
+ * behavior exactly — unexpired watches stay claimed and retry, expired ones
+ * downgrade to the hidden path — so this can only ever REDUCE doubled wakes,
+ * never lose one.
+ *
+ * ORDERING IS THE CONTRACT. The watches are marked fired only once the join
+ * row exists: a crash between the two would otherwise leave them claimed and
+ * deliver the same wake twice. That is the same rule the created-turn arm
+ * above follows, for the same reason.
+ *
+ * Not a guarantee of one message: steering is at-most-once and the harness
+ * takes it at its next safe point. A steer that misses still surfaces —
+ * `listConversationsWithParkedFollowUps` promotes the parked row into its
+ * own turn, which is today's behavior.
+ */
+const joinRunningTurn = async (
+  bucket: WakeBucket,
+  message: string,
+  ids: string[],
+): Promise<boolean> => {
+  try {
+    const running = await db.turn.findFirst({
+      where: { conversationId: bucket.conversationId, status: "running" },
+      select: { id: true },
+    });
+    // The conflict was something other than a live turn (a queued one, a
+    // race that resolved). Nothing to steer into.
+    if (!running) return false;
+
+    await createFollowUp(bucket.conversationId, running.id, message, {
+      source: "watch",
+      userId: null,
+    });
+    // Only now: the row exists, so the wake cannot be delivered twice.
+    await db.processWatch.updateMany({
+      where: { id: { in: ids }, status: "triggered" },
+      data: { status: "fired", firedAt: new Date() },
+    });
+    log.info(
+      {
+        conversationId: bucket.conversationId,
+        turnId: running.id,
+        joined: ids.length,
+      },
+      "origin busy; wake joined the running turn",
+    );
+    return true;
+  } catch (err) {
+    // Best-effort by design: anything unexpected falls back to the retry and
+    // downgrade path, which is what shipped before this existed.
+    log.info(
+      { err: String(err), conversationId: bucket.conversationId },
+      "wake join failed; falling back to retry",
+    );
+    return false;
+  }
+};
+
 const fireBucket = async (bucket: WakeBucket): Promise<void> => {
   const message = buildConsolidatedWakeMessage(
     bucket.watches.map((entry) => entry.watch),
@@ -261,6 +330,17 @@ const fireBucket = async (bucket: WakeBucket): Promise<void> => {
     });
   } catch (error) {
     if (error instanceof ServiceError && error.code === "CONFLICT") {
+      // The thread's one active slot is taken — the agent is mid-answer,
+      // very often about the FIRST watch of this same batch. Waiting is what
+      // produced the running commentary: agent A finishes, the wake fires,
+      // agent B finishes 10s later, and its wake queues behind a turn that
+      // is already talking about A.
+      //
+      // JOIN it instead. `createFollowUp` is built for exactly this — a
+      // `joining` row that steers into the running turn — so the batch is
+      // reported once, by the turn already speaking.
+      if (await joinRunningTurn(bucket, message, ids)) return;
+
       const now = Date.now();
       const expired = bucket.watches.filter(
         (entry) => entry.watch.expiresAt.getTime() < now,

--- a/packages/db/prisma/migrations/20260831232114_add_channel_turn_receipt_narration_card/migration.sql
+++ b/packages/db/prisma/migrations/20260831232114_add_channel_turn_receipt_narration_card/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "channel_turn_receipts" ADD COLUMN     "card_at" TIMESTAMP(3),
+ADD COLUMN     "card_rev" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "card_steps" TEXT[],
+ADD COLUMN     "card_thread_ts" TEXT,
+ADD COLUMN     "card_ts" TEXT,
+ADD COLUMN     "seen_message_ts" TEXT,
+ADD COLUMN     "work_status_set" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1333,22 +1333,62 @@ model ChannelApprovalPrompt {
 // provider-side ledger only — no Turn FK on purpose (rows are pruned by age
 // >24h on insert, which also covers turns whose cursor never advances).
 model ChannelTurnReceipt {
-  id             String   @id @default(uuid())
-  turnId         String   @unique @map("turn_id")
-  agentChannelId String   @map("agent_channel_id")
+  id             String    @id @default(uuid())
+  turnId         String    @unique @map("turn_id")
+  agentChannelId String    @map("agent_channel_id")
   // Provider-opaque address of the USER's message the mark sits on
   // (Slack: channel id + message ts). For `kind: "session"` rows, `messageTs`
   // is the THREAD ROOT ts the provider's work-status API is keyed by.
   channel        String
-  messageTs      String   @map("message_ts")
+  messageTs      String    @map("message_ts")
   // "reaction" = an emoji sits on the message and must come off on clear;
   // "session" = the provider's native thread work-status (Slack: the agent
   // session loader) is on and must be set back on clear.
-  kind           String   @default("reaction")
+  kind           String    @default("reaction")
   // The emoji, for reaction rows. Null on session rows — there is nothing
   // to take off a specific message.
   reaction       String?
-  createdAt      DateTime @default(now()) @map("created_at")
+  // The provider-side id of the live NARRATION card for this turn (Slack:
+  // the message ts of the task-card post). Null until the turn runs its
+  // first tool, and on providers that cannot narrate at all. It lives HERE
+  // rather than in its own table because its lifetime is exactly this row's:
+  // posted while the turn works, removed by the same clear and sweep paths
+  // that take the loader down, so an abandoned card is impossible by
+  // construction.
+  cardTs         String?   @map("card_ts")
+  // Where the narration card is POSTED: the thread root for a group mention,
+  // NULL for a DM. Distinct from `messageTs` on purpose — that is the
+  // session root the native loader is keyed by, which a DM must have (Slack
+  // refuses a session without one) but which the card must NOT use, or every
+  // DM turn would open a thread for a loader nobody asked to keep.
+  cardThreadTs   String?   @map("card_thread_ts")
+  // Whether the provider's native work-status was actually turned on for
+  // this turn. False when the card carries the whole signal (a DM, where
+  // the enum would open a thread for nothing), and the clear must then NOT
+  // try to set a status that was never set.
+  workStatusSet  Boolean   @default(false) @map("work_status_set")
+  // Where a SEEN mark sits, when one rides beside a narration card. On a
+  // session row `messageTs` is the thread root, not the user's message, so
+  // the emoji's own address has to be kept separately or the clear would
+  // try to unreact the wrong line.
+  seenMessageTs  String?   @map("seen_message_ts")
+  // The steps shown on that card, oldest first — the turn's whole narration
+  // so far. The card is RE-RENDERED from this list on every update rather
+  // than patched, so this is the single source of what the reader sees, and
+  // it survives a process restart because it lives here rather than in
+  // adapter memory.
+  cardSteps      String[]  @map("card_steps")
+  // How many times the card has been written. The narration's compare-and-set
+  // key: two detached pushes for one turn read the same revision, and only
+  // the one whose update still matches it proceeds — an array cannot serve
+  // as that key (Prisma's list `equals` does not match an empty column, so
+  // the first claim of every turn would fail).
+  cardRev        Int       @default(0) @map("card_rev")
+  // When the card was last written, for the narration throttle. Slack's
+  // write is rate-limited per app, and tool boundaries alone do not bound
+  // it — a busy agent runs tools faster than the ceiling allows.
+  cardAt         DateTime? @map("card_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
 
   agentChannel AgentChannel @relation(fields: [agentChannelId], references: [id], onDelete: Cascade)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@onecli/agent-protocol':
+        specifier: workspace:*
+        version: link:../../packages/agent-protocol
       '@onecli/api':
         specifier: workspace:*
         version: link:../../packages/api


### PR DESCRIPTION
## Summary

Sync of the latest development window. Two features:

- **Live Slack task cards.** A running turn now posts one task card that updates in place as the agent works, instead of threading progress DMs. Narration receipts are persisted per turn — includes the `channel_turn_receipt` narration-card migration (`20260831232114`).
- **Live activity loader for web chat.** The chat thread renders a live activity line for in-flight turns (and the same loader fix applies to Slack DMs), backed by the new `@onecli/agent-protocol` `./activity` module — shared activity parsing with its own security test suite. `apps/web` now depends on `@onecli/agent-protocol` directly.

## Notes

- Schema change ships with its migration; Prisma client regenerates via `db:generate`.
- Lockfile regenerated for the new workspace dependency.