### PR TITLE
fix(api): canonicalize configured origins in the trusted set

### DIFF
--- a/packages/api/src/lib/public-origins.test.ts
+++ b/packages/api/src/lib/public-origins.test.ts
@@ -340,6 +340,50 @@ describe("buildTrustedOrigins", () => {
       "http://127.0.0.1:10254",
     ]);
   });
+
+  // Browsers send `Origin` with a lowercase host, no default port and a
+  // compressed IPv6 literal. The set is matched exactly, so it has to use that
+  // spelling whatever the operator typed.
+  it("spells configured origins the way a browser sends them", () => {
+    const { origins } = buildTrustedOrigins(
+      resolvePublicOrigins({ externalUrl: "HTTPS://OneCLI.Acme.com:443" }),
+      "http://Extra.Acme.com:80,http://[0:0:0:0:0:0:0:1]:10254",
+    );
+    expect(origins).toEqual([
+      "https://onecli.acme.com",
+      "http://extra.acme.com",
+      "http://[::1]:10254",
+    ]);
+  });
+
+  it("does the same for a legacy APP_URL alias and a split-host api", () => {
+    const { origins } = buildTrustedOrigins(
+      resolvePublicOrigins({
+        appUrl: "https://App.Acme.com:443",
+        apiUrl: "https://API.acme.com",
+      }),
+    );
+    expect(origins).toEqual(["https://app.acme.com", "https://api.acme.com"]);
+  });
+
+  it("finds the loopback twin of an uppercase localhost", () => {
+    const { origins } = buildTrustedOrigins(
+      resolvePublicOrigins({ externalUrl: "http://LOCALHOST:10254" }),
+    );
+    expect(origins).toEqual([
+      "http://localhost:10254",
+      "http://127.0.0.1:10254",
+    ]);
+  });
+
+  // `new URL("data:…").origin` is the opaque "null" that sandboxed and file://
+  // pages send, so a value that isn't an origin must stay as written.
+  it("never turns a non-origin value into the opaque origin", () => {
+    const { origins } = buildTrustedOrigins(
+      resolvePublicOrigins({ appUrl: "data:text/html,hi" }),
+    );
+    expect(origins).not.toContain("null");
+  });
 });
 
 describe("formatOriginsBanner", () => {
@@ -562,6 +606,22 @@ describe("trustedBrowserOrigin", () => {
     expect(trustedBrowserOrigin("HTTPS://onecli.acme.com")).toBe(
       "https://onecli.acme.com",
     );
+  });
+
+  it("matches a configured origin however its host and port are spelled", () => {
+    clearAll();
+    process.env.ONECLI_EXTERNAL_URL = "HTTPS://OneCLI.Acme.com:443";
+    process.env.ONECLI_TRUSTED_ORIGINS = "HTTP://Extra.Acme.com:80";
+    expect(trustedBrowserOrigin("https://onecli.acme.com")).toBe(
+      "https://onecli.acme.com",
+    );
+    expect(trustedBrowserOrigin("http://extra.acme.com")).toBe(
+      "http://extra.acme.com",
+    );
+    expect(
+      trustedBrowserOrigin("https://onecli.acme.com:8443"),
+    ).toBeUndefined();
+    expect(trustedBrowserOrigin("http://onecli.acme.com")).toBeUndefined();
   });
 
   // Env is read per call, never frozen at module load: the api-server builds

--- a/packages/api/src/lib/public-origins.ts
+++ b/packages/api/src/lib/public-origins.ts
@@ -447,6 +447,25 @@ const loopbackTwin = (origin: string): string | undefined => {
 
 const originHost = (origin: string) => parseOrigin(origin)?.[2];
 
+/**
+ * A configured origin spelled the way a browser sends `Origin`: lowercase
+ * host, no default port, compressed IP literal. The trusted set is matched
+ * exactly, so `HTTPS://OneCLI.Example.com:443` would otherwise never match its
+ * own dashboard. Only values `normalizeOrigin` accepts are respelled; anything
+ * else (a legacy alias with a path, a port `URL` rejects) stays as written, so
+ * no origin that wasn't configured can join the set, the opaque "null" least
+ * of all. Advertised URLs keep the operator's spelling; only matching changes.
+ */
+const browserOrigin = (origin: string): string => {
+  const normalized = normalizeOrigin(origin);
+  if (!normalized) return origin;
+  try {
+    return new URL(normalized).origin;
+  } catch {
+    return origin;
+  }
+};
+
 export interface TrustedOrigins {
   origins: string[];
   warnings: string[];
@@ -463,8 +482,10 @@ export const buildTrustedOrigins = (
   extraCsv?: string,
 ): TrustedOrigins => {
   const warnings: string[] = [];
-  const origins = [resolved.app];
-  const appTwin = loopbackTwin(resolved.app);
+  const app = browserOrigin(resolved.app);
+  const api = browserOrigin(resolved.api);
+  const origins = [app];
+  const appTwin = loopbackTwin(app);
   if (appTwin) origins.push(appTwin);
 
   for (const entry of extraCsv?.split(",") ?? []) {
@@ -472,7 +493,7 @@ export const buildTrustedOrigins = (
     if (!trimmed) continue;
     const normalized = normalizeOrigin(trimmed);
     if (normalized) {
-      origins.push(normalized);
+      origins.push(browserOrigin(normalized));
     } else {
       warnings.push(
         `ONECLI_TRUSTED_ORIGINS entry "${trimmed}" is not a valid ` +
@@ -486,10 +507,10 @@ export const buildTrustedOrigins = (
   // config — and better-auth already trusts its own baseURL origin.
   if (
     resolved.sources.api.source !== "default" &&
-    originHost(resolved.api) !== originHost(resolved.app)
+    originHost(api) !== originHost(app)
   ) {
-    origins.push(resolved.api);
-    const apiTwin = loopbackTwin(resolved.api);
+    origins.push(api);
+    const apiTwin = loopbackTwin(api);
     if (apiTwin) origins.push(apiTwin);
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/onecli/onecli/blob/main/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, with a regression test.

## What is the current behavior?

Fixes #560

`buildTrustedOrigins` adds configured origins to the trusted set as written. `normalizeOrigin` lowercases only the scheme, and the `APP_URL` alias and `API_URL` override (and their `NEXT_PUBLIC_` variants) are only trimmed and stripped of trailing slashes. The consumers match the request origin exactly: CORS and the trusted-referer step through `trustedBrowserOrigin`, better-auth's `trustedOrigins`, and the CLI confirm check. So an origin configured with an uppercase host, an explicit default port or an expanded IPv6 literal never matches what the browser sends. That includes `HTTPS://OneCLI.Example.com:443` against `https://onecli.example.com`. better-auth still accepts the api origin through its own `baseURL`, so single-origin sign-in keeps working, but the CLI confirm check and CORS refuse it.

## What is the new behavior?

A small `browserOrigin` helper respells a configured origin the way a browser sends `Origin`, using `URL`. `buildTrustedOrigins` applies it to the app origin, the split-host api origin and `ONECLI_TRUSTED_ORIGINS` entries.

Only values `normalizeOrigin` already accepts are respelled. Anything else, such as a legacy alias with a path or a port `URL` rejects, stays as written, so nothing can become the opaque `"null"`. `normalizeOrigin`, startup validation and every advertised URL (OAuth redirect URIs, the CLI api host, install snippets) keep the operator's spelling, so no redirect URI changes and no configuration that loads today starts failing.

A different host, scheme or port still doesn't match. Loopback twins and the split-host check now use the respelled host: an uppercase `localhost` gets its `127.0.0.1` twin, and an `API_URL` on the dashboard's own host that differs only in case is recognized as same-host and no longer added separately, matching the existing rule for same-host APIs.

## Additional context

I deliberately left `normalizeOrigin` alone. Respelling there would change every URL derived from `ONECLI_EXTERNAL_URL`, including OAuth redirect URIs that providers compare exactly, and would make some values that load today fail validation.

Open PR #473 builds the gateway's copy of this set in Rust (dashboard origin, loopback twin and extras) and keeps hosts as written. If both land, the gateway side would want the same respelling, and I'm happy to follow up there.

`packages/api/src/lib/public-origins.test.ts` gains four `buildTrustedOrigins` cases:
- an uppercase host with `:443`, plus default-port and IPv6 extras
- a legacy alias with a split api host
- an uppercase `localhost` and its twin
- a guard that a `data:` alias never becomes `"null"`

It also gains one `trustedBrowserOrigin` case: with `ONECLI_EXTERNAL_URL=HTTPS://OneCLI.Acme.com:443` and `ONECLI_TRUSTED_ORIGINS=HTTP://Extra.Acme.com:80`, the browser spellings match, while another port or the http scheme on the same host still doesn't. The `data:` guard passes on `main` as well; the other four new cases fail there.

Checked locally on Node 22.22.0 with pnpm 9.0.0, sharing a turbo cache with a clean run on `main`:

| Check | Result |
|---|---|
| Updated `public-origins.test.ts` against unpatched `main` (`3e595ef`) | 4 failed, 54 passed (58 tests) |
| Updated `public-origins.test.ts` with this change | 58 passed (58 tests) |
| `pnpm --filter @onecli/api test` | 2793 passed, 855 skipped (3648 tests); on `main`, 2788 passed, 855 skipped (3643 tests) |
| `pnpm --filter @onecli/web test` | 864 passed, 8 skipped (872 tests); on `main`, 864 passed, 8 skipped (872 tests) |
| `pnpm build` | passed |
| `pnpm check` | passed |

Not tested against a running deployment or through a real browser CORS request.
