### PR TITLE
fix(api): atomically consume CLI auth poll session

### DIFF
--- a/packages/api/src/services/cli-auth-service.pg.test.ts
+++ b/packages/api/src/services/cli-auth-service.pg.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { randomBytes } from "node:crypto";
+
+import { proofDatabaseUrl } from "../testing/pg-proof.js";
+
+/**
+ * CLI auth poll must hand out the workspace API key at most once. The unit
+ * suite mocks the CAS boundary; this suite proves the race on real Postgres.
+ */
+
+const PROOF_URL = proofDatabaseUrl();
+
+type Db = typeof import("@onecli/db").db;
+type CliAuth = typeof import("./cli-auth-service");
+
+let db: Db;
+let pollCliAuthSession: CliAuth["pollCliAuthSession"];
+
+const P = "cli-auth-";
+const ORG = `${P}org`;
+const WORKSPACE = `${P}ws`;
+const USER_EMAIL = `${P}user@example.invalid`;
+
+const reset = async () => {
+  await db.cliAuthSession.deleteMany({ where: { code: { startsWith: P } } });
+  await db.apiKey.deleteMany({ where: { key: { startsWith: P } } });
+  await db.user.deleteMany({ where: { email: USER_EMAIL } });
+  await db.workspace.deleteMany({ where: { id: WORKSPACE } });
+  await db.organization.deleteMany({ where: { id: ORG } });
+};
+
+beforeAll(async () => {
+  if (!PROOF_URL) return;
+  process.env.DATABASE_URL = PROOF_URL;
+  process.env.EDITION = "onprem";
+  process.env.NEXT_PUBLIC_EDITION = "onprem";
+
+  ({ db } = await import("@onecli/db"));
+  ({ pollCliAuthSession } = await import("./cli-auth-service"));
+
+  await reset();
+  await db.organization.create({ data: { id: ORG, name: ORG, slug: ORG } });
+  await db.workspace.create({
+    data: { id: WORKSPACE, name: WORKSPACE, organizationId: ORG },
+  });
+});
+
+afterAll(async () => {
+  if (!PROOF_URL) return;
+  await reset();
+  await db.$disconnect();
+});
+
+describe.skipIf(!PROOF_URL)("pollCliAuthSession — concurrent consume", () => {
+  it("hands out the api key to exactly one concurrent poll", async () => {
+    const user = await db.user.create({
+      data: {
+        email: USER_EMAIL,
+        externalAuthId: `ba:${randomBytes(8).toString("hex")}`,
+      },
+    });
+    const apiKey = `${P}${randomBytes(32).toString("hex")}`;
+    await db.apiKey.create({
+      data: {
+        key: apiKey,
+        userId: user.id,
+        userEmail: USER_EMAIL,
+        workspaceId: WORKSPACE,
+        kind: "user",
+      },
+    });
+
+    const code = `${P}${randomBytes(8).toString("hex")}`;
+    await db.cliAuthSession.create({
+      data: {
+        code,
+        status: "confirmed",
+        apiKey,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    });
+
+    const [first, second] = await Promise.all([
+      pollCliAuthSession(code),
+      pollCliAuthSession(code),
+    ]);
+
+    const winners = [first, second].filter((r) => r.status === "ok");
+    expect(winners).toHaveLength(1);
+    expect(winners[0]).toMatchObject({
+      status: "ok",
+      api_key: apiKey,
+      workspace_id: WORKSPACE,
+    });
+
+    const losers = [first, second].filter((r) => r.status !== "ok");
+    expect(losers).toHaveLength(1);
+    expect(losers[0]).toEqual({ status: "expired" });
+
+    const row = await db.cliAuthSession.findUnique({ where: { code } });
+    expect(row).toMatchObject({ status: "consumed", apiKey: null });
+  });
+});

--- a/packages/api/src/services/cli-auth-service.test.ts
+++ b/packages/api/src/services/cli-auth-service.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  cliAuthSession: {
+    findUnique: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  apiKey: {
+    findUnique: vi.fn(),
+  },
+}));
+
+vi.mock("@onecli/db", () => ({ db: dbMock }));
+
+import { pollCliAuthSession } from "./cli-auth-service";
+
+const CODE = "abc123";
+const API_KEY = `oc_${"a".repeat(64)}`;
+const FUTURE = new Date(Date.now() + 60_000);
+
+describe("pollCliAuthSession — atomic consume", () => {
+  beforeEach(() => {
+    dbMock.cliAuthSession.findUnique.mockReset();
+    dbMock.cliAuthSession.updateMany.mockReset();
+    dbMock.apiKey.findUnique.mockReset();
+  });
+
+  it("returns the api key only when the consume update wins", async () => {
+    dbMock.cliAuthSession.findUnique.mockResolvedValue({
+      status: "confirmed",
+      apiKey: API_KEY,
+      expiresAt: FUTURE,
+    });
+    dbMock.cliAuthSession.updateMany.mockResolvedValue({ count: 1 });
+    dbMock.apiKey.findUnique.mockResolvedValue({ workspaceId: "ws-1" });
+
+    await expect(pollCliAuthSession(CODE)).resolves.toEqual({
+      status: "ok",
+      api_key: API_KEY,
+      workspace_id: "ws-1",
+    });
+
+    expect(dbMock.cliAuthSession.updateMany).toHaveBeenCalledWith({
+      where: { code: CODE, status: "confirmed", apiKey: { not: null } },
+      data: { apiKey: null, status: "consumed" },
+    });
+  });
+
+  it("does not return the api key when another poll already consumed it", async () => {
+    dbMock.cliAuthSession.findUnique.mockResolvedValue({
+      status: "confirmed",
+      apiKey: API_KEY,
+      expiresAt: FUTURE,
+    });
+    dbMock.cliAuthSession.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(pollCliAuthSession(CODE)).resolves.toEqual({
+      status: "expired",
+    });
+    expect(dbMock.apiKey.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("treats an already-consumed session as expired", async () => {
+    dbMock.cliAuthSession.findUnique.mockResolvedValue({
+      status: "consumed",
+      apiKey: null,
+      expiresAt: FUTURE,
+    });
+
+    await expect(pollCliAuthSession(CODE)).resolves.toEqual({
+      status: "expired",
+    });
+    expect(dbMock.cliAuthSession.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/cli-auth-service.ts
+++ b/packages/api/src/services/cli-auth-service.ts
@@ -53,24 +53,31 @@ export const pollCliAuthSession = async (code: string) => {
   }
 
   if (session.status === "confirmed" && session.apiKey) {
+    const apiKey = session.apiKey;
+    // Atomic consume — same CAS shape as confirmCliAuthSession. Without the
+    // status+apiKey guard, concurrent polls both read confirmed and both
+    // return the plaintext key before either update lands.
+    const consumed = await db.cliAuthSession.updateMany({
+      where: { code, status: "confirmed", apiKey: { not: null } },
+      data: { apiKey: null, status: "consumed" },
+    });
+    if (consumed.count === 0) {
+      return { status: "expired" as const };
+    }
+
     const apiKeyRecord = await db.apiKey.findUnique({
-      where: { key: session.apiKey },
+      where: { key: apiKey },
       select: { workspaceId: true },
     });
 
-    // Clear the API key after reading so it can only be consumed once
-    await db.cliAuthSession.update({
-      where: { code },
-      data: { apiKey: null, status: "consumed" },
-    });
     return {
       status: "ok" as const,
-      api_key: session.apiKey,
+      api_key: apiKey,
       workspace_id: apiKeyRecord?.workspaceId ?? null,
     };
   }
 
-  if (session.status === "expired") {
+  if (session.status === "consumed" || session.status === "expired") {
     return { status: "expired" as const };
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

During CLI device auth, the install script polls `GET /v1/auth/cli/poll?code=...` until the browser confirms the session. After confirmation, `pollCliAuthSession` reads a `confirmed` row with a plaintext `apiKey`, returns it to the caller, and then clears the row.

That read-then-update is not atomic. Two concurrent poll requests can both observe `status=confirmed` with a non-null `apiKey` and both return the workspace API key before either update lands. The code comment already claims the key is consumed once, and `confirmCliAuthSession` uses a CAS-style update, but the poll path did not.

## What is the new behavior?

Poll now consumes the session with an atomic `updateMany` guarded on `code`, `status: confirmed`, and `apiKey IS NOT NULL`, matching the CAS pattern used by `confirmCliAuthSession`. Only the poll that wins the update returns `status: ok` with the API key; the loser gets `status: expired`. Already-consumed sessions also return `expired`.

## Additional context

### Root cause

Non-atomic read-then-update in `packages/api/src/services/cli-auth-service.ts` (`pollCliAuthSession`).

### Issue

Independently discovered through code review and execution-path analysis. I did not find an existing upstream issue or open PR for this race.

### Testing

- `pnpm --filter @onecli/api test src/services/cli-auth-service.test.ts` — 3 passed
- `pnpm --filter @onecli/api test src/services/cli-auth-service.pg.test.ts` — skipped locally (no `POLICY_PROOF_DATABASE_URL`); runs in CI against real Postgres
- `pnpm --filter @onecli/api lint` on changed files — passed

### Reproduction (conceptual)

1. Create a CLI auth session and confirm it in the browser.
2. Fire two concurrent `GET /v1/auth/cli/poll?code=...` requests.
3. Before this fix, both can return `{ status: ok, api_key: ... }`.
4. After this fix, exactly one returns `ok`; the other returns `expired`.