### PR TITLE
fix: isolate postgres from agent bridge

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql
     ports:
-      - "${ONECLI_BIND_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
+      - "${ONECLI_POSTGRES_BIND_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-onecli}"]
       interval: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql
     ports:
-      - "${ONECLI_BIND_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
+      - "${ONECLI_POSTGRES_BIND_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-onecli}"]
       interval: 5s

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -186,6 +186,10 @@ and for tunnel access.
 published ports bind on. The installers detect and persist it; it never
 shapes a URL.
 
+PostgreSQL is separate: it binds to `127.0.0.1` by default even when other
+OneCLI ports bind to another interface. Set `ONECLI_POSTGRES_BIND_HOST` only
+when direct database access from another machine or container is required.
+
 ### Scenarios
 
 | Scenario                                              | What to set                                                                                                                                |

--- a/scripts/compose-network-boundary.test.mjs
+++ b/scripts/compose-network-boundary.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const read = (relativePath) =>
+  readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+
+test("PostgreSQL does not inherit the agent-reachable bind address", () => {
+  for (const file of [
+    "docker/docker-compose.yml",
+    "docker/docker-compose.dev.yml",
+  ]) {
+    const compose = read(file);
+    assert.doesNotMatch(
+      compose,
+      /\$\{ONECLI_BIND_HOST:-127\.0\.0\.1\}:\$\{POSTGRES_PORT:-5432\}:5432/,
+    );
+    assert.match(
+      compose,
+      /\$\{ONECLI_POSTGRES_BIND_HOST:-127\.0\.0\.1\}:\$\{POSTGRES_PORT:-5432\}:5432/,
+    );
+  }
+});
+
+test("the gateway retains the agent-reachable bind address", () => {
+  assert.match(
+    read("docker/docker-compose.yml"),
+    /\$\{ONECLI_BIND_HOST:-127\.0\.0\.1\}:\$\{ONECLI_GATEWAY_PORT:-10255\}:10255/,
+  );
+});

--- a/scripts/install-sh.test.mjs
+++ b/scripts/install-sh.test.mjs
@@ -44,6 +44,16 @@ test("provision persists the detected bind host (the revert trap is dead)", () =
   rmSync(r.home, { recursive: true, force: true });
 });
 
