### PR TITLE
fix(web): preserve HeadersInit overrides in API requests

### DIFF
--- a/apps/web/src/lib/api-fetch.test.ts
+++ b/apps/web/src/lib/api-fetch.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `apiFetch` takes a standard `RequestInit`, so caller headers can arrive as a
+ * `Headers` instance, `[name, value]` pairs, or a plain object. The behavior
+ * worth pinning: every form replaces the URL-derived and auth defaults, even
+ * when the header name's casing differs, instead of being dropped or joined
+ * onto them.
+ */
+
+const env = vi.hoisted(() => ({ cloud: false }));
+vi.mock("@/lib/env", () => ({
+  get IS_CLOUD() {
+    return env.cloud;
+  },
+}));
+vi.mock("aws-amplify/auth", () => ({
+  fetchAuthSession: async () => ({
+    tokens: { idToken: { toString: () => "id-token-1" } },
+  }),
+}));
+vi.mock("@onecli/api/lib/public-origins", () => ({
+  apiOrigin: () => "https://api.example.test",
+}));
+
+const { apiFetch } = await import("./api-fetch");
+
+const fetchMock = vi.fn<typeof fetch>();
+const sentHeaders = () => new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+
+beforeEach(() => {
+  env.cloud = false;
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async () => new Response("{}"));
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("window", { location: { pathname: "/w/ws-from-url/agents" } });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const workspaceOverrides: [string, HeadersInit][] = [
+  ["a Headers instance", new Headers({ "X-Workspace-Id": "ws-selected" })],
+  ["[name, value] pairs", [["X-Workspace-Id", "ws-selected"]]],
+  ["a plain object", { "X-Workspace-Id": "ws-selected" }],
+];
+
+describe("apiFetch caller headers", () => {
+  it.each(workspaceOverrides)(
+    "replace the URL-derived workspace when passed as %s",
+    async (_form, headers) => {
+      await apiFetch("/v1/agents", { headers });
+      expect(sentHeaders().get("x-workspace-id")).toBe("ws-selected");
+      expect(sentHeaders().has("0")).toBe(false);
+    },
+  );
+
+  it("replace a default whose name differs only in casing", async () => {
+    await apiFetch("/v1/example", {
+      headers: { "content-type": "text/plain" },
+    });
+    expect(sentHeaders().get("content-type")).toBe("text/plain");
+  });
+
+  it("replace the cloud bearer token with a lowercase authorization", async () => {
+    env.cloud = true;
+    await apiFetch("/v1/example", {
+      headers: { authorization: "Bearer caller-token" },
+    });
+    expect(sentHeaders().get("authorization")).toBe("Bearer caller-token");
+  });
+
+  it("leave the defaults in place when none are passed", async () => {
+    await apiFetch("/v1/example");
+    expect(sentHeaders().get("content-type")).toBe("application/json");
+    expect(sentHeaders().get("x-workspace-id")).toBe("ws-from-url");
+  });
+});

--- a/apps/web/src/lib/api-fetch.ts
+++ b/apps/web/src/lib/api-fetch.ts
@@ -47,6 +47,16 @@ export const apiFetch = async (
   const workspaceId = getWorkspaceId();
   const organizationId = getOrganizationId();
 
+  const headers = new Headers({
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(workspaceId ? { "X-Workspace-Id": workspaceId } : {}),
+    ...(organizationId ? { "X-Organization-Id": organizationId } : {}),
+  });
+  new Headers(options?.headers).forEach((value, name) => {
+    headers.set(name, value);
+  });
+
   return fetch(`${API_ORIGIN}${path}`, {
     ...options,
     // Self-host: the API lives on another port of the same host, so the
@@ -54,20 +64,14 @@ export const apiFetch = async (
     // origin — it is one of the deployment's own). Cloud uses the bearer
     // token instead.
     ...(IS_CLOUD ? null : { credentials: "include" as const }),
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(workspaceId ? { "X-Workspace-Id": workspaceId } : {}),
-      ...(organizationId ? { "X-Organization-Id": organizationId } : {}),
-      ...(options?.headers as Record<string, string> | undefined),
-    },
+    headers,
   });
 };
 
 /**
  * The binary sibling of `apiFetch` — same origin, auth, tenancy headers and
  * cookie/bearer split, WITHOUT the forced JSON Content-Type: `apiFetch`
- * spreads caller headers over its own, so a caller can only override (never
+ * merges caller headers over its own, so a caller can only override (never
  * delete) `Content-Type`, and a raw upload's type must be the file's own.
  */
 export const apiUpload = async (

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -34,8 +34,8 @@ export const refusal = async (res: Response): Promise<ApiError> => {
 
 /** Explicit workspace targeting for callers whose URL carries no scope (the
  * org-level Get Started picker, onboarding). The override wins over the
- * path-derived scope (apiFetch spreads options.headers last) and the server
- * re-fences it against the caller's memberships. */
+ * path-derived scope (apiFetch applies options.headers over its defaults)
+ * and the server re-fences it against the caller's memberships. */
 export const workspaceScope = (
   workspaceId?: string,
 ): RequestInit | undefined =>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix with a regression test. The bug is latent: no current caller hits it.

## What is the current behavior?

Fixes #556

`apiFetch` casts `options.headers` to a record and spreads it over its defaults. That drops or mangles overrides in three ways:
- A `Headers` instance contributes nothing.
- `[name, value]` pairs turn into index-named headers.
- A name that differs only in casing is joined onto the default instead of replacing it: `{ "content-type": "text/plain" }` goes out as `content-type: application/json, text/plain`.

Every current call site that passes headers uses a plain object with the defaults' casing, so nothing is wrong on the wire today.

## What is the new behavior?

`apiFetch` builds its defaults into a fresh `Headers`, normalizes the caller's `HeadersInit` with `new Headers(options?.headers)`, and copies each entry over with `set`. Caller headers now replace defaults case-insensitively, whatever form they arrive in.

Unchanged:
- the URL and request options
- `credentials: "include"` on self-host
- the cloud bearer token, where a caller's `Authorization` still wins
- the caller's header object, which is not mutated

Two comments described the old spread and now say how headers are applied: the `apiUpload` doc comment, and the note on `workspaceScope()` in `lib/api/client.ts`.

A few small differences, none of which change behavior:
- `fetch` now receives a `Headers` object instead of a plain object.
- Caller headers that don't replace a default are sent with lowercase names, since `Headers` lowercases them. Header names are case-insensitive.
- An invalid header name now throws from `new Headers(...)` inside `apiFetch` rather than from `fetch`. Either way the caller gets a promise that rejects with a `TypeError`.

## Additional context

`apps/web/src/lib/api-fetch.test.ts` covers:
- each `HeadersInit` form overriding the URL-derived `X-Workspace-Id`
- a lowercase `content-type`
- a lowercase `authorization` on cloud
- the defaults when no headers are passed

Only `@/lib/env`, `aws-amplify/auth`, `apiOrigin` and `fetch` are mocked; the workspace comes from the real `WORKSPACE_PATH_RE`.

Checked locally on Node 22.22.0 with pnpm 9.0.0, sharing a turbo cache with a clean run on `main`:

| Check | Result |
|---|---|
| New test against unpatched `main` (`3e595ef`) | 4 failed, 2 passed (6 tests) |
| New test with this change | 6 passed (6 tests) |
| `pnpm --filter @onecli/web test` | 870 passed, 8 skipped (878 tests); on `main`, 864 passed, 8 skipped (872 tests) |
| `pnpm build` | passed |
| `pnpm check` | passed |

Not tested in a browser against a running instance.