+test("provision persists an explicit PostgreSQL bind override", () => {
+  const r = run(["--provision-url-env"], {
+    ONECLI_BIND_HOST: "172.17.0.1",
+    ONECLI_POSTGRES_BIND_HOST: "192.168.1.50",
+  });
+  assert.equal(r.status, 0);
+  assert.match(readEnv(r), /^ONECLI_POSTGRES_BIND_HOST=192\.168\.1\.50$/m);
+  rmSync(r.home, { recursive: true, force: true });
+});
+
 test("a non-loopback bind freezes ONECLI_EXTERNAL_URL with the frozen comment", () => {
   const r = run(["--provision-url-env"], { ONECLI_BIND_HOST: "10.0.0.5" });
   assert.equal(r.status, 0);
@@ -504,9 +514,15 @@ const BS = String.fromCharCode(92); // a single backslash
 const escLine = (key, v) => `${key}="${v.split("\n").join(`${BS}n`)}"`;
 const FAKE_MATERIAL =
   [
-    escLine("SSH_CA_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\nFAKECA\n-----END PRIVATE KEY-----\n"),
+    escLine(
+      "SSH_CA_PRIVATE_KEY",
+      "-----BEGIN PRIVATE KEY-----\nFAKECA\n-----END PRIVATE KEY-----\n",
+    ),
     'TERMINATOR_CA_PUBLIC_KEY="ssh-ed25519 FAKECALINE"',
-    escLine("TERMINATOR_HOST_KEY", "-----BEGIN OPENSSH PRIVATE KEY-----\nFAKEHOST\n-----END OPENSSH PRIVATE KEY-----\n"),
+    escLine(
+      "TERMINATOR_HOST_KEY",
+      "-----BEGIN OPENSSH PRIVATE KEY-----\nFAKEHOST\n-----END OPENSSH PRIVATE KEY-----\n",
+    ),
   ].join("\n") + "\n";
 const SSH_DOCKER_STUB = [
   'import { appendFileSync, readFileSync } from "node:fs";',
@@ -556,11 +572,17 @@ test("provisions the SSH front door's coupled key material", () => {
   const r = runSshStubbed("ONECLI_EXTERNAL_URL=http://box.example:10254\n");
   assert.match(r.env, /^SSH_CA_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\\n/m);
   assert.match(r.env, /^TERMINATOR_CA_PUBLIC_KEY="ssh-ed25519 FAKECALINE"$/m);
-  assert.match(r.env, /^TERMINATOR_HOST_KEY="-----BEGIN OPENSSH PRIVATE KEY-----\\n/m);
+  assert.match(
+    r.env,
+    /^TERMINATOR_HOST_KEY="-----BEGIN OPENSSH PRIVATE KEY-----\\n/m,
+  );
   // SSH_HOST derives from the external URL's hostname; SSH_PORT is NEVER
   // written here (compose's ONECLI_SSH_PORT is the single knob).
   assert.match(r.env, /^SSH_HOST=box\.example$/m);
-  assert.ok(!/^SSH_PORT=/m.test(r.env), "SSH_PORT must not be written by the compose door");
+  assert.ok(
+    !/^SSH_PORT=/m.test(r.env),
+    "SSH_PORT must not be written by the compose door",
+  );
   // Each multi-line PEM is ONE physical line (\n-escaped), never raw newlines.
   for (const line of r.env.split("\n"))
     assert.ok(!line.startsWith("-----"), "a PEM leaked as a raw line: " + line);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,9 @@
 #   export POSTGRES_PORT=5433
 #   curl -fsSL https://onecli.sh/install | sh
 #
+# Expose PostgreSQL beyond the host only when explicitly required:
+#   export ONECLI_POSTGRES_BIND_HOST=192.168.1.50
+#
 # Custom app/gateway/api ports (e.g. for multi-user hosts):
 #   export ONECLI_APP_PORT=11254
 #   export ONECLI_GATEWAY_PORT=11255
@@ -150,6 +153,25 @@ ensure_env_value() {
   fi
   printf '%s=%s\n' "$1" "$2" >> "$ENV_FILE"
   chmod 600 "$ENV_FILE"
+}
+
+# Persist every shell-provided publish-plane override that must survive a later
+# bare `docker compose up`. Defaults remain implicit in the compose file.
+persist_publish_config() {
+  ensure_env_value ONECLI_BIND_HOST "$ONECLI_BIND_HOST"
+  for pair in \
+    "ONECLI_APP_PORT:${ONECLI_APP_PORT:-}" \
+    "ONECLI_GATEWAY_PORT:${ONECLI_GATEWAY_PORT:-}" \
+    "ONECLI_API_PORT:${ONECLI_API_PORT:-}" \
+    "POSTGRES_PORT:${POSTGRES_PORT:-}" \
+    "ONECLI_POSTGRES_BIND_HOST:${ONECLI_POSTGRES_BIND_HOST:-}" \
+    "ONECLI_SSH_PORT:${ONECLI_SSH_PORT:-}"; do
+    _var="${pair%%:*}"
+    _val="${pair#*:}"
+    if [ -n "$_val" ]; then
+      ensure_env_value "$_var" "$_val"
+    fi
+  done
 }
 
 # The runner's credential (hosted agents): a "rnr_"-prefixed hex token, the
@@ -626,14 +648,7 @@ main() {
   # revert to loopback). Exported custom ports are recorded for the same
   # reason; defaults stay implicit.
 
-  ensure_env_value ONECLI_BIND_HOST "$ONECLI_BIND_HOST"
-  for pair in "ONECLI_APP_PORT:${ONECLI_APP_PORT:-}" "ONECLI_GATEWAY_PORT:${ONECLI_GATEWAY_PORT:-}" "ONECLI_API_PORT:${ONECLI_API_PORT:-}" "POSTGRES_PORT:${POSTGRES_PORT:-}" "ONECLI_SSH_PORT:${ONECLI_SSH_PORT:-}"; do
-    _var="${pair%%:*}"
-    _val="${pair#*:}"
-    if [ -n "$_val" ]; then
-      ensure_env_value "$_var" "$_val"
-    fi
-  done
+  persist_publish_config
 
   # ── Required secrets (split stack) ──
   # Must exist before ANY compose command touches the file — it refuses to
@@ -844,7 +859,7 @@ if [ "$1" = "--provision-url-env" ]; then
     exit 1
   fi
   mkdir -p "$INSTALL_DIR"
-  ensure_env_value ONECLI_BIND_HOST "$ONECLI_BIND_HOST"
+  persist_publish_config
   provision_external_url || exit 1
   exit 0
 fi


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

PostgreSQL inherits `ONECLI_BIND_HOST`, making its published port reachable from unrelated containers on the Docker bridge.

Addresses [#268](https://github.com/onecli/onecli/issues/268)

## What is the new behavior?

PostgreSQL binds to `127.0.0.1` by default. Operators can explicitly expose it using `ONECLI_POSTGRES_BIND_HOST`.

The gateway continues to use `ONECLI_BIND_HOST`.

## Additional context

Verified on a disposable Linux Docker host:

- an unrelated bridge container could no longer reach PostgreSQL;
- host access to PostgreSQL continued to work;
- build, lint, type, formatting, and script tests passed
